### PR TITLE
CI Testing: Speed up testing with `uv`

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -22,17 +22,18 @@ jobs:
       run: |
         python -m venv venv
         source venv/bin/activate
+        pip install uv
     - name: Install dependencies
       run: |
         source venv/bin/activate
-        python -m pip install --upgrade pip 
-        pip install torch==2.2.0
-        pip install -e ".[dev]" 
-        pip install flake8 pytest
+        uv pip install --upgrade pip 
+        uv pip install torch==2.2.0
+        uv pip install -e ".[dev]" 
+        uv pip install flake8 pytest
     - name: Install plugin
       run: |
         source venv/bin/activate
-        pip install pytest-github-actions-annotate-failures
+        uv pip install pytest-github-actions-annotate-failures
     - name: Test with pytest
       run: |
         source venv/bin/activate
@@ -49,7 +50,7 @@ jobs:
         cd brainsets_tmp
         git clone https://github.com/neuro-galaxy/brainsets.git
         cd brainsets
-        pip install -e ".[dandi]"
+        uv pip install -e ".[dandi]"
         cd ../../ 
     - name: Download sample dataset
       run: |

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -29,7 +29,6 @@ jobs:
         uv pip install --upgrade pip 
         uv pip install torch==2.2.0
         uv pip install -e ".[dev]" 
-        uv pip install flake8 pytest
     - name: Install plugin
       run: |
         source venv/bin/activate


### PR DESCRIPTION
Currently Github Actions take ~3m45s to complete, out of which ~2m30s are spent just installing python packages with `pip install`. 

This PR brings in using [`uv`](https://pypi.org/project/uv/) for installing python packages. It's very fast and installs packages in parallel (raw `pip` does it serially). Using this reduces the total package installation time to ~45s, and overall testing time to ~2m.

| Task                 | Time before | Time with `uv` |
|----------------------|-------------|----------------|
| Install dependencies | 1m 34s      | 25s            |
| Install plugin       | 1s          | 0s             |
| Install brainsets    | 53s         | 19s            |
| **Total**            | **2m 28s**      | **44s**            |