### PR TITLE
Unify session/unit/subject ID prefixing logic

### DIFF
--- a/examples/poyo/train.py
+++ b/examples/poyo/train.py
@@ -177,8 +177,7 @@ class DataModule(L.LightningDataModule):
         self.test_dataset.disable_data_leakage_check()
 
     def get_session_ids(self):
-        # In POYO, each recording is a different session
-        return self.train_dataset.get_recording_ids()
+        return self.train_dataset.get_session_ids()
 
     def get_unit_ids(self):
         return self.train_dataset.get_unit_ids()

--- a/examples/poyo/train.py
+++ b/examples/poyo/train.py
@@ -177,7 +177,8 @@ class DataModule(L.LightningDataModule):
         self.test_dataset.disable_data_leakage_check()
 
     def get_session_ids(self):
-        return self.train_dataset.get_session_ids()
+        # In POYO, each recording is a different session
+        return self.train_dataset.get_recording_ids()
 
     def get_unit_ids(self):
         return self.train_dataset.get_unit_ids()
@@ -206,9 +207,7 @@ class DataModule(L.LightningDataModule):
 
         self.log.info(f"Training on {len(train_sampler)} samples")
         self.log.info(f"Training on {len(self.train_dataset.get_unit_ids())} units")
-        self.log.info(
-            f"Training on {len(self.train_dataset.get_session_ids())} sessions"
-        )
+        self.log.info(f"Training on {len(self.get_session_ids())} sessions")
 
         return train_loader
 

--- a/examples/poyo_plus/train.py
+++ b/examples/poyo_plus/train.py
@@ -200,7 +200,8 @@ class DataModule(L.LightningDataModule):
         self.test_dataset.disable_data_leakage_check()
 
     def get_session_ids(self):
-        return self.train_dataset.get_session_ids()
+        # Each recording is a different session
+        return self.train_dataset.get_recording_ids()
 
     def get_unit_ids(self):
         return self.train_dataset.get_unit_ids()
@@ -259,9 +260,7 @@ class DataModule(L.LightningDataModule):
 
         self.log.info(f"Training on {len(train_sampler)} samples")
         self.log.info(f"Training on {len(self.train_dataset.get_unit_ids())} units")
-        self.log.info(
-            f"Training on {len(self.train_dataset.get_session_ids())} sessions"
-        )
+        self.log.info(f"Training on {len(self.get_session_ids())} sessions")
 
         return train_loader
 

--- a/examples/poyo_plus/train.py
+++ b/examples/poyo_plus/train.py
@@ -200,8 +200,7 @@ class DataModule(L.LightningDataModule):
         self.test_dataset.disable_data_leakage_check()
 
     def get_session_ids(self):
-        # Each recording is a different session
-        return self.train_dataset.get_recording_ids()
+        return self.train_dataset.get_session_ids()
 
     def get_unit_ids(self):
         return self.train_dataset.get_unit_ids()

--- a/tests/test_poyo_plus.py
+++ b/tests/test_poyo_plus.py
@@ -98,6 +98,7 @@ def test_poyo_plus_tokenizer(task_specs):
             domain="auto",
         ),
         units=ArrayDict(id=np.array(["unit1", "unit2", "unit3"])),
+        recording_id="test/session1",
         session="session1",
         # Add config matching the YAML structure
         config={
@@ -179,6 +180,7 @@ def test_poyo_plus_tokenizer_to_model(task_specs, model):
             start=np.array([0, 0.5]),
             end=np.array([0.1, 0.55]),
         ),
+        recording_id="test/session1",
         session="session1",
         config={
             "multitask_readout": [

--- a/tests/test_poyo_plus.py
+++ b/tests/test_poyo_plus.py
@@ -1,6 +1,7 @@
 import pytest
 import torch
 import numpy as np
+from dataclasses import dataclass
 from unittest.mock import Mock
 from temporaldata import Data, IrregularTimeSeries, Interval, ArrayDict
 
@@ -45,6 +46,11 @@ def model(task_specs):
     model.session_emb.initialize_vocab(np.arange(10))
 
     return model
+
+
+@dataclass
+class SimpleSessionDescription:
+    id: str
 
 
 def test_poyo_plus_forward(model):
@@ -98,8 +104,7 @@ def test_poyo_plus_tokenizer(task_specs):
             domain="auto",
         ),
         units=ArrayDict(id=np.array(["unit1", "unit2", "unit3"])),
-        recording_id="test/session1",
-        session="session1",
+        session=SimpleSessionDescription(id="session1"),
         # Add config matching the YAML structure
         config={
             "multitask_readout": [
@@ -181,7 +186,7 @@ def test_poyo_plus_tokenizer_to_model(task_specs, model):
             end=np.array([0.1, 0.55]),
         ),
         recording_id="test/session1",
-        session="session1",
+        session=SimpleSessionDescription(id="session1"),
         config={
             "multitask_readout": [
                 {

--- a/torch_brain/data/dataset.py
+++ b/torch_brain/data/dataset.py
@@ -60,6 +60,12 @@ class Dataset(torch.utils.data.Dataset):
             in a session based on a predefined split.
         transform: A transform to apply to the data. This transform should be a callable
             that takes a Data object and returns a Data object.
+        unit_id_prefix_fn: Optional[Callable[[Data], str]]
+            Function to generate prefix strings for unit IDs to ensure uniqueness across the dataset.
+            Takes a Data object as input and returns a string prefix.
+            By default (when None), uses: "<brainset-id>/<session-id>/"
+            Example:
+                >>> unit_id_prefix_fn = lambda data: f"{data.brainset.id}/{data.session.id}/"
     """
 
     _check_for_data_leakage_flag: bool = True
@@ -373,8 +379,11 @@ class Dataset(torch.utils.data.Dataset):
         return sorted(list(self.recording_dict.keys()))
 
     def _get_unit_ids_with_prefix(self, data: Data) -> np.ndarray:
-        r"""Add prefix string to data.units.id. This is an inplace modification.
-        Prefix string is chosen based on unit_id_prefix_fmt.
+        r"""Add prefix string to data.units.id and return a new numpy string array.
+
+        If `unit_id_prefix_fn` is set (not None), then this function is used
+        to decide the prefix string. Otherwise, the default value is:
+        `<data.brainset.id>/<data.session.id>/`
         """
         if self.unit_id_prefix_fn is not None:
             prefix_str = self.unit_id_prefix_fn(data)

--- a/torch_brain/data/dataset.py
+++ b/torch_brain/data/dataset.py
@@ -413,8 +413,7 @@ class Dataset(torch.utils.data.Dataset):
     def get_unit_ids(self):
         r"""Returns all unit ids in the dataset."""
         unit_ids_list = []
-        for recording_id in self.recording_dict.keys():
-            data = self._data_objects[recording_id]
+        for data in self._data_objects.values():
             unit_ids = self._get_unit_ids_with_prefix(data)
             unit_ids_list.extend(unit_ids)
         return unit_ids_list

--- a/torch_brain/data/dataset.py
+++ b/torch_brain/data/dataset.py
@@ -386,10 +386,6 @@ class Dataset(torch.utils.data.Dataset):
             ans[recording_id] = self.recording_dict[recording_id]["config"]
         return ans
 
-    def get_recording_ids(self):
-        r"""Returns the session ids of the dataset."""
-        return sorted(list(self.recording_dict.keys()))
-
     def _get_unit_ids_with_prefix(self, data: Data) -> np.ndarray:
         r"""Return unit ids with prefix applied"""
         prefix_str = self.unit_id_prefix_fn(data)
@@ -423,11 +419,17 @@ class Dataset(torch.utils.data.Dataset):
             unit_ids_list.extend(unit_ids)
         return unit_ids_list
 
+    def get_session_ids(self):
+        r"""Returns the session ids of the dataset."""
+        session_ids = []
+        for data in self.recording_dict.values():
+            session_ids.append(self._get_session_id_with_prefix(data))
+        return sorted(list(set(session_ids)))
+
     def get_subject_ids(self):
         r"""Returns all subject ids in the dataset."""
         subject_ids = []
-        for recording_id in self.recording_dict.keys():
-            data = self._data_objects[recording_id]
+        for data in self.recording_dict.values():
             subject_ids.append(self._get_subject_id_with_prefix(data))
         return sorted(list(set(subject_ids)))
 

--- a/torch_brain/data/dataset.py
+++ b/torch_brain/data/dataset.py
@@ -421,15 +421,15 @@ class Dataset(torch.utils.data.Dataset):
 
     def get_session_ids(self):
         r"""Returns the session ids of the dataset."""
-        session_ids = []
-        for data in self.recording_dict.values():
-            session_ids.append(self._get_session_id_with_prefix(data))
-        return sorted(list(set(session_ids)))
+        ans = []
+        for data in self._data_objects.values():
+            ans.append(self._get_session_id_with_prefix(data))
+        return sorted(ans)
 
     def get_subject_ids(self):
         r"""Returns all subject ids in the dataset."""
         subject_ids = []
-        for data in self.recording_dict.values():
+        for data in self._data_objects.values():
             subject_ids.append(self._get_subject_id_with_prefix(data))
         return sorted(list(set(subject_ids)))
 

--- a/torch_brain/models/poyo.py
+++ b/torch_brain/models/poyo.py
@@ -375,7 +375,7 @@ class POYOTokenizer:
         }
 
         if self.eval:
-            batch["session_id"] = data.recording_id
+            batch["session_id"] = data.session.id
             batch["absolute_start"] = data.absolute_start
 
             if eval_mask is not None:

--- a/torch_brain/models/poyo.py
+++ b/torch_brain/models/poyo.py
@@ -353,7 +353,7 @@ class POYOTokenizer:
         )
 
         # create session index for output
-        output_session_index = self.session_tokenizer(data.session)
+        output_session_index = self.session_tokenizer(data.recording_id)
         output_session_index = np.repeat(output_session_index, len(output_timestamps))
 
         batch = {
@@ -375,7 +375,7 @@ class POYOTokenizer:
         }
 
         if self.eval:
-            batch["session_id"] = data.session
+            batch["session_id"] = data.recording_id
             batch["absolute_start"] = data.absolute_start
 
             if eval_mask is not None:

--- a/torch_brain/models/poyo.py
+++ b/torch_brain/models/poyo.py
@@ -353,7 +353,7 @@ class POYOTokenizer:
         )
 
         # create session index for output
-        output_session_index = self.session_tokenizer(data.recording_id)
+        output_session_index = self.session_tokenizer(data.session.id)
         output_session_index = np.repeat(output_session_index, len(output_timestamps))
 
         batch = {

--- a/torch_brain/models/poyo_plus.py
+++ b/torch_brain/models/poyo_plus.py
@@ -353,7 +353,7 @@ class POYOPlusTokenizer:
 
         if self.eval:
             # we will add a few more fields needed for evaluation
-            batch["session_id"] = data.recording_id
+            batch["session_id"] = data.session.id
             batch["absolute_start"] = data.absolute_start
             batch["eval_mask"] = chain(output_eval_mask, allow_missing_keys=True)
 

--- a/torch_brain/models/poyo_plus.py
+++ b/torch_brain/models/poyo_plus.py
@@ -318,7 +318,7 @@ class POYOPlusTokenizer:
         )
 
         ### prepare outputs
-        session_index = self.session_tokenizer(data.recording_id)
+        session_index = self.session_tokenizer(data.session.id)
 
         (
             output_timestamps,

--- a/torch_brain/models/poyo_plus.py
+++ b/torch_brain/models/poyo_plus.py
@@ -318,7 +318,7 @@ class POYOPlusTokenizer:
         )
 
         ### prepare outputs
-        session_index = self.session_tokenizer(data.session)
+        session_index = self.session_tokenizer(data.recording_id)
 
         (
             output_timestamps,
@@ -353,7 +353,7 @@ class POYOPlusTokenizer:
 
         if self.eval:
             # we will add a few more fields needed for evaluation
-            batch["session_id"] = data.session
+            batch["session_id"] = data.recording_id
             batch["absolute_start"] = data.absolute_start
             batch["eval_mask"] = chain(output_eval_mask, allow_missing_keys=True)
 


### PR DESCRIPTION
Addresses issues raised in #39 

1.  Unify id prefix applications into methods `_get_*_ids_with_prefix(data: Data) -> str` 
2. Add a way for users to control the prefixes by providing `unit_id_prefix_fn`, `session_id_prefix_fn`, and `subject_id_prefix_fn`