### PR TITLE
Typo fix: `MODALITIY_REGISTRY`

### DIFF
--- a/examples/poyo/train.py
+++ b/examples/poyo/train.py
@@ -14,7 +14,7 @@ from lightning.pytorch.callbacks import (
 from omegaconf import DictConfig, OmegaConf
 from temporaldata import Data
 
-from torch_brain.registry import MODALITIY_REGISTRY, ModalitySpec
+from torch_brain.registry import MODALITY_REGISTRY, ModalitySpec
 from torch_brain.models.poyo import POYO
 from torch_brain.utils import callbacks as tbrain_callbacks
 from torch_brain.utils import seed_everything
@@ -282,7 +282,7 @@ def main(cfg: DictConfig):
     # get modality details
     # TODO: add test to verify that all recordings have the same readout
     readout_id = cfg.dataset[0].config.readout.readout_id
-    readout_spec = MODALITIY_REGISTRY[readout_id]
+    readout_spec = MODALITY_REGISTRY[readout_id]
 
     # make model and data module
     model = hydra.utils.instantiate(cfg.model, readout_spec=readout_spec)

--- a/examples/poyo_plus/finetune.py
+++ b/examples/poyo_plus/finetune.py
@@ -12,7 +12,7 @@ from lightning.pytorch.callbacks import (
 )
 from omegaconf import DictConfig
 
-from torch_brain.registry import MODALITIY_REGISTRY
+from torch_brain.registry import MODALITY_REGISTRY
 from torch_brain.utils import callbacks as tbrain_callbacks
 from torch_brain.utils import seed_everything
 from torch_brain.utils.datamodules import DataModule
@@ -120,7 +120,7 @@ def main(cfg: DictConfig):
         )
 
     # make model
-    model = hydra.utils.instantiate(cfg.model, readout_specs=MODALITIY_REGISTRY)
+    model = hydra.utils.instantiate(cfg.model, readout_specs=MODALITY_REGISTRY)
     load_model_from_ckpt(model, cfg.ckpt_path)
     log.info(f"Loaded model weights from {cfg.ckpt_path}")
 

--- a/examples/poyo_plus/train.py
+++ b/examples/poyo_plus/train.py
@@ -23,7 +23,7 @@ from torch_brain.data.sampler import (
     RandomFixedWindowSampler,
 )
 from torch_brain.models import POYOPlus
-from torch_brain.registry import MODALITIY_REGISTRY
+from torch_brain.registry import MODALITY_REGISTRY
 from torch_brain.transforms import Compose
 from torch_brain.utils import callbacks as tbrain_callbacks
 from torch_brain.utils import seed_everything
@@ -102,7 +102,7 @@ class TrainWrapper(L.LightningModule):
             # count the number of sequences in the batch that have the current task
             num_sequences_with_current_task = torch.any(
                 batch["model_inputs"]["output_decoder_index"]
-                == MODALITIY_REGISTRY[readout_id].id,
+                == MODALITY_REGISTRY[readout_id].id,
                 dim=1,
             ).sum()
             loss = loss + taskwise_loss[readout_id] * num_sequences_with_current_task
@@ -224,12 +224,12 @@ class DataModule(L.LightningDataModule):
 
             for readout_config in multitask_readout:
                 readout_id = readout_config["readout_id"]
-                if readout_id not in MODALITIY_REGISTRY:
+                if readout_id not in MODALITY_REGISTRY:
                     raise ValueError(
                         f"Readout {readout_id} not found in modality registry, please register it "
                         "using torch_brain.register_modality()"
                     )
-                custum_readout_registry[readout_id] = MODALITIY_REGISTRY[readout_id]
+                custum_readout_registry[readout_id] = MODALITY_REGISTRY[readout_id]
         return custum_readout_registry
 
     def get_metrics(self):
@@ -343,7 +343,7 @@ def main(cfg: DictConfig):
 
     # make model and datamodule
     # TODO: resolve the readout_id from dataset, only build readouts needed
-    model = hydra.utils.instantiate(cfg.model, readout_specs=MODALITIY_REGISTRY)
+    model = hydra.utils.instantiate(cfg.model, readout_specs=MODALITY_REGISTRY)
     data_module = DataModule(cfg)
     data_module.setup_dataset_and_link_model(model)
 

--- a/tests/test_poyo_plus.py
+++ b/tests/test_poyo_plus.py
@@ -26,9 +26,9 @@ def setup_module():
 
 @pytest.fixture
 def task_specs():
-    from torch_brain.registry import MODALITIY_REGISTRY
+    from torch_brain.registry import MODALITY_REGISTRY
 
-    return MODALITIY_REGISTRY
+    return MODALITY_REGISTRY
 
 
 @pytest.fixture

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -4,7 +4,7 @@ from torch_brain.registry import (
     DataType,
     ModalitySpec,
     register_modality,
-    MODALITIY_REGISTRY,
+    MODALITY_REGISTRY,
 )
 
 
@@ -41,9 +41,9 @@ def test_modality_spec_creation():
 @pytest.fixture
 def clear_registry():
     """Fixture to clear the registry before and after each test."""
-    MODALITIY_REGISTRY.clear()
+    MODALITY_REGISTRY.clear()
     yield
-    MODALITIY_REGISTRY.clear()
+    MODALITY_REGISTRY.clear()
 
 
 def test_register_modality(clear_registry):
@@ -58,9 +58,9 @@ def test_register_modality(clear_registry):
     )
 
     assert modality_id == 1
-    assert "test_modality" in MODALITIY_REGISTRY
-    assert MODALITIY_REGISTRY["test_modality"].id == 1
-    assert MODALITIY_REGISTRY["test_modality"].dim == 2
+    assert "test_modality" in MODALITY_REGISTRY
+    assert MODALITY_REGISTRY["test_modality"].id == 1
+    assert MODALITY_REGISTRY["test_modality"].dim == 2
 
 
 def test_register_duplicate_modality(clear_registry):
@@ -109,6 +109,6 @@ def test_register_multiple_modalities(clear_registry):
 
     assert id1 == 1
     assert id2 == 2
-    assert len(MODALITIY_REGISTRY) == 2
-    assert MODALITIY_REGISTRY["modality1"].id == 1
-    assert MODALITIY_REGISTRY["modality2"].id == 2
+    assert len(MODALITY_REGISTRY) == 2
+    assert MODALITY_REGISTRY["modality1"].id == 1
+    assert MODALITY_REGISTRY["modality2"].id == 2

--- a/torch_brain/__init__.py
+++ b/torch_brain/__init__.py
@@ -1,3 +1,3 @@
 from . import nn
 
-from .registry import register_modality, get_modality_by_id, MODALITIY_REGISTRY
+from .registry import register_modality, get_modality_by_id, MODALITY_REGISTRY

--- a/torch_brain/models/poyo_plus.py
+++ b/torch_brain/models/poyo_plus.py
@@ -17,7 +17,7 @@ from torch_brain.nn import (
     RotaryEmbedding,
     prepare_for_multitask_readout,
 )
-from torch_brain.registry import ModalitySpec, MODALITIY_REGISTRY
+from torch_brain.registry import ModalitySpec, MODALITY_REGISTRY
 
 from torch_brain.utils import (
     create_linspace_latent_tokens,
@@ -71,7 +71,7 @@ class POYOPlus(nn.Module):
         self,
         *,
         sequence_length: float,
-        readout_specs: Dict[str, ModalitySpec] = MODALITIY_REGISTRY,
+        readout_specs: Dict[str, ModalitySpec] = MODALITY_REGISTRY,
         latent_step: float,
         num_latents_per_step: int = 64,
         dim: int = 512,

--- a/torch_brain/nn/multitask_readout.py
+++ b/torch_brain/nn/multitask_readout.py
@@ -194,7 +194,7 @@ def prepare_for_multitask_readout(
 
         key = readout_config["readout_id"]
 
-        if key not in torch_brain.MODALITIY_REGISTRY:
+        if key not in torch_brain.MODALITY_REGISTRY:
             raise ValueError(
                 f"Readout {key} not found in modality registry, please register it "
                 "using torch_brain.register_modality()"

--- a/torch_brain/registry.py
+++ b/torch_brain/registry.py
@@ -42,7 +42,7 @@ class ModalitySpec:
     loss_fn: Callable  # can be overwritten
 
 
-MODALITIY_REGISTRY: Dict[str, ModalitySpec] = {}
+MODALITY_REGISTRY: Dict[str, ModalitySpec] = {}
 _ID_TO_MODALITY: Dict[int, str] = {}
 
 
@@ -61,17 +61,17 @@ def register_modality(name: str, **kwargs: Any) -> int:
         ValueError: If a modality with the given name already exists
     """
     # Check if modality already exists
-    if name in MODALITIY_REGISTRY:
+    if name in MODALITY_REGISTRY:
         raise ValueError(f"Modality {name} already exists in registry")
 
     # Get next available ID
-    next_id = len(MODALITIY_REGISTRY) + 1
+    next_id = len(MODALITY_REGISTRY) + 1
 
     # Create DecoderSpec from kwargs and set ID
     decoder_spec = ModalitySpec(**kwargs, id=next_id)
 
     # Add to registries
-    MODALITIY_REGISTRY[name] = decoder_spec
+    MODALITY_REGISTRY[name] = decoder_spec
     _ID_TO_MODALITY[next_id] = name
 
     return next_id

--- a/torch_brain/utils/readout.py
+++ b/torch_brain/utils/readout.py
@@ -42,7 +42,7 @@ def prepare_for_readout(
 
     key = readout_config["readout_id"]
 
-    if key not in torch_brain.MODALITIY_REGISTRY:
+    if key not in torch_brain.MODALITY_REGISTRY:
         raise ValueError(
             f"Readout {key} not found in modality registry, please register it "
             "using torch_brain.register_modality()"


### PR DESCRIPTION
Addresses #61 

This PR fixes a typo `MODALITIY_REGISTRY` -> `MODALITY_REGISTRY`. It touches a lot of unrelated files. 