### PR TITLE
Rename interval_dict to sampling_intervals

### DIFF
--- a/examples/poyo/train.py
+++ b/examples/poyo/train.py
@@ -193,7 +193,7 @@ class DataModule(L.LightningDataModule):
 
     def train_dataloader(self):
         train_sampler = RandomFixedWindowSampler(
-            interval_dict=self.train_dataset.get_sampling_intervals(),
+            sampling_intervals=self.train_dataset.get_sampling_intervals(),
             window_length=self.sequence_length,
             generator=torch.Generator().manual_seed(self.cfg.seed + 1),
         )
@@ -220,7 +220,7 @@ class DataModule(L.LightningDataModule):
         batch_size = self.cfg.eval_batch_size or self.cfg.batch_size
 
         val_sampler = DistributedStitchingFixedWindowSampler(
-            interval_dict=self.val_dataset.get_sampling_intervals(),
+            sampling_intervals=self.val_dataset.get_sampling_intervals(),
             window_length=self.sequence_length,
             step=self.sequence_length / 2,
             batch_size=batch_size,
@@ -246,7 +246,7 @@ class DataModule(L.LightningDataModule):
         batch_size = self.cfg.eval_batch_size or self.cfg.batch_size
 
         test_sampler = DistributedStitchingFixedWindowSampler(
-            interval_dict=self.test_dataset.get_sampling_intervals(),
+            sampling_intervals=self.test_dataset.get_sampling_intervals(),
             window_length=self.sequence_length,
             step=self.sequence_length / 2,
             batch_size=batch_size,

--- a/examples/poyo_plus/train.py
+++ b/examples/poyo_plus/train.py
@@ -247,7 +247,7 @@ class DataModule(L.LightningDataModule):
 
     def train_dataloader(self):
         train_sampler = RandomFixedWindowSampler(
-            interval_dict=self.train_dataset.get_sampling_intervals(),
+            sampling_intervals=self.train_dataset.get_sampling_intervals(),
             window_length=self.sequence_length,
             generator=torch.Generator().manual_seed(self.cfg.seed + 1),
         )
@@ -274,7 +274,7 @@ class DataModule(L.LightningDataModule):
         batch_size = self.cfg.eval_batch_size or self.cfg.batch_size
 
         val_sampler = DistributedStitchingFixedWindowSampler(
-            interval_dict=self.val_dataset.get_sampling_intervals(),
+            sampling_intervals=self.val_dataset.get_sampling_intervals(),
             window_length=self.sequence_length,
             step=self.sequence_length / 2,
             batch_size=batch_size,
@@ -301,7 +301,7 @@ class DataModule(L.LightningDataModule):
         batch_size = self.cfg.eval_batch_size or self.cfg.batch_size
 
         test_sampler = DistributedStitchingFixedWindowSampler(
-            interval_dict=self.test_dataset.get_sampling_intervals(),
+            sampling_intervals=self.test_dataset.get_sampling_intervals(),
             window_length=self.sequence_length,
             step=self.sequence_length / 2,
             batch_size=batch_size,

--- a/tests/test_dataset_real.py
+++ b/tests/test_dataset_real.py
@@ -73,7 +73,7 @@
 #     sess_emb.initialize_vocab(ds.session_ids)
 
 #     sampler = SequentialFixedWindowSampler(
-#         interval_dict=ds.get_sampling_intervals(),
+#         sampling_intervals=ds.get_sampling_intervals(),
 #         window_length=1.0,
 #     )
 #     assert len(sampler) > 0
@@ -209,7 +209,7 @@
 #     model.session_emb.initialize_vocab(ds.session_ids)
 
 #     sampler = SequentialFixedWindowSampler(
-#         interval_dict=ds.get_sampling_intervals(),
+#         sampling_intervals=ds.get_sampling_intervals(),
 #         window_length=1.0,
 #     )
 #     assert len(sampler) > 0

--- a/tests/test_stitcher_sampler.py
+++ b/tests/test_stitcher_sampler.py
@@ -7,7 +7,7 @@ from torch_brain.data.sampler import DistributedStitchingFixedWindowSampler
 
 def test_distributed_stitching_sampler():
     # create test interval dict
-    interval_dict = {
+    sampling_intervals = {
         "session1": Interval(start=np.array([0.0, 20.0]), end=np.array([10.0, 30.0])),
         "session2": Interval(start=np.array([0.0]), end=np.array([15.0])),
     }
@@ -19,7 +19,7 @@ def test_distributed_stitching_sampler():
 
     # Test rank 0
     sampler0 = DistributedStitchingFixedWindowSampler(
-        interval_dict=interval_dict,
+        sampling_intervals=sampling_intervals,
         window_length=window_length,
         step=step,
         batch_size=batch_size,
@@ -30,7 +30,7 @@ def test_distributed_stitching_sampler():
 
     # Test rank 1
     sampler1 = DistributedStitchingFixedWindowSampler(
-        interval_dict=interval_dict,
+        sampling_intervals=sampling_intervals,
         window_length=window_length,
         step=step,
         batch_size=batch_size,

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -70,7 +70,7 @@
 #     model.session_emb.initialize_vocab(ds.session_ids)
 
 #     sampler = SequentialFixedWindowSampler(
-#         interval_dict=ds.get_sampling_intervals(),
+#         sampling_intervals=ds.get_sampling_intervals(),
 #         window_length=1.0,
 #     )
 #     assert len(sampler) > 0


### PR DESCRIPTION
Clean-up sampler arguments to keep it simple and consistent. `interval_dict` should be `sampling_intervals`. 
 
I am also open to renaming `sampling_intervals` to `sampling_intervals_dict`, including in `dataset.get_sampling_intervals_dict()`

I also fixed some of the documentation in the sampler.
