### PR TITLE
RFC: A new way to initialize `Dataset`

### DIFF
--- a/examples/poyo/train.py
+++ b/examples/poyo/train.py
@@ -150,7 +150,7 @@ class DataModule(L.LightningDataModule):
 
     def setup(self, stage=None):
         train_transforms = hydra.utils.instantiate(self.cfg.train_transforms)
-        self.train_dataset = Dataset(
+        self.train_dataset = Dataset.from_config(
             root=self.cfg.data_root,
             config=self.cfg.dataset,
             split="train",
@@ -160,7 +160,7 @@ class DataModule(L.LightningDataModule):
 
         eval_tokenizer = copy.copy(self.tokenizer)
         eval_tokenizer.eval = True
-        self.val_dataset = Dataset(
+        self.val_dataset = Dataset.from_config(
             root=self.cfg.data_root,
             config=self.cfg.dataset,
             split="valid",
@@ -168,7 +168,7 @@ class DataModule(L.LightningDataModule):
         )
         self.val_dataset.disable_data_leakage_check()
 
-        self.test_dataset = Dataset(
+        self.test_dataset = Dataset.from_config(
             root=self.cfg.data_root,
             config=self.cfg.dataset,
             split="test",

--- a/torch_brain/transforms/__init__.py
+++ b/torch_brain/transforms/__init__.py
@@ -3,3 +3,8 @@ from .unit_dropout import UnitDropout, TriangleDistribution
 from .random_time_scaling import RandomTimeScaling
 from .random_crop import RandomCrop
 from .output_sampler import RandomOutputSampler
+
+from typing import Callable, Any
+from temporaldata import Data
+
+TransformType = Callable[[Data], Any]


### PR DESCRIPTION
This is a request for comments:

I tried adding a "Initialize Dataset from a list of Data objects," and realized our current implementation of `Dataset.__init__()` is getting quite hairy. So came up with this alternate way of initializations: through `@classmethods` only. Users will have access to 3 (or more in the future) ways of initializing datasets:

1. `Dataset.from_config(root, config)`
2. `Dataset.from_data_files(filepath_dict)`
3. `Dataset.from_data_objects(data_dict)`

One issue I see is that the lack of `Dataset.__init__` could be worrying for more novice users. For this, we can choose one of the three ways to act as the `__init__` way (I think `from_data_files` is the most novice-user friendly?).