### PR TITLE
bin_spikes support of custom data types

### DIFF
--- a/tests/test_binning.py
+++ b/tests/test_binning.py
@@ -1,8 +1,7 @@
-import pytest
-
 import numpy as np
+import pytest
+from temporaldata import Interval, IrregularTimeSeries
 
-from temporaldata import IrregularTimeSeries, Interval
 from torch_brain.utils.binning import bin_spikes
 
 
@@ -19,6 +18,13 @@ def test_bin_data():
     )
     assert binned_data.shape == expected.shape
     assert np.allclose(binned_data, expected)
+    assert binned_data.dtype == np.float32
+
+    # test with np.int32
+    binned_data = bin_spikes(
+        spikes, num_units=2, bin_size=1.0, right=True, dtype=np.int32
+    )
+    assert binned_data.dtype == np.int32
 
     # larger bin size
     spikes = IrregularTimeSeries(

--- a/torch_brain/utils/binning.py
+++ b/torch_brain/utils/binning.py
@@ -1,10 +1,13 @@
 import numpy as np
-
 from temporaldata import IrregularTimeSeries
 
 
 def bin_spikes(
-    spikes: IrregularTimeSeries, num_units: int, bin_size: float, right: bool = True
+    spikes: IrregularTimeSeries,
+    num_units: int,
+    bin_size: float,
+    right: bool = True,
+    dtype: np.dtype = np.float32,
 ) -> np.ndarray:
     r"""Bins spikes into time bins of size `bin_size`. If the total time spanned by
     the spikes is not a multiple of `bin_size`, the spikes are truncated to the nearest
@@ -20,6 +23,7 @@ def bin_spikes(
         bin_size: Size of the time bins in seconds.
         right: If True, any excess spikes are truncated from the left end of the time
             series. Otherwise, they are truncated from the right end.
+        dtype: Data type of the returned array.
     """
     start = spikes.domain.start[0]
     end = spikes.domain.end[-1]
@@ -36,7 +40,7 @@ def bin_spikes(
     num_bins = round((end - start) / bin_size)
 
     rate = 1 / bin_size  # avoid precision issues
-    binned_spikes = np.zeros((num_units, num_bins))
+    binned_spikes = np.zeros((num_units, num_bins), dtype=dtype)
     bin_index = np.floor((spikes.timestamps) * rate).astype(int)
     np.add.at(binned_spikes, (spikes.unit_index, bin_index), 1)
 


### PR DESCRIPTION
add an extra args to support custom numpy data types in bin_spikes and add tests