### PR TITLE
Adding 2d padding in collater

### DIFF
--- a/torch_brain/data/__init__.py
+++ b/torch_brain/data/__init__.py
@@ -1,3 +1,12 @@
-from .dataset import Dataset
 from . import sampler
-from .collate import collate, pad, track_mask, pad8, track_mask8, chain, track_batch
+from .collate import (
+    chain,
+    collate,
+    pad,
+    pad2d,
+    pad8,
+    track_batch,
+    track_mask,
+    track_mask8,
+)
+from .dataset import Dataset


### PR DESCRIPTION
# Padding Variable-Sized 2D Tensors Within a Batch

Imagine having a tensor with 2D shapes that vary within the batch and across dimensions. We would like to pad each tensor at the bottom and the right to ensure consistent sizes.

# Use Case
A typical use case is when creating a causal attention mask. This mask can be more complex than a simple triangular matrix because the timestamps can been shuffled within the batch (e.g. NDT2 and MAE based models).

Some examples can be found in the test file.

# Current Implementation
The current implementation might not be optimal, but I have an intuition that preallocating memory is still a good practice.

One alternative approach is to use `torch.pad` for each tensor using a for-loop and then stack them. However, based on my experience, this tends to be suboptimal compared to preallocating memory.

I can try benchmarking both methods to provide empirical results. Additionally, I’m very interested if you have suggestions for a more optimal solution.

# Possible Optimizations
We could consider implementing the 2d padding function at a lower level in C++ using JIT, but I am unsure if it's worth the effort, especially if the function is used in only a few models.


