### PR TITLE
Simplify stitching sampler logic

### DIFF
--- a/torch_brain/utils/stitcher.py
+++ b/torch_brain/utils/stitcher.py
@@ -14,6 +14,7 @@ import wandb
 
 import torch_brain
 from torch_brain.registry import ModalitySpec, DataType
+from torch_brain.data.sampler import OptimizedStitcherSamplerWrapper
 
 
 def stitch(timestamps: torch.Tensor, values: torch.Tensor) -> torch.Tensor:
@@ -255,6 +256,11 @@ class DataForMultiTaskDecodingStitchEvaluator:
 class MultiTaskDecodingStitchEvaluator(L.Callback):
     def __init__(self, metrics: dict):
         self.metrics = metrics
+
+    def convert_to_stitcher_sampler(self, sampler):
+        stitch_sampler = OptimizedStitcherSamplerWrapper(sampler)
+        self.sequence_index = stitch_sampler.sequence_index
+        return stitch_sampler
 
     def on_validation_epoch_start(self, trainer, pl_module):
         self._setup_cache(trainer, mode="val")


### PR DESCRIPTION
Currently the custom stitching sampler is used for three reasons:
1. it makes sure that samples that are meant to be stitched are sampled close to each other. 
2. it tracks the "groups" of samples that are meant to be stitched together, to know when they are fully processed, and that the cache can be flushed.
3. it makes sure that the groups of samples are sent to the same rank to avoid sending copies of the data across ranks.

There is a lot of back and forth between the dataset and the stitchevaluator, and currently this will only work for one sampler. 

This PR proposes a `convert_to_stitching_sampler` function. that can be applied to any sampler. This removes the need for the `DistributedStitchingSampler` and simplified the interface, making the use of the stitcher optional.

Fundamentally, the stitching sampler is not supposed to change the behavior of the sampler, so this makes sense. We can change the stitcher to make the call to the `convert_to_stitching_sampler` optional, and only recommend it if there is OOM error, or in the documentation.