### PR TITLE
Fixed StitcherEvaluator bug and added [minimal] tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -160,3 +160,5 @@ data/raw
 
 .DS_Store
 **/.DS_Store
+
+checkpoint.pth

--- a/tests/test_stitcher_evaluator.py
+++ b/tests/test_stitcher_evaluator.py
@@ -1,0 +1,69 @@
+import pytest
+import torch
+import lightning as L
+import torchmetrics
+from collections import defaultdict
+
+from torch_brain.utils.stitcher import MultiTaskDecodingStitchEvaluator
+
+
+class MockDataModule:
+    def __init__(self, sequence_index):
+        self.val_sequence_index = sequence_index
+        self.test_sequence_index = sequence_index
+
+
+class MockTrainer:
+    def __init__(self, sequence_index):
+        self.datamodule = MockDataModule(sequence_index)
+        self.loggers = []
+        self.is_global_zero = True
+
+
+@pytest.fixture
+def mock_metrics():
+    return {
+        "session1": {
+            "task1": {
+                "accuracy": torchmetrics.Accuracy(task="multiclass", num_classes=3),
+                "f1": torchmetrics.F1Score(task="multiclass", num_classes=3),
+            },
+            "task2": {"mse": torchmetrics.MeanSquaredError()},
+        }
+    }
+
+
+@pytest.fixture
+def evaluator(mock_metrics):
+    return MultiTaskDecodingStitchEvaluator(metrics=mock_metrics)
+
+
+def test_initialization(evaluator):
+    assert evaluator.metrics is not None
+    assert "session1" in evaluator.metrics
+    assert "task1" in evaluator.metrics["session1"]
+    assert "task2" in evaluator.metrics["session1"]
+
+
+def test_on_validation_epoch_start(evaluator):
+    sequence_index = torch.tensor([0, 0, 1, 1, 1])
+    trainer = MockTrainer(sequence_index)
+
+    evaluator._on_epoch_start_helper(trainer, mode="val")
+
+    assert evaluator.sample_ptr == 0
+    assert len(evaluator.cache) == 2  # max sequence_index + 1
+    assert evaluator.counter == [0, 0]
+    assert torch.equal(evaluator.cache_flush_threshold, torch.tensor([2, 3]))
+
+
+def test_on_test_epoch_start(evaluator):
+    sequence_index = torch.tensor([0, 0, 1, 1, 1])
+    trainer = MockTrainer(sequence_index)
+
+    evaluator._on_epoch_start_helper(trainer, mode="test")
+
+    assert evaluator.sample_ptr == 0
+    assert len(evaluator.cache) == 2
+    assert evaluator.counter == [0, 0]
+    assert torch.equal(evaluator.cache_flush_threshold, torch.tensor([2, 3]))

--- a/torch_brain/utils/stitcher.py
+++ b/torch_brain/utils/stitcher.py
@@ -230,7 +230,7 @@ class MultiTaskDecodingStitchEvaluator(L.Callback):
         self.metrics = metrics
 
     def on_validation_epoch_start(self, trainer, pl_module):
-        self._on_epoch_start_helper(trainer, mode="val")
+        self._setup_cache(trainer, mode="val")
 
     def on_validation_batch_end(self, trainer, pl_module, outputs, batch, batch_idx):
         target_values = batch.pop("target_values")
@@ -358,7 +358,7 @@ class MultiTaskDecodingStitchEvaluator(L.Callback):
                     )
 
     def on_test_epoch_start(self, trainer, pl_module):
-        self._on_epoch_start_helper(trainer, mode="test")
+        self._setup_cache(trainer, mode="test")
 
     def on_test_batch_end(self, *args, **kwargs):
         self.on_validation_batch_end(*args, **kwargs)
@@ -366,7 +366,7 @@ class MultiTaskDecodingStitchEvaluator(L.Callback):
     def on_test_epoch_end(self, *args, **kwargs):
         self.on_validation_epoch_end(*args, **kwargs, prefix="test")
 
-    def _on_epoch_start_helper(self, trainer, mode: str = "val"):
+    def _setup_cache(self, trainer, mode: str = "val"):
         if mode == "val":
             self.sequence_index = trainer.datamodule.val_sequence_index
         elif mode == "test":

--- a/torch_brain/utils/stitcher.py
+++ b/torch_brain/utils/stitcher.py
@@ -230,26 +230,7 @@ class MultiTaskDecodingStitchEvaluator(L.Callback):
         self.metrics = metrics
 
     def on_validation_epoch_start(self, trainer, pl_module):
-        # prepare a cache for each contiguous sequence
-        self.sequence_index = trainer.datamodule.val_sequence_index
-        num_sequences = self.sequence_index.max().item() + 1
-        self.sample_ptr = 0
-
-        self.cache = [
-            {
-                "target": defaultdict(list),
-                "pred": defaultdict(list),
-                "timestamps": defaultdict(list),
-            }
-            for _ in range(num_sequences)
-        ]
-
-        self.counter = [0] * num_sequences
-        # set the target of the couter based on unique in sequence_index
-        # use torch.unique to get the count
-        _, self.cache_flush_threshold = torch.unique(
-            self.sequence_index, return_counts=True
-        )
+        self._on_epoch_start_helper(trainer, mode="val")
 
     def on_validation_batch_end(self, trainer, pl_module, outputs, batch, batch_idx):
         target_values = batch.pop("target_values")
@@ -376,11 +357,38 @@ class MultiTaskDecodingStitchEvaluator(L.Callback):
                         {f"{prefix}_metrics": wandb.Table(dataframe=metrics_df)}
                     )
 
-    def on_test_epoch_start(self, *args, **kwargs):
-        self.on_validation_epoch_start(*args, **kwargs)
+    def on_test_epoch_start(self, trainer, pl_module):
+        self._on_epoch_start_helper(trainer, mode="test")
 
     def on_test_batch_end(self, *args, **kwargs):
         self.on_validation_batch_end(*args, **kwargs)
 
     def on_test_epoch_end(self, *args, **kwargs):
         self.on_validation_epoch_end(*args, **kwargs, prefix="test")
+
+    def _on_epoch_start_helper(self, trainer, mode: str = "val"):
+        if mode == "val":
+            self.sequence_index = trainer.datamodule.val_sequence_index
+        elif mode == "test":
+            self.sequence_index = trainer.datamodule.test_sequence_index
+        else:
+            raise ValueError(f"Invalid mode: {mode}")
+
+        num_sequences = self.sequence_index.max().item() + 1
+        self.sample_ptr = 0
+
+        self.cache = [
+            {
+                "target": defaultdict(list),
+                "pred": defaultdict(list),
+                "timestamps": defaultdict(list),
+            }
+            for _ in range(num_sequences)
+        ]
+
+        self.counter = [0] * num_sequences
+        # set the target of the couter based on unique in sequence_index
+        # use torch.unique to get the count
+        _, self.cache_flush_threshold = torch.unique(
+            self.sequence_index, return_counts=True
+        )


### PR DESCRIPTION
The `on_validation_epoch_start` method always used the the `val_sequence_index` from the `trainer.data_module` which causes issues especially if no validation was ever done before attempting to _test_.

edited typo