### PR TITLE
Merging tokenizer with model

### DIFF
--- a/torch_brain/data/dataset.py
+++ b/torch_brain/data/dataset.py
@@ -418,7 +418,7 @@ class Dataset(torch.utils.data.Dataset):
             unit_ids = data.units.id
             unit_ids = np.core.defchararray.add(
                 f"{data.brainset.id}/{data.session.id}/",
-                unit_ids.id.astype(str),
+                unit_ids.astype(str),
             )
             unit_ids_list.extend(unit_ids)
         return unit_ids_list

--- a/torch_brain/models/__init__.py
+++ b/torch_brain/models/__init__.py
@@ -1,2 +1,2 @@
-from .poyo import POYO, poyo_mp, POYOTokenizer
+from .poyo import POYO, poyo_mp
 from .poyo_plus import POYOPlus, POYOPlusTokenizer

--- a/torch_brain/models/poyo.py
+++ b/torch_brain/models/poyo.py
@@ -106,6 +106,8 @@ class POYO(nn.Module):
                 f"({latent_step}). This is a simple warning, and this behavior is allowed."
             )
 
+        self.num_latents = num_latents
+
         # embeddings
         self.unit_emb = InfiniteVocabEmbedding(dim, init_scale=emb_init_scale)
         self.session_emb = InfiniteVocabEmbedding(dim, init_scale=emb_init_scale)
@@ -228,7 +230,11 @@ class POYO(nn.Module):
         extra = {
             "session_id": data.session,
             "absolute_start": data.absolute_start,
-            "eval_mask": pad8(eval_mask),
+            "eval_mask": (
+                pad8(eval_mask)
+                if eval_mask is not None
+                else track_mask8(output_session_index)
+            ),
         }
 
         return batch, extra


### PR DESCRIPTION
The idea of attaching a tokenizer to the model is already used in our code (InfiniteVocabEmbedding), and given that we keep passing object references across the model and the tokenizer, and that each tokenizer is specific to a given model, we can merge the tokenizer and make it a method of the model. This also has the added advantage of simplifying the loading of the model from a checkpoint. 

This draft PR tests what this might look like. 

- We need to stick with either tokenize or tokenizer (and update InfiniteVocabEmbedding).
- We shouldn't use "batch" inside of the tokenizer, it's actually a single sample
- The tokenizer is defined to return exactly the input to the forward function of the model, maybe we can have it return the outputs and then any extras used outside of the model. this is a tentative idea, but we should try to simplify/unify the interface.
- A question is whether passing this tokenizer to the cpu workers will cause issues with pickling or making copies of the models which is on GPU. this needs to be tested.
