### PR TITLE
Bugfix: xformers attn_bias dtype should follow query

### DIFF
--- a/torch_brain/nn/rotary_attention.py
+++ b/torch_brain/nn/rotary_attention.py
@@ -456,7 +456,7 @@ def rotary_attn_xformers_func(
         else None
     )
     attn_bias = (
-        attn_mask.float().masked_fill(attn_mask.logical_not(), float("-inf"))
+        attn_mask.to(query.dtype).masked_fill(attn_mask.logical_not(), float("-inf"))
         if attn_mask is not None
         else None
     )


### PR DESCRIPTION
Bug: Training with xformers in bf16 precision fails because dtype of `attn_bias` doesn't match that of the query/key/value inputs.