### PR TITLE
More streamlining of model interface and train scripts

### DIFF
--- a/examples/poyo/configs/base.yaml
+++ b/examples/poyo/configs/base.yaml
@@ -3,8 +3,6 @@
 data_root: ./data/processed/
 log_dir: ./logs
 
-sequence_length: 1.0  # in seconds
-latent_step: 0.125  # in seconds
 # TODO: resolve the readout_id from dataset, raise error if multiple found
 readout_id: cursor_velocity_2d
 

--- a/examples/poyo/configs/model/poyo_single_session.yaml
+++ b/examples/poyo/configs/model/poyo_single_session.yaml
@@ -1,7 +1,9 @@
 _target_: torch_brain.models.POYOPlus
+sequence_length: 1.0
+latent_step: 0.125
 dim: 64
 dim_head: 64
-num_latents: 16
+num_latents_per_step: 16
 depth: 6
 cross_heads: 2
 self_heads: 8

--- a/examples/poyo/configs/model/poyo_single_session.yaml
+++ b/examples/poyo/configs/model/poyo_single_session.yaml
@@ -1,10 +1,10 @@
 _target_: torch_brain.models.POYOPlus
 sequence_length: 1.0
 latent_step: 0.125
-dim: 64
-dim_head: 64
 num_latents_per_step: 16
+dim: 64
 depth: 6
+dim_head: 64
 cross_heads: 2
 self_heads: 8
 ffn_dropout: 0.2

--- a/examples/poyo/train.py
+++ b/examples/poyo/train.py
@@ -166,7 +166,7 @@ class DataModule(L.LightningDataModule):
             root=self.cfg.data_root,
             config=self.cfg.dataset,
             split="valid",
-            transform=partial(model.tokenize, eval_mode=True),
+            transform=model.tokenize,
         )
         self.val_dataset.disable_data_leakage_check()
 
@@ -174,7 +174,7 @@ class DataModule(L.LightningDataModule):
             root=self.cfg.data_root,
             config=self.cfg.dataset,
             split="test",
-            transform=partial(model.tokenize, eval_mode=True),
+            transform=model.tokenize,
         )
         self.test_dataset.disable_data_leakage_check()
 

--- a/examples/poyo/train.py
+++ b/examples/poyo/train.py
@@ -290,7 +290,7 @@ def main(cfg: DictConfig):
     # get modality details
     readout_spec = MODALITIY_REGISTRY[cfg.readout_id]
 
-    # make model and dota module
+    # make model and data module
     model = poyo_mp(readout_spec=readout_spec)
     data_module = DataModule(cfg=cfg)
     data_module.setup_dataset_and_link_model(model)

--- a/examples/poyo/train.py
+++ b/examples/poyo/train.py
@@ -1,4 +1,3 @@
-from functools import partial
 import logging
 from typing import Callable, Dict
 import copy

--- a/examples/poyo/train.py
+++ b/examples/poyo/train.py
@@ -83,10 +83,10 @@ class TrainWrapper(L.LightningModule):
     def training_step(self, batch, batch_idx):
 
         # forward pass
-        output_values = self.model(**batch["model_input"])
+        output_values = self.model(**batch["model_inputs"])
 
         # compute loss
-        mask = batch["model_input"]["output_mask"]
+        mask = batch["model_inputs"]["output_mask"]
         output_values = output_values[mask]
         target_values = batch["target_values"][mask]
         target_weights = batch["target_weights"][mask]
@@ -111,7 +111,7 @@ class TrainWrapper(L.LightningModule):
         #     self.log(f"targets/mean_{name}", targets.mean())
         #     self.log(f"targets/std_{name}", targets.std())
 
-        unit_index = batch["model_input"]["input_unit_index"].float()
+        unit_index = batch["model_inputs"]["input_unit_index"].float()
         self.log("inputs/mean_unit_index", unit_index.mean())
         self.log("inputs/std_unit_index", unit_index.std())
 
@@ -120,12 +120,12 @@ class TrainWrapper(L.LightningModule):
     def validation_step(self, batch, batch_idx):
 
         # forward pass
-        output_values = self.model(**batch["model_input"])
+        output_values = self.model(**batch["model_inputs"])
 
         # prepare data for evaluator
         # (goes to DecodingStitchEvaluator.on_validation_batch_end)
         data_for_eval = DataForDecodingStitchEvaluator(
-            timestamps=batch["model_input"]["output_timestamps"],
+            timestamps=batch["model_inputs"]["output_timestamps"],
             preds=output_values,
             targets=batch["target_values"],
             eval_masks=batch["eval_mask"],

--- a/examples/poyo_plus/configs/base.yaml
+++ b/examples/poyo_plus/configs/base.yaml
@@ -3,9 +3,6 @@
 data_root: ./data/processed/
 log_dir: ./logs
 
-sequence_length: 1.0  # in seconds
-latent_step: 0.125
-
 epochs: 1000
 eval_epochs: 1
 

--- a/examples/poyo_plus/configs/model/poyo_single_session.yaml
+++ b/examples/poyo_plus/configs/model/poyo_single_session.yaml
@@ -1,7 +1,9 @@
 _target_: torch_brain.models.POYOPlus
+sequence_length: 1.0
+latent_step: 0.125
+num_latents_per_step: 16
 dim: 64
 dim_head: 64
-num_latents: 16
 depth: 6
 cross_heads: 2
 self_heads: 8

--- a/examples/poyo_plus/train.py
+++ b/examples/poyo_plus/train.py
@@ -22,7 +22,7 @@ from torch_brain.data.sampler import (
     DistributedStitchingFixedWindowSampler,
     RandomFixedWindowSampler,
 )
-from torch_brain.models import POYOPlusTokenizer
+from torch_brain.models import POYOPlus
 from torch_brain.nn import compute_loss_or_metric
 from torch_brain.registry import MODALITIY_REGISTRY
 from torch_brain.transforms import Compose
@@ -40,7 +40,7 @@ logger = logging.getLogger(__name__)
 class TrainWrapper(L.LightningModule):
     def __init__(
         self,
-        model: nn.Module,
+        model: POYOPlus,
         cfg: DictConfig,
     ):
         super().__init__()
@@ -76,13 +76,13 @@ class TrainWrapper(L.LightningModule):
         }
 
     def training_step(self, batch, batch_idx):
-        target_values = batch.pop("target_values")
-        target_weights = batch.pop("target_weights")
 
         # forward pass
-        output_values = self.model(**batch, unpack_output=False)
+        output_values = self.model(**batch["model_inputs"], unpack_output=False)
 
         # compute loss
+        target_values = batch["target_values"]
+        target_weights = batch["target_weights"]
         loss = torch.tensor(0, device=self.device, dtype=torch.float32)
         taskwise_loss = {}
         for readout_id in output_values.keys():
@@ -101,12 +101,13 @@ class TrainWrapper(L.LightningModule):
 
             # count the number of sequences in the batch that have the current task
             num_sequences_with_current_task = torch.any(
-                batch["output_decoder_index"] == MODALITIY_REGISTRY[readout_id].id,
+                batch["model_inputs"]["output_decoder_index"]
+                == MODALITIY_REGISTRY[readout_id].id,
                 dim=1,
             ).sum()
             loss = loss + taskwise_loss[readout_id] * num_sequences_with_current_task
 
-        batch_size = batch["input_unit_index"].shape[0]
+        batch_size = batch["model_inputs"]["input_unit_index"].shape[0]
         # TODO change batch_size when POYOPlusEfficient is used
         loss = loss / batch_size
 
@@ -123,7 +124,7 @@ class TrainWrapper(L.LightningModule):
         #     self.log(f"targets/mean_{name}", targets.mean())
         #     self.log(f"targets/std_{name}", targets.std())
 
-        unit_index = batch["input_unit_index"].float()
+        unit_index = batch["model_inputs"]["input_unit_index"].float()
         self.log("inputs/mean_unit_index", unit_index.mean())
         self.log("inputs/std_unit_index", unit_index.std())
 
@@ -137,7 +138,7 @@ class TrainWrapper(L.LightningModule):
         eval_mask = batch.pop("eval_mask")
 
         # forward pass
-        output_values = self.model(**batch, unpack_output=True)
+        output_values = self.model(**batch["model_inputs"], unpack_output=True)
 
         # add removed elements back to batch
         batch["target_values"] = target_values
@@ -152,24 +153,22 @@ class TrainWrapper(L.LightningModule):
 
 
 class DataModule(L.LightningDataModule):
-    def __init__(
-        self,
-        cfg: DictConfig,
-        tokenizer: Callable[[Data], Dict],
-    ):
+    def __init__(self, cfg: DictConfig):
         super().__init__()
         self.cfg = cfg
-        self.tokenizer = tokenizer
-
-        self.train_dataset = None
         self.log = logging.getLogger(__name__)
 
-    def setup(self, stage=None):
+    def setup_dataset_and_link_model(self, model: POYOPlus):
+        r"""Setup Dataset objects, and update a given model's embedding vocabs (session
+        and unit_emb)
+        """
+        self.sequence_length = model.sequence_length
+
         # prepare transforms
         train_transforms = hydra.utils.instantiate(self.cfg.train_transforms)
 
         # compose transforms, tokenizer is always the last transform
-        train_transform = Compose([*train_transforms, self.tokenizer])
+        train_transform = Compose([*train_transforms, model.tokenize])
 
         self.train_dataset = Dataset(
             root=self.cfg.data_root,
@@ -179,15 +178,14 @@ class DataModule(L.LightningDataModule):
         )
         self.train_dataset.disable_data_leakage_check()
 
-        # validation and test datasets require a tokenizer that is in eval mode
-        eval_tokenizer = copy.copy(self.tokenizer)
-        eval_tokenizer.eval = True
+        self._init_model_vocab(model)
 
+        # validation and test datasets require a tokenizer that is in eval mode
         self.val_dataset = Dataset(
             root=self.cfg.data_root,
             config=self.cfg.dataset,
             split="valid",
-            transform=eval_tokenizer,
+            transform=model.tokenize,
         )
         self.val_dataset.disable_data_leakage_check()
 
@@ -195,9 +193,14 @@ class DataModule(L.LightningDataModule):
             root=self.cfg.data_root,
             config=self.cfg.dataset,
             split="test",
-            transform=eval_tokenizer,
+            transform=model.tokenize,
         )
         self.test_dataset.disable_data_leakage_check()
+
+    def _init_model_vocab(self, model: POYOPlus):
+        # TODO: Add code for finetuning situation (when model already has a vocab)
+        model.unit_emb.initialize_vocab(self.get_unit_ids())
+        model.session_emb.initialize_vocab(self.get_session_ids())
 
     def get_session_ids(self):
         return self.train_dataset.get_session_ids()
@@ -241,7 +244,7 @@ class DataModule(L.LightningDataModule):
     def train_dataloader(self):
         train_sampler = RandomFixedWindowSampler(
             interval_dict=self.train_dataset.get_sampling_intervals(),
-            window_length=self.cfg.sequence_length,
+            window_length=self.sequence_length,
             generator=torch.Generator().manual_seed(self.cfg.seed + 1),
         )
 
@@ -268,8 +271,8 @@ class DataModule(L.LightningDataModule):
 
         val_sampler = DistributedStitchingFixedWindowSampler(
             interval_dict=self.val_dataset.get_sampling_intervals(),
-            window_length=self.cfg.sequence_length,
-            step=self.cfg.sequence_length / 2,
+            window_length=self.sequence_length,
+            step=self.sequence_length / 2,
             batch_size=batch_size,
             num_replicas=self.trainer.world_size,
             rank=self.trainer.global_rank,
@@ -295,8 +298,8 @@ class DataModule(L.LightningDataModule):
 
         test_sampler = DistributedStitchingFixedWindowSampler(
             interval_dict=self.test_dataset.get_sampling_intervals(),
-            window_length=self.cfg.sequence_length,
-            step=self.cfg.sequence_length / 2,
+            window_length=self.sequence_length,
+            step=self.sequence_length / 2,
             batch_size=batch_size,
             num_replicas=self.trainer.world_size,
             rank=self.trainer.global_rank,
@@ -335,25 +338,11 @@ def main(cfg: DictConfig):
             log_model=cfg.wandb.log_model,
         )
 
-    # make model
+    # make model and datamodule
     # TODO: resolve the readout_id from dataset, only build readouts needed
     model = hydra.utils.instantiate(cfg.model, readout_specs=MODALITIY_REGISTRY)
-
-    tokenizer = POYOPlusTokenizer(
-        model.unit_emb.tokenizer,
-        model.session_emb.tokenizer,
-        decoder_registry=MODALITIY_REGISTRY,
-        latent_step=cfg.latent_step,
-        num_latents_per_step=cfg.model.num_latents,
-    )
-
-    # setup data module
-    data_module = DataModule(cfg, tokenizer)
-    data_module.setup()
-
-    # register units and sessions
-    model.unit_emb.initialize_vocab(data_module.get_unit_ids())
-    model.session_emb.initialize_vocab(data_module.get_session_ids())
+    data_module = DataModule(cfg)
+    data_module.setup_dataset_and_link_model(model)
 
     # Lightning train wrapper
     wrapper = TrainWrapper(cfg=cfg, model=model)

--- a/examples/poyo_plus/train.py
+++ b/examples/poyo_plus/train.py
@@ -144,10 +144,10 @@ class TrainWrapper(L.LightningModule):
             timestamps=batch["model_inputs"]["output_timestamps"],
             preds=output_values,
             targets=batch["target_values"],
+            decoder_indices=batch["model_inputs"]["output_decoder_index"],
             eval_masks=batch["eval_mask"],
             session_ids=batch["session_id"],
             absolute_starts=batch["absolute_start"],
-            decoder_indices=batch["model_inputs"]["output_decoder_index"],
         )
 
         return data_for_eval

--- a/tests/test_poyo_plus.py
+++ b/tests/test_poyo_plus.py
@@ -7,7 +7,7 @@ from temporaldata import Data, IrregularTimeSeries, Interval, ArrayDict
 
 from torch_brain.data import collate
 from torch_brain.registry import DataType, register_modality
-from torch_brain.models.poyo_plus import POYOPlus, POYOPlusTokenizer
+from torch_brain.models.poyo_plus import POYOPlus
 
 
 def setup_module():
@@ -33,17 +33,19 @@ def task_specs():
 @pytest.fixture
 def model(task_specs):
     model = POYOPlus(
+        sequence_length=1.0,
+        latent_step=0.1,
+        num_latents_per_step=8,
         dim=32,
         dim_head=16,
-        num_latents=8,
         depth=2,
         readout_specs=task_specs,
     )
 
     # initialize unit vocab with 100 units labeled 0-99
-    model.unit_emb.initialize_vocab(np.arange(100))
+    # model.unit_emb.initialize_vocab(np.arange(100))
     # initialize session vocab with 10 sessions labeled 0-9
-    model.session_emb.initialize_vocab(np.arange(10))
+    # model.session_emb.initialize_vocab(np.arange(10))
 
     return model
 
@@ -58,6 +60,10 @@ def test_poyo_plus_forward(model):
     n_in = 10
     n_latent = 8
     n_out = 4
+
+    # Initialize dummy units and sessions
+    model.unit_emb.initialize_vocab(np.arange(100))
+    model.session_emb.initialize_vocab(np.arange(10))
 
     # Create dummy input data
     inputs = {
@@ -84,7 +90,7 @@ def test_poyo_plus_forward(model):
     assert outputs[0]["cursor_velocity_2d"].shape == (n_out, 2)
 
 
-def test_poyo_plus_tokenizer(task_specs):
+def test_poyo_plus_tokenizer(task_specs, model):
     # Create dummy data similar to test_dataset_sim.py
     data = Data(
         spikes=IrregularTimeSeries(
@@ -121,24 +127,26 @@ def test_poyo_plus_tokenizer(task_specs):
         },
     )
 
-    # Create mock tokenizers
-    unit_tokenizer = lambda x: np.arange(len(x))
-    session_tokenizer = lambda x: 0
-
-    # Initialize tokenizer
-    tokenizer = POYOPlusTokenizer(
-        unit_tokenizer=unit_tokenizer,
-        session_tokenizer=session_tokenizer,
-        decoder_registry=task_specs,
-        latent_step=0.1,
-        num_latents_per_step=8,
-    )
+    # Initialize vocabs (needed by the tokenizer)
+    model.unit_emb.initialize_vocab(data.units.id)
+    model.session_emb.initialize_vocab([data.session.id])
 
     # Apply tokenizer
-    batch = tokenizer(data)
+    batch = model.tokenize(data)
 
-    # Check that all expected keys are present
-    expected_keys = {
+    # Check that all expected keys are present in the top level
+    expected_top_level_keys = {
+        "model_inputs",
+        "target_values",
+        "target_weights",
+        "session_id",
+        "absolute_start",
+        "eval_mask",
+    }
+    assert set(batch.keys()) == expected_top_level_keys
+
+    # Check that all expected keys are present in model_inputs
+    expected_model_input_keys = {
         "input_unit_index",
         "input_timestamps",
         "input_token_type",
@@ -148,17 +156,20 @@ def test_poyo_plus_tokenizer(task_specs):
         "output_session_index",
         "output_timestamps",
         "output_decoder_index",
-        "target_values",
-        "target_weights",
     }
-    assert set(batch.keys()) == expected_keys
+    assert set(batch["model_inputs"].keys()) == expected_model_input_keys
 
     # Check that output values contain the expected tasks
     assert set(batch["target_values"].obj.keys()).issubset(set(task_specs.keys()))
 
     # Verify latent tokens
-    assert batch["latent_index"].shape[0] == len(np.arange(0, 1, 0.1)) * 8
-    assert batch["latent_timestamps"].shape[0] == len(np.arange(0, 1, 0.1)) * 8
+    assert (
+        batch["model_inputs"]["latent_index"].shape[0] == len(np.arange(0, 1, 0.1)) * 8
+    )
+    assert (
+        batch["model_inputs"]["latent_timestamps"].shape[0]
+        == len(np.arange(0, 1, 0.1)) * 8
+    )
 
 
 def test_poyo_plus_tokenizer_to_model(task_specs, model):
@@ -204,32 +215,21 @@ def test_poyo_plus_tokenizer_to_model(task_specs, model):
         },
     )
 
-    # Create mock tokenizers
-    unit_tokenizer = lambda x: np.arange(len(x))
-    session_tokenizer = lambda x: 0
-
-    # Initialize tokenizer
-    tokenizer = POYOPlusTokenizer(
-        unit_tokenizer=unit_tokenizer,
-        session_tokenizer=session_tokenizer,
-        decoder_registry=task_specs,
-        latent_step=0.1,
-        num_latents_per_step=8,
-    )
+    # Initialize vocabs (needed by the tokenizer)
+    model.unit_emb.initialize_vocab(data.units.id)
+    model.session_emb.initialize_vocab([data.session.id])
 
     # Apply tokenizer
-    batch = tokenizer(data)
+    batch = model.tokenize(data)
 
     # Create a batch list with a single element (simulating a batch size of 1)
     batch_list = [batch]
 
     # Use collate to properly batch the inputs
-    model_inputs = collate(batch_list)
+    collated_batch = collate(batch_list)
 
-    model_inputs.pop("target_values")
-    model_inputs.pop("target_weights")
     # Forward pass through model
-    outputs = model(**model_inputs)
+    outputs = model(**collated_batch["model_inputs"])
 
     # Basic checks
     assert isinstance(outputs, dict)

--- a/tests/test_poyo_plus.py
+++ b/tests/test_poyo_plus.py
@@ -172,7 +172,7 @@ def test_poyo_plus_tokenizer(task_specs, model):
     )
 
 
-def test_poyo_plus_tokenizer_to_model(task_specs, model):
+def test_poyo_plus_tokenizer_to_model(model):
     # Create dummy data similar to test_dataset_sim.py
     data = Data(
         spikes=IrregularTimeSeries(

--- a/torch_brain/models/__init__.py
+++ b/torch_brain/models/__init__.py
@@ -1,2 +1,2 @@
-from .poyo import POYO, poyo_mp, POYOTokenizer
+from .poyo import POYO, poyo_mp
 from .poyo_plus import POYOPlus, POYOPlusTokenizer

--- a/torch_brain/models/__init__.py
+++ b/torch_brain/models/__init__.py
@@ -1,2 +1,2 @@
 from .poyo import POYO, poyo_mp
-from .poyo_plus import POYOPlus, POYOPlusTokenizer
+from .poyo_plus import POYOPlus

--- a/torch_brain/models/poyo.py
+++ b/torch_brain/models/poyo.py
@@ -305,7 +305,7 @@ class POYO(nn.Module):
         output_session_index = np.repeat(output_session_index, len(output_timestamps))
 
         data_dict = {
-            "model_input": {
+            "model_inputs": {
                 # input sequence (keys/values for the encoder)
                 "input_unit_index": pad8(spike_unit_index),
                 "input_timestamps": pad8(spike_timestamps),

--- a/torch_brain/models/poyo.py
+++ b/torch_brain/models/poyo.py
@@ -252,7 +252,7 @@ class POYO(nn.Module):
 
         return output
 
-    def tokenize(self, data: Data) -> Dict:
+    def tokenize(self, data: Data, eval_mode: bool = False) -> Dict:
         r"""Tokenizer used to tokenize Data for the POYO model.
 
         This tokenizer can be called as a transform. If you are applying multiple
@@ -322,11 +322,17 @@ class POYO(nn.Module):
             # ground truth targets
             "target_values": pad8(output_values),
             "target_weights": pad8(output_weights),
-            # extra data needed for evaluation
-            "session_id": data.session.id,
-            "absolute_start": data.absolute_start,
-            "eval_mask": pad8(eval_mask) if eval_mask is not None else None,
         }
+
+        if eval_mode:
+            data_dict.update(
+                {
+                    # extra data needed for evaluation
+                    "session_id": data.session.id,
+                    "absolute_start": data.absolute_start,
+                    "eval_mask": pad8(eval_mask) if eval_mask is not None else None,
+                }
+            )
 
         return data_dict
 

--- a/torch_brain/models/poyo.py
+++ b/torch_brain/models/poyo.py
@@ -83,7 +83,7 @@ class POYO(nn.Module):
     ):
         super().__init__()
 
-        self._ensure_valid_params(sequence_length, latent_step)
+        self._validate_params(sequence_length, latent_step)
 
         self.sequence_length = sequence_length
         self.latent_step = latent_step
@@ -336,7 +336,7 @@ class POYO(nn.Module):
 
         return data_dict
 
-    def _ensure_valid_params(self, sequence_length, latent_step):
+    def _validate_params(self, sequence_length, latent_step):
         r"""Ensure: sequence_length, and latent_step are floating point numbers greater
         than zero. And sequence_length is a multiple of latent_step.
         """

--- a/torch_brain/models/poyo.py
+++ b/torch_brain/models/poyo.py
@@ -1,4 +1,5 @@
 from typing import Callable, Dict, Iterable, List, Optional, Tuple, Union
+import logging
 
 import numpy as np
 import torch.nn as nn
@@ -349,7 +350,7 @@ class POYO(nn.Module):
 
         # check if sequence_length is a multiple of latent_step
         if abs(sequence_length % latent_step) > 1e-10:
-            self.log.warning(
+            logging.warning(
                 f"sequence_length ({sequence_length}) is not a multiple of latent_step "
                 f"({latent_step}). This is a simple warning, and this behavior is allowed."
             )

--- a/torch_brain/models/poyo.py
+++ b/torch_brain/models/poyo.py
@@ -45,13 +45,13 @@ class POYO(nn.Module):
         to the appropriate output dimension.
 
     Args:
-        dim: Hidden dimension of the model
-        dim_out: Dimension of the output
-        dim_head: Dimension of each attention head
-        sequence_length: Maximum duration of the input sequence (in seconds)
+        sequence_length: Maximum duration of the input spike sequence (in seconds)
+        readout_spec: A :class:`torch_brain.registry.ModalitySpec` specifying readout properties
         latent_step: Timestep of the latent grid (in seconds)
         num_latents_per_step: Number of unique latent tokens (repeated at every latent step)
+        dim: Hidden dimension of the model
         depth: Number of processing layers (self-attentions in the latent space)
+        dim_head: Dimension of each attention head
         cross_heads: Number of attention heads used in a cross-attention layer
         self_heads: Number of attention heads used in a self-attention layer
         ffn_dropout: Dropout rate for feed-forward networks
@@ -60,7 +60,6 @@ class POYO(nn.Module):
         emb_init_scale: Scale for embedding initialization
         t_min: Minimum timestamp resolution for rotary embeddings
         t_max: Maximum timestamp resolution for rotary embeddings
-        dim_out: Dimension of the output
     """
 
     def __init__(
@@ -68,9 +67,9 @@ class POYO(nn.Module):
         *,
         sequence_length: float,
         readout_spec: ModalitySpec,
-        dim: int = 512,
         latent_step: float,
         num_latents_per_step: int = 64,
+        dim: int = 512,
         depth: int = 2,
         dim_head: int = 64,
         cross_heads: int = 1,

--- a/torch_brain/models/poyo.py
+++ b/torch_brain/models/poyo.py
@@ -252,7 +252,7 @@ class POYO(nn.Module):
 
         return output
 
-    def tokenize(self, data: Data, eval_mode: bool = False) -> Dict:
+    def tokenize(self, data: Data) -> Dict:
         r"""Tokenizer used to tokenize Data for the POYO model.
 
         This tokenizer can be called as a transform. If you are applying multiple
@@ -322,17 +322,11 @@ class POYO(nn.Module):
             # ground truth targets
             "target_values": pad8(output_values),
             "target_weights": pad8(output_weights),
+            # extra data needed for evaluation
+            "session_id": data.session.id,
+            "absolute_start": data.absolute_start,
+            "eval_mask": pad8(eval_mask) if eval_mask is not None else None,
         }
-
-        if eval_mode:
-            data_dict.update(
-                {
-                    # extra data needed for evaluation
-                    "session_id": data.session.id,
-                    "absolute_start": data.absolute_start,
-                    "eval_mask": pad8(eval_mask) if eval_mask is not None else None,
-                }
-            )
 
         return data_dict
 

--- a/torch_brain/models/poyo_plus.py
+++ b/torch_brain/models/poyo_plus.py
@@ -48,10 +48,15 @@ class POYOPlus(nn.Module):
         to the appropriate output dimension required by each task.
 
     Args:
+        sequence_length: Maximum duration of the input spike sequence (in seconds)
+        readout_specs: Specifications for each prediction task. This is a dictionary
+            with strings as keys (task names), and :class:`torch_brain.registry.ModalitySpec`
+            as values. One key-value pair for each prediction task.
+        latent_step: Timestep of the latent grid (in seconds)
+        num_latents_per_step: Number of unique latent tokens (repeated at every latent step)
         dim: Dimension of all embeddings
-        dim_head: Dimension of each attention head
-        num_latents_per_step: Number of unique latent tokens
         depth: Number of processing layers
+        dim_head: Dimension of each attention head
         cross_heads: Number of attention heads used in a cross-attention layer
         self_heads: Number of attention heads used in a self-attention layer
         ffn_dropout: Dropout rate for feed-forward networks
@@ -60,9 +65,6 @@ class POYOPlus(nn.Module):
         emb_init_scale: Scale for embedding initialization
         t_min: Minimum timestamp resolution for rotary embeddings
         t_max: Maximum timestamp resolution for rotary embeddings
-        readout_specs: Specifications for each prediction task. This is a dictionary
-            with strings as keys (task names), and :class:`torch_brain.registry.ModalitySpec`
-            as values. One key-value pair for each prediction task.
     """
 
     def __init__(

--- a/torch_brain/models/poyo_plus.py
+++ b/torch_brain/models/poyo_plus.py
@@ -1,4 +1,5 @@
 from typing import Dict, List, Optional, Tuple
+import logging
 
 import numpy as np
 import torch.nn as nn
@@ -363,7 +364,7 @@ class POYOPlus(nn.Module):
 
         # check if sequence_length is a multiple of latent_step
         if abs(sequence_length % latent_step) > 1e-10:
-            self.log.warning(
+            logging.warning(
                 f"sequence_length ({sequence_length}) is not a multiple of latent_step "
                 f"({latent_step}). This is a simple warning, and this behavior is allowed."
             )

--- a/torch_brain/models/poyo_plus.py
+++ b/torch_brain/models/poyo_plus.py
@@ -3,6 +3,7 @@ from typing import Dict, List, Optional, Tuple
 import numpy as np
 import torch.nn as nn
 from torchtyping import TensorType
+from temporaldata import Data
 
 from torch_brain.data import chain, pad8, track_mask8
 from torch_brain.nn import (
@@ -15,7 +16,7 @@ from torch_brain.nn import (
     RotaryEmbedding,
     prepare_for_multitask_readout,
 )
-from torch_brain.registry import ModalitySpec
+from torch_brain.registry import ModalitySpec, MODALITIY_REGISTRY
 
 from torch_brain.utils import (
     create_linspace_latent_tokens,
@@ -48,7 +49,7 @@ class POYOPlus(nn.Module):
     Args:
         dim: Dimension of all embeddings
         dim_head: Dimension of each attention head
-        num_latents: Number of unique latent tokens
+        num_latents_per_step: Number of unique latent tokens
         depth: Number of processing layers
         cross_heads: Number of attention heads used in a cross-attention layer
         self_heads: Number of attention heads used in a self-attention layer
@@ -58,34 +59,47 @@ class POYOPlus(nn.Module):
         emb_init_scale: Scale for embedding initialization
         t_min: Minimum timestamp resolution for rotary embeddings
         t_max: Maximum timestamp resolution for rotary embeddings
-        readout_specs: Specifications for each prediction task
+        readout_specs: Specifications for each prediction task. This is a dictionary
+            with strings as keys (task names), and :class:`torch_brain.registry.ModalitySpec`
+            as values. One key-value pair for each prediction task.
     """
 
     def __init__(
         self,
         *,
-        dim=512,
-        dim_head=64,
-        num_latents=64,
-        depth=2,
-        cross_heads=1,
-        self_heads=8,
-        ffn_dropout=0.2,
-        lin_dropout=0.4,
-        atn_dropout=0.0,
-        emb_init_scale=0.02,
-        t_min=1e-4,
-        t_max=4.0,
-        readout_specs: Dict[str, ModalitySpec],
+        sequence_length: float,
+        readout_specs: Dict[str, ModalitySpec] = MODALITIY_REGISTRY,
+        latent_step: float,
+        num_latents_per_step: int = 64,
+        dim: int = 512,
+        depth: int = 2,
+        dim_head: int = 64,
+        cross_heads: int = 1,
+        self_heads: int = 8,
+        ffn_dropout: float = 0.2,
+        lin_dropout: float = 0.4,
+        atn_dropout: float = 0.0,
+        emb_init_scale: float = 0.02,
+        t_min: float = 1e-4,
+        t_max: float = 4.0,
     ):
         super().__init__()
+
+        self._validate_params(sequence_length, latent_step)
+
+        self.latent_step = latent_step
+        self.num_latents_per_step = num_latents_per_step
+        self.sequence_length = sequence_length
+        self.readout_specs = readout_specs
 
         # embeddings
         self.unit_emb = InfiniteVocabEmbedding(dim, init_scale=emb_init_scale)
         self.session_emb = InfiniteVocabEmbedding(dim, init_scale=emb_init_scale)
         self.token_type_emb = Embedding(4, dim, init_scale=emb_init_scale)
         self.task_emb = Embedding(len(readout_specs), dim, init_scale=emb_init_scale)
-        self.latent_emb = Embedding(num_latents, dim, init_scale=emb_init_scale)
+        self.latent_emb = Embedding(
+            num_latents_per_step, dim, init_scale=emb_init_scale
+        )
         self.rotary_emb = RotaryEmbedding(dim_head, t_min, t_max)
 
         self.dropout = nn.Dropout(p=lin_dropout)
@@ -244,44 +258,15 @@ class POYOPlus(nn.Module):
 
         return output
 
+    def tokenize(self, data: Data) -> Dict:
+        r"""Tokenizer used to tokenize Data for the POYO+ model.
 
-class POYOPlusTokenizer:
-    r"""Tokenizer used to tokenize Data for the POYO1 model.
+        This tokenizer can be called as a transform. If you are applying multiple
+        transforms, make sure to apply this one last.
 
-    This tokenizer can be called as a transform. If you are applying multiple
-    transforms, make sure to apply this one last.
+        This code runs on CPU. Do not access GPU tensors inside this function.
+        """
 
-    Args:
-        unit_tokenizer (Callable): Tokenizer for the units.
-        session_tokenizer (Callable): Tokenizer for the sessions.
-        decoder_registry (Dict): Registry of the decoders.
-        weight_registry (Dict): Registry of the weights.
-        latent_step (float): Step size for generating latent tokens.
-        num_latents_per_step (int): Number of latents per step.
-    """
-
-    def __init__(
-        self,
-        unit_tokenizer,
-        session_tokenizer,
-        decoder_registry,
-        latent_step,
-        num_latents_per_step,
-        sequence_length=1.0,
-        eval=False,
-    ):
-        self.unit_tokenizer = unit_tokenizer
-        self.session_tokenizer = session_tokenizer
-
-        self.decoder_registry = decoder_registry
-
-        self.latent_step = latent_step
-        self.num_latents_per_step = num_latents_per_step
-        self.sequence_length = sequence_length
-
-        self.eval = eval
-
-    def __call__(self, data):
         # context window
         start, end = 0, self.sequence_length
 
@@ -306,7 +291,7 @@ class POYOPlusTokenizer:
 
         # unit_index is relative to the recording, so we want it to map it to
         # the global unit index
-        local_to_global_map = np.array(self.unit_tokenizer(unit_ids))
+        local_to_global_map = np.array(self.unit_emb.tokenizer(unit_ids))
         spike_unit_index = local_to_global_map[spike_unit_index]
 
         ### prepare latents
@@ -318,7 +303,7 @@ class POYOPlusTokenizer:
         )
 
         ### prepare outputs
-        session_index = self.session_tokenizer(data.session.id)
+        session_index = self.session_emb.tokenizer(data.session.id)
 
         (
             output_timestamps,
@@ -328,33 +313,57 @@ class POYOPlusTokenizer:
             output_eval_mask,
         ) = prepare_for_multitask_readout(
             data,
-            self.decoder_registry,
+            self.readout_specs,
         )
 
         session_index = np.repeat(session_index, len(output_timestamps))
 
-        batch = {
-            # input sequence
-            "input_unit_index": pad8(spike_unit_index),
-            "input_timestamps": pad8(spike_timestamps),
-            "input_token_type": pad8(spike_token_type_index),
-            "input_mask": track_mask8(spike_unit_index),
-            # latent sequence
-            "latent_index": latent_index,
-            "latent_timestamps": latent_timestamps,
-            # output sequence
-            "output_session_index": pad8(session_index),
-            "output_timestamps": pad8(output_timestamps),
-            "output_decoder_index": pad8(output_task_index),
+        data_dict = {
+            "model_inputs": {
+                # input sequence
+                "input_unit_index": pad8(spike_unit_index),
+                "input_timestamps": pad8(spike_timestamps),
+                "input_token_type": pad8(spike_token_type_index),
+                "input_mask": track_mask8(spike_unit_index),
+                # latent sequence
+                "latent_index": latent_index,
+                "latent_timestamps": latent_timestamps,
+                # output sequence
+                "output_session_index": pad8(session_index),
+                "output_timestamps": pad8(output_timestamps),
+                "output_decoder_index": pad8(output_task_index),
+            },
             # ground truth targets
             "target_values": chain(output_values, allow_missing_keys=True),
             "target_weights": chain(output_weights, allow_missing_keys=True),
+            # extra fields for evaluation
+            "session_id": data.session.id,
+            "absolute_start": data.absolute_start,
+            "eval_mask": chain(output_eval_mask, allow_missing_keys=True),
         }
 
-        if self.eval:
-            # we will add a few more fields needed for evaluation
-            batch["session_id"] = data.session.id
-            batch["absolute_start"] = data.absolute_start
-            batch["eval_mask"] = chain(output_eval_mask, allow_missing_keys=True)
+        return data_dict
 
-        return batch
+    def _validate_params(self, sequence_length, latent_step):
+        r"""Ensure: sequence_length, and latent_step are floating point numbers greater
+        than zero. And sequence_length is a multiple of latent_step.
+        """
+
+        if not isinstance(sequence_length, float):
+            raise ValueError("sequence_length must be a float")
+        if not sequence_length > 0:
+            raise ValueError("sequence_length must be greater than 0")
+        self.sequence_length = sequence_length
+
+        if not isinstance(latent_step, float):
+            raise ValueError("latent_step must be a float")
+        if not latent_step > 0:
+            raise ValueError("latent_step must be greater than 0")
+        self.latent_step = latent_step
+
+        # check if sequence_length is a multiple of latent_step
+        if abs(sequence_length % latent_step) > 1e-10:
+            self.log.warning(
+                f"sequence_length ({sequence_length}) is not a multiple of latent_step "
+                f"({latent_step}). This is a simple warning, and this behavior is allowed."
+            )

--- a/torch_brain/utils/readout.py
+++ b/torch_brain/utils/readout.py
@@ -77,7 +77,7 @@ def prepare_for_readout(
 
     # resolve eval mask
     eval_mask = None
-    eval_interval_key = data.config.get("eval_interval", None)
+    eval_interval_key = readout_config.get("eval_interval", None)
     if eval_interval_key is not None:
         eval_interval = data.get_nested_attribute(eval_interval_key)
         eval_mask = isin_interval(timestamps, eval_interval)

--- a/torch_brain/utils/stitcher.py
+++ b/torch_brain/utils/stitcher.py
@@ -102,21 +102,15 @@ class DecodingStitchEvaluator(L.Callback):
     Since the stitching is done only on tensors on the same GPU, sequences that are
     split across multiple GPUs will not be stitched together. In this case, it is
     recommended to use a stitching-aware sampler like
-    `DistributedStitchingFixedWindowSampler` which ensures that the sequences are
-    split across GPUs in a way that allows for correct stitching.
+    :class:`~torch_brain.data.sampler.DistributedStitchingFixedWindowSampler`
+    which ensures that the sequences are split across GPUs in a way that allows for
+    correct stitching.
 
-    This callback is called _after_ the validation_step, and has two main inputs:
-    - The output of the validation_step function, which is expected to be the
-      model predictions. These should be a :class:`~torch.Tensor` of shape (B, N, ...),
-      where B is the batch size, N is the number of timestamps.
-    - The batch dictionary that should have atleast the following keys:
-        - "target_values": :class:`~torch.Tensor` of shape (B, N, ...)
-        - "output_timestamps": :class:`~torch.Tensor` of shape (B, N) and dtype float
-        - "output_mask": :class:`~torch.Tensor` of shape (B, N) and dtype bool
-        - "session_id": A list of session IDs for each sample in the batch
-        - "absolute_start": :class:`~torch.Tensor` of shape (B) and dtype float
+    This callback is called _after_ the validation_step, and expects you to return a
+    :class:`~DataForDecodingStitchEvaluator` object from the validation_step lightning
+    module method.
     Please refer to the examples/poyo/train.py script for an example of how to write
-    a validation_step(...) function that outputs the required tensors.
+    such a validation_step(...) function.
 
     This callback operates by maintaining a cache of the predictions, targets, and
     timestamps for each session. This cache is updated at the end of each batch.

--- a/torch_brain/utils/stitcher.py
+++ b/torch_brain/utils/stitcher.py
@@ -77,10 +77,12 @@ def stitch(timestamps: torch.Tensor, values: torch.Tensor) -> torch.Tensor:
 
 @dataclass
 class DataForDecodingStitchEvaluator:
-    timestamps: torch.FloatTensor  # Batch x T_max
+    r"""A batch's worth of data for :class:`DecodingStitchEvaluator`"""
+
+    timestamps: torch.FloatTensor  # B x T_max
     preds: torch.FloatTensor  # B x T_max x D_output
     targets: torch.FloatTensor  # B x T_max x D_output
-    eval_mask: torch.BoolTensor  # B x T_max
+    eval_masks: torch.BoolTensor  # B x T_max
     session_ids: list  # A list of session ID strings, 1 for each batch
     absolute_starts: torch.Tensor  # Batch
 
@@ -176,7 +178,7 @@ class DecodingStitchEvaluator(L.Callback):
         # Update the cache with the predictions, targets, and timestamps
         batch_size = len(data.timestamps)
         for i in range(batch_size):
-            mask = data.eval_mask[i]
+            mask = data.eval_masks[i]
             session_id = data.session_ids[i]
             absolute_start = data.absolute_starts[i]
 

--- a/torch_brain/utils/stitcher.py
+++ b/torch_brain/utils/stitcher.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 import logging
 from collections import defaultdict
-from typing import Callable, Iterable, Optional
+from typing import Callable, Iterable, List, Optional
 
 import hydra
 import numpy as np
@@ -83,7 +83,7 @@ class DataForDecodingStitchEvaluator:
     preds: torch.FloatTensor  # B x T_max x D_output
     targets: torch.FloatTensor  # B x T_max x D_output
     eval_masks: torch.BoolTensor  # B x T_max
-    session_ids: list  # A list of session ID strings, 1 for each batch
+    session_ids: List[str]  # A list of session ID strings, 1 for each sample in batch
     absolute_starts: torch.Tensor  # Batch
 
 
@@ -243,6 +243,19 @@ class DecodingStitchEvaluator(L.Callback):
 
     def on_test_epoch_end(self, *args, **kwargs):
         self.on_validation_epoch_end(*args, **kwargs, prefix="test")
+
+
+@dataclass
+class DataForMultiTaskDecodingStitchEvaluator:
+    r"""A batch's worth of data for :class:`DecodingStitchEvaluator`"""
+
+    timestamps: torch.FloatTensor  # B x T_max
+    preds: torch.FloatTensor  # B x T_max x D_output
+    targets: torch.FloatTensor  # B x T_max x D_output
+    eval_masks: torch.BoolTensor  # B x T_max
+    session_ids: List[str]  # A list of session ID strings, 1 for each sample in batch
+    absolute_starts: torch.Tensor  # Batch
+    decoder_indices: torch.LongTensor  # B x T_max
 
 
 class MultiTaskDecodingStitchEvaluator(L.Callback):


### PR DESCRIPTION
The PR brings in _three_ features/ideas.  Currently these are only applied to POYO and its surrounding code. If/once we are happy with these, we can update POYO+ with similar ideas.

1. Tokenizer is made part of the Model.
    - I am fairly confident that putting tokenizer in model does not copy the model's weight tensors (which are on GPU) to the workers. I printed `id(self.unit_emb.weight)` inside the tokenizer, and all workers had the same id. This should mean `unit_emb.weight` points to the same place in memory for all workers and is not a fresh copy for each.
    - `DataModule.setup()` has been changed to `DataModule.setup_dataset_and_link_model(model: POYO)` which sets up the train/val/test datasets, links the tokenize fn to the datasets, and updates the embedding vocabularies. I think this is a good way to express the tight relationship between our data and model, but open to suggestions/criticisms.
    
2. Tokenizer's output now has a `batch["model_input"]` which can straightaway be pass to the model. No popping items from batch dictionary required.
    - I am not super happy about accessing output mask through `batch["model_input"]["output_mask"]`, but the only alternative I see is to have another copy of this as `batch["output_mask"]` which has (very slight, but non-zero in general) dataloader performance implications.
    
3. Data interface to `DecodingStitchEvaluator` is formalized with a dataclass: `DataForDecodingStitchEvaluator`
    - This way the Callback based StitchEvaluator framework becomes a bit more transparent, and more generally usable by non-POYO train scripts. The problem with current approach was the requirement to follow a batch dictionary format that was hidden in documentation.
    - I know we might be considering changing StitchEvaluator API altogether. But this seems like a better version to keep in the main branch until we get to reworking the API.

#### TODOs for once we're happy about these ideas:
- [x] Mirror changes in POYO+ and MultiTaskDecodingStitchEvaluator
- [x] Tests
- [x] Doc Updates:
  - [x] POYO
  - [x] POYO+
  - [x] DecodingStitchEvaluator
  - [x] ~MultitaskDecodingStitchEvaluator~ (it never had a docstring, so this can be a separate PR)