### PR TITLE
RFC: Alternate Stitcher framework

### DIFF
--- a/examples/poyo/configs/base.yaml
+++ b/examples/poyo/configs/base.yaml
@@ -6,6 +6,7 @@ log_dir: ./logs
 sequence_length: 1.0  # in seconds
 latent_step: 0.125  # in seconds
 readout_modality_name: cursor_velocity_2d
+readout_metric_name: r2
 
 epochs: 1000
 eval_epochs: 1  # frequency for doing validation 

--- a/torch_brain/nn/loss.py
+++ b/torch_brain/nn/loss.py
@@ -1,3 +1,4 @@
+from typing import Optional
 import torch
 import torch.nn.functional as F
 from torchmetrics import R2Score
@@ -10,7 +11,7 @@ def compute_loss_or_metric(
     output_type: DataType,
     output: torch.Tensor,
     target: torch.Tensor,
-    weights: torch.Tensor,
+    weights: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:
     r"""Helper function to compute various losses or metrics for a given output type.
 


### PR DESCRIPTION
This PR introduces an alternate stitcher framework. This framework has two main goals:
1. Separating stitching logic/API from metric computation and logging.
2. Introduce a good API for stitching. Motivation: If stitching is made low-effort and intuitive, we can expect developers to take care of stitching+metric computation by themselves. This means we don't have to design and maintain a collection of stitcher/metric-computation frameworks.

The Stitcher API:
```
stitcher = Stitcher()
stitcher.update(timestamps1, preds1, targets1)
stitcher.update(timestamps2, preds2, targets2)
stitcher.update(timestamps3, preds3, targets3)
stitched_preds, stitched_target = stitcher.compute()
stitcher.reset()
```


My testing has been on POYO-MP scale, and I observe that the modification that this PR brings is zero-cost. i.e., the validation epoch time does not change.