### PR TITLE
add a geter to access all the subjects ids of a dataset

### DIFF
--- a/tests/test_dataset_sim.py
+++ b/tests/test_dataset_sim.py
@@ -168,3 +168,13 @@ def test_get_session_data(dummy_data):
 
     assert len(data.spikes) == 1000
     assert len(data.gabors) == 1000
+
+
+def test_get_subject_ids(dummy_data):
+    ds = Dataset(
+        dummy_data,
+        split=None,
+        include=[{"selection": [{"brainset": "allen_neuropixels_mock"}]}],
+    )
+    subject_ids = ds.get_subject_ids()
+    assert subject_ids == ["allen_neuropixels_mock/alice", "allen_neuropixels_mock/bob"]

--- a/torch_brain/data/dataset.py
+++ b/torch_brain/data/dataset.py
@@ -1,16 +1,14 @@
-import os
-import logging
 import copy
+import logging
+import os
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
-import copy
-import numpy as np
 
-
-import numpy as np
 import h5py
+import numpy as np
 import torch
+
 from temporaldata import Data, Interval
 
 
@@ -389,6 +387,14 @@ class Dataset(torch.utils.data.Dataset):
     def get_session_ids(self):
         r"""Returns all session ids in the dataset."""
         return list(self.session_dict.keys())
+
+    def get_subject_ids(self):
+        r"""Returns all subject ids in the dataset."""
+        subject_ids = []
+        for session_id in self.session_dict.keys():
+            data = self._data_objects[session_id]
+            subject_ids.append(f"{data.brainset.id}/{data.subject.id}")
+        return sorted(list(set(subject_ids)))
 
     def disable_data_leakage_check(self):
         r"""Disables the data leakage check.


### PR DESCRIPTION
I needed access to subject IDs to create subject embedding as NDT2 does.
About implementation:
- I use a set to avoid duplicates 
- If you think a better implementation that covers more cases can be made or have tips let me know