### PR TITLE
Add resampling and pre_split_transform feature

### DIFF
--- a/tests/test_resampling.py
+++ b/tests/test_resampling.py
@@ -65,8 +65,8 @@ def regular_data(base_frequency):
     data = Data(
         att1=RegularTimeSeries(
             sampling_rate=base_frequency,
-            values=np.arange(100, 150, dtype=np.float64),
             domain=Interval(0.0, 50.0),
+            values=np.arange(100, 150, dtype=np.float64),
         ),
         domain="auto",
     )
@@ -199,43 +199,127 @@ def test_upsampling_irregular(
     assert np.array_equal(data.att1.values, x_out[N:])
 
 
-# def test_downsampling_regular(
-#     regular_data, base_frequency, downsampling_frequency, center_window, even_window
-# ):
-#     pre_slice_transform = Resampler(base_frequency, downsampling_frequency)
-#     start = center_window["start"]
-#     end = center_window["end"]
-#     data = pre_slice_transform(regular_data, start, end)
+def test_downsampling_regular(
+    regular_data,
+    base_frequency,
+    downsampling_frequency,
+    center_window,
+    right_window,
+    left_window,
+):
+    # 1 case: centered window
+    pre_slice_transform = Resampler(base_frequency, downsampling_frequency)
+    start = center_window["start"]
+    end = center_window["end"]
+    data = pre_slice_transform(regular_data, start, end)
 
-#     expected_timestamps = np.arange(
-#         start,
-#         end,
-#         1 / downsampling_frequency,
-#     )
-#     assert np.array_equal(data.att1.timestamps, expected_timestamps)
+    extra_window_length = pre_slice_transform.extra_window_length
+    window_start = int(start - extra_window_length / 2)
+    window_end = int(end + extra_window_length / 2)
+    x_in = regular_data.att1.values[window_start:window_end]
+    num = int((window_end - window_start) * downsampling_frequency)
+    t_in = regular_data.att1.timestamps[window_start:window_end]
+    x_out, t_out = resample(x_in, num, t=t_in, window="hamming")
 
-#     window_start = 10
-#     window_end = 40
-#     num = int((window_end - window_start) * downsampling_frequency)
-#     unsliced_expected_values = resample(
-#         irregular_data.att1.values[window_start:window_end], num
-#     )
-#     expected_values = unsliced_expected_values[5:10]
-#     print(expected_values)
-#     print(data.att1.values)
-#     assert np.array_equal(data.att1.values, expected_values)
+    N = int(extra_window_length * downsampling_frequency / 2)
+    assert np.array_equal(data.att1.timestamps, t_out[N:-N])
+    assert np.array_equal(data.att1.values, x_out[N:-N])
+
+    # 2 case: right window
+    pre_slice_transform = Resampler(base_frequency, downsampling_frequency)
+    start = right_window["start"]
+    end = right_window["end"]
+    data = pre_slice_transform(regular_data, start, end)
+
+    extra_window_length = pre_slice_transform.extra_window_length
+    window_start = int(start)
+    window_end = int(end + extra_window_length)
+    x_in = regular_data.att1.values[window_start:window_end]
+    num = int((window_end - window_start) * downsampling_frequency)
+    t_in = regular_data.att1.timestamps[window_start:window_end]
+    x_out, t_out = resample(x_in, num, t=t_in, window="hamming")
+
+    N = int(extra_window_length * downsampling_frequency)
+    assert np.array_equal(data.att1.timestamps, t_out[:-N])
+    assert np.array_equal(data.att1.values, x_out[:-N])
+
+    # 3 case: left window
+    pre_slice_transform = Resampler(base_frequency, downsampling_frequency)
+    start = left_window["start"]
+    end = left_window["end"]
+    data = pre_slice_transform(regular_data, start, end)
+
+    extra_window_length = pre_slice_transform.extra_window_length
+    window_start = int(start - extra_window_length)
+    window_end = int(end)
+    x_in = regular_data.att1.values[window_start:window_end]
+    num = int((window_end - window_start) * downsampling_frequency)
+    t_in = regular_data.att1.timestamps[window_start:window_end]
+    x_out, t_out = resample(x_in, num, t=t_in, window="hamming")
+
+    N = int(extra_window_length * downsampling_frequency)
+    assert np.array_equal(data.att1.timestamps, t_out[N:])
+    assert np.array_equal(data.att1.values, x_out[N:])
 
 
-# def test_upsampling_regular(regular_data, base_frequency, upsampling_frequency):
-#     pre_slice_transform = Resampler(base_frequency, upsampling_frequency)
-#     data = pre_slice_transform(regular_data, 0.0, 10.0)
+def test_upsampling_regular(
+    regular_data,
+    base_frequency,
+    upsampling_frequency,
+    center_window,
+    right_window,
+    left_window,
+):
+    # 1 case: centered window
+    pre_slice_transform = Resampler(base_frequency, upsampling_frequency)
+    start = center_window["start"]
+    end = center_window["end"]
+    data = pre_slice_transform(regular_data, start, end)
 
-#     expected_timestamps = np.arange(
-#         0.0, 10.0 + pre_slice_transform.extra_window_length, 1 / upsampling_frequency
-#     )
-#     print("expected_timestamps", expected_timestamps.shape)
-#     print("data.att1.timestamps", data.att1.timestamps.shape)
-#     assert np.array_equal(data.att1.timestamps, expected_timestamps)
+    extra_window_length = pre_slice_transform.extra_window_length
+    window_start = int(start - extra_window_length / 2)
+    window_end = int(end + extra_window_length / 2)
+    x_in = regular_data.att1.values[window_start:window_end]
+    num = int((window_end - window_start) * upsampling_frequency)
+    t_in = regular_data.att1.timestamps[window_start:window_end]
+    x_out, t_out = resample(x_in, num, t=t_in, window="hamming")
 
-#     expected_values = resample(regular_data.att1.values[:30], len(expected_timestamps))
-#     assert np.array_equal(data.att1.values, expected_values)
+    N = int(extra_window_length * upsampling_frequency / 2)
+    assert np.array_equal(data.att1.timestamps, t_out[N:-N])
+    assert np.array_equal(data.att1.values, x_out[N:-N])
+
+    # 2 case: right window
+    pre_slice_transform = Resampler(base_frequency, upsampling_frequency)
+    start = right_window["start"]
+    end = right_window["end"]
+    data = pre_slice_transform(regular_data, start, end)
+
+    extra_window_length = pre_slice_transform.extra_window_length
+    window_start = int(start)
+    window_end = int(end + extra_window_length)
+    x_in = regular_data.att1.values[window_start:window_end]
+    num = int((window_end - window_start) * upsampling_frequency)
+    t_in = regular_data.att1.timestamps[window_start:window_end]
+    x_out, t_out = resample(x_in, num, t=t_in, window="hamming")
+
+    N = int(extra_window_length * upsampling_frequency)
+    assert np.array_equal(data.att1.timestamps, t_out[:-N])
+    assert np.array_equal(data.att1.values, x_out[:-N])
+
+    # 3 case: left window
+    pre_slice_transform = Resampler(base_frequency, upsampling_frequency)
+    start = left_window["start"]
+    end = left_window["end"]
+    data = pre_slice_transform(regular_data, start, end)
+
+    extra_window_length = pre_slice_transform.extra_window_length
+    window_start = int(start - extra_window_length)
+    window_end = int(end)
+    x_in = regular_data.att1.values[window_start:window_end]
+    num = int((window_end - window_start) * upsampling_frequency)
+    t_in = regular_data.att1.timestamps[window_start:window_end]
+    x_out, t_out = resample(x_in, num, t=t_in, window="hamming")
+
+    N = int(extra_window_length * upsampling_frequency)
+    assert np.array_equal(data.att1.timestamps, t_out[N:])
+    assert np.array_equal(data.att1.values, x_out[N:])

--- a/tests/test_resampling.py
+++ b/tests/test_resampling.py
@@ -37,8 +37,13 @@ def center_window():
 
 
 @pytest.fixture
-def even_window():
-    return {"start": 0.0, "end": 12.0}
+def right_window():
+    return {"start": 0.0, "end": 10.0}
+
+
+@pytest.fixture
+def left_window():
+    return {"start": 40.0, "end": 50.0}
 
 
 @pytest.fixture
@@ -69,28 +74,129 @@ def regular_data(base_frequency):
 
 
 def test_downsampling_irregular(
-    irregular_data, base_frequency, downsampling_frequency, center_window
+    irregular_data,
+    base_frequency,
+    downsampling_frequency,
+    center_window,
+    right_window,
+    left_window,
 ):
+    # 1 case: centered window
     pre_slice_transform = Resampler(base_frequency, downsampling_frequency)
     start = center_window["start"]
     end = center_window["end"]
     data = pre_slice_transform(irregular_data, start, end)
 
-    expected_timestamps = np.arange(
-        start,
-        end,
-        1 / downsampling_frequency,
-    )
-    assert np.array_equal(data.att1.timestamps, expected_timestamps)
-
-    window_start = 10
-    window_end = 40
+    extra_window_length = pre_slice_transform.extra_window_length
+    window_start = int(start - extra_window_length / 2)
+    window_end = int(end + extra_window_length / 2)
+    x_in = irregular_data.att1.values[window_start:window_end]
     num = int((window_end - window_start) * downsampling_frequency)
-    unsliced_expected_values = resample(
-        irregular_data.att1.values[window_start:window_end], num
-    )
-    expected_values = unsliced_expected_values[5:10]
-    assert np.array_equal(data.att1.values, expected_values)
+    t_in = irregular_data.att1.timestamps[window_start:window_end]
+    x_out, t_out = resample(x_in, num, t=t_in, window="hamming")
+
+    N = int(extra_window_length * downsampling_frequency / 2)
+    assert np.array_equal(data.att1.timestamps, t_out[N:-N])
+    assert np.array_equal(data.att1.values, x_out[N:-N])
+
+    # 2 case: right window
+    pre_slice_transform = Resampler(base_frequency, downsampling_frequency)
+    start = right_window["start"]
+    end = right_window["end"]
+    data = pre_slice_transform(irregular_data, start, end)
+
+    extra_window_length = pre_slice_transform.extra_window_length
+    window_start = int(start)
+    window_end = int(end + extra_window_length)
+    x_in = irregular_data.att1.values[window_start:window_end]
+    num = int((window_end - window_start) * downsampling_frequency)
+    t_in = irregular_data.att1.timestamps[window_start:window_end]
+    x_out, t_out = resample(x_in, num, t=t_in, window="hamming")
+
+    N = int(extra_window_length * downsampling_frequency)
+    assert np.array_equal(data.att1.timestamps, t_out[:-N])
+    assert np.array_equal(data.att1.values, x_out[:-N])
+
+    # 3 case: left window
+    pre_slice_transform = Resampler(base_frequency, downsampling_frequency)
+    start = left_window["start"]
+    end = left_window["end"]
+    data = pre_slice_transform(irregular_data, start, end)
+
+    extra_window_length = pre_slice_transform.extra_window_length
+    window_start = int(start - extra_window_length)
+    window_end = int(end)
+    x_in = irregular_data.att1.values[window_start:window_end]
+    num = int((window_end - window_start) * downsampling_frequency)
+    t_in = irregular_data.att1.timestamps[window_start:window_end]
+    x_out, t_out = resample(x_in, num, t=t_in, window="hamming")
+
+    N = int(extra_window_length * downsampling_frequency)
+    assert np.array_equal(data.att1.timestamps, t_out[N:])
+    assert np.array_equal(data.att1.values, x_out[N:])
+
+
+def test_upsampling_irregular(
+    irregular_data,
+    base_frequency,
+    upsampling_frequency,
+    center_window,
+    right_window,
+    left_window,
+):
+    # 1 case: centered window
+    pre_slice_transform = Resampler(base_frequency, upsampling_frequency)
+    start = center_window["start"]
+    end = center_window["end"]
+    data = pre_slice_transform(irregular_data, start, end)
+
+    extra_window_length = pre_slice_transform.extra_window_length
+    window_start = int(start - extra_window_length / 2)
+    window_end = int(end + extra_window_length / 2)
+    x_in = irregular_data.att1.values[window_start:window_end]
+    num = int((window_end - window_start) * upsampling_frequency)
+    t_in = irregular_data.att1.timestamps[window_start:window_end]
+    x_out, t_out = resample(x_in, num, t=t_in, window="hamming")
+
+    N = int(extra_window_length * upsampling_frequency / 2)
+    assert np.array_equal(data.att1.timestamps, t_out[N:-N])
+    assert np.array_equal(data.att1.values, x_out[N:-N])
+
+    # 2 case: right window
+    pre_slice_transform = Resampler(base_frequency, upsampling_frequency)
+    start = right_window["start"]
+    end = right_window["end"]
+    data = pre_slice_transform(irregular_data, start, end)
+
+    extra_window_length = pre_slice_transform.extra_window_length
+    window_start = int(start)
+    window_end = int(end + extra_window_length)
+    x_in = irregular_data.att1.values[window_start:window_end]
+    num = int((window_end - window_start) * upsampling_frequency)
+    t_in = irregular_data.att1.timestamps[window_start:window_end]
+    x_out, t_out = resample(x_in, num, t=t_in, window="hamming")
+
+    N = int(extra_window_length * upsampling_frequency)
+    assert np.array_equal(data.att1.timestamps, t_out[:-N])
+    assert np.array_equal(data.att1.values, x_out[:-N])
+
+    # 3 case: left window
+    pre_slice_transform = Resampler(base_frequency, upsampling_frequency)
+    start = left_window["start"]
+    end = left_window["end"]
+    data = pre_slice_transform(irregular_data, start, end)
+
+    extra_window_length = pre_slice_transform.extra_window_length
+    window_start = int(start - extra_window_length)
+    window_end = int(end)
+    x_in = irregular_data.att1.values[window_start:window_end]
+    num = int((window_end - window_start) * upsampling_frequency)
+    t_in = irregular_data.att1.timestamps[window_start:window_end]
+    x_out, t_out = resample(x_in, num, t=t_in, window="hamming")
+
+    N = int(extra_window_length * upsampling_frequency)
+    assert np.array_equal(data.att1.timestamps, t_out[N:])
+    assert np.array_equal(data.att1.values, x_out[N:])
 
 
 # def test_downsampling_regular(
@@ -117,21 +223,6 @@ def test_downsampling_irregular(
 #     expected_values = unsliced_expected_values[5:10]
 #     print(expected_values)
 #     print(data.att1.values)
-#     assert np.array_equal(data.att1.values, expected_values)
-
-
-# def test_upsampling_irregular(irregular_data, base_frequency, upsampling_frequency):
-#     pre_slice_transform = Resampler(base_frequency, upsampling_frequency)
-#     data = pre_slice_transform(irregular_data, 0.0, 10.0)
-
-#     expected_timestamps = np.arange(
-#         0.0, 10.0 + pre_slice_transform.extra_window_length, 1 / upsampling_frequency
-#     )
-#     assert np.array_equal(data.att1.timestamps, expected_timestamps)
-
-#     expected_values = resample(
-#         irregular_data.att1.values[:30], len(expected_timestamps)
-#     )
 #     assert np.array_equal(data.att1.values, expected_values)
 
 

--- a/tests/test_resampling.py
+++ b/tests/test_resampling.py
@@ -1,0 +1,53 @@
+import logging
+
+import numpy as np
+import pytest
+from scipy.signal import resample
+from temporaldata import ArrayDict, Data, IrregularTimeSeries
+
+from torch_brain.transforms import Resampler
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.fixture
+def mock_data_1():
+    timestamps = np.arange(200, dtype=np.float64)
+    values = np.arange(200, 400, dtype=np.float64)
+
+    data = Data(
+        att1=IrregularTimeSeries(
+            timestamps=timestamps,
+            values=values,
+            timekeys=["timestamps", "values"],
+            domain="auto",
+        ),
+        domain="auto",
+    )
+    return data
+
+
+@pytest.fixture
+def base_frequency_1():
+    return 1.0
+
+
+@pytest.fixture
+def resample_frequency_1():
+    return 0.5
+
+
+def test_downsampling(mock_data_1, base_frequency_1, resample_frequency_1):
+    pre_slice_transform = Resampler(base_frequency_1, resample_frequency_1)
+    data = pre_slice_transform(mock_data_1, 0.0, 10.0)
+    print(data.att1.timestamps)
+
+    expected_timestamps = np.arange(
+        0.0, 10.0 + pre_slice_transform.extra_window_length, 1 / resample_frequency_1
+    )
+    print(expected_timestamps)
+
+    assert np.array_equal(data.att1.timestamps, expected_timestamps)
+
+    expected_values = resample(mock_data_1.att1.values[:15], len(expected_timestamps))
+    assert np.array_equal(data.att1.values, expected_values)

--- a/torch_brain/data/dataset.py
+++ b/torch_brain/data/dataset.py
@@ -85,6 +85,7 @@ class Dataset(torch.utils.data.Dataset):
         recording_id: Optional[str] = None,
         split: Optional[str] = None,
         transform: Optional[Callable[[Data], Any]] = None,
+        pre_slice_transform: Optional[Callable[[Data], Any]] = None,
         unit_id_prefix_fn: Callable[[Data], str] = default_unit_id_prefix_fn,
         session_id_prefix_fn: Callable[[Data], str] = default_session_id_prefix_fn,
         subject_id_prefix_fn: Callable[[Data], str] = default_subject_id_prefix_fn,
@@ -94,6 +95,7 @@ class Dataset(torch.utils.data.Dataset):
         self.config = config
         self.split = split
         self.transform = transform
+        self.pre_slice_transform = pre_slice_transform
         self.unit_id_prefix_fn = unit_id_prefix_fn
         self.session_id_prefix_fn = session_id_prefix_fn
         self.subject_id_prefix_fn = subject_id_prefix_fn
@@ -296,6 +298,10 @@ class Dataset(torch.utils.data.Dataset):
             end: The end time of the slice.
         """
         data = copy.copy(self._data_objects[recording_id])
+
+        if self.pre_slice_transform is not None:
+            data = self.pre_slice_transform(data, start, end)
+
         # TODO: add more tests to make sure that slice does not modify the original data object
         # note there should be no issues as long as the self._data_objects stay lazy
         sample = data.slice(start, end)

--- a/torch_brain/transforms/__init__.py
+++ b/torch_brain/transforms/__init__.py
@@ -2,5 +2,6 @@ from .container import Compose, ConditionalChoice, RandomChoice
 from .output_sampler import RandomOutputSampler
 from .random_crop import RandomCrop
 from .random_time_scaling import RandomTimeScaling
+from .resampling import Resampler
 from .unit_dropout import TriangleDistribution, UnitDropout
 from .unit_filter import UnitFilter, UnitFilterById

--- a/torch_brain/transforms/resampling.py
+++ b/torch_brain/transforms/resampling.py
@@ -63,18 +63,18 @@ class Resampler:
                 num = int((window_end - window_start) * self.resample_frequency)
                 t_in = val.timestamps
 
-                resampled_time_values = {}
+                resampled_time_based_values = {}
                 for timekey in val._timekeys:
                     if timekey == "timestamps":
                         continue
 
                     x_in = getattr(val, timekey)
                     x_out, t_out = resample(x_in, num, t=t_in, window="hamming")
-                    resampled_time_values[timekey] = x_out
+                    resampled_time_based_values[timekey] = x_out
 
                 unsliced_value = IrregularTimeSeries(
                     timestamps=t_out,
-                    **resampled_time_values,
+                    **resampled_time_based_values,
                     timekeys=val._timekeys,
                     domain="auto",
                 )
@@ -86,17 +86,20 @@ class Resampler:
 
             elif isinstance(value, RegularTimeSeries):
                 val = copy.copy(value)
-                window_length = window_start - window_start
-                num = int(window_length * self.resample_frequency)
-                tmp = {}
+                num = int((window_end - window_start) * self.resample_frequency)
+
+                resampled_time_based_values = {}
                 for timekey in val.keys():
-                    tmp[timekey] = resample(getattr(val, timekey), num)
+                    x_in = getattr(val, timekey)
+                    x_out = resample(x_in, num, window="hamming")
+                    resampled_time_based_values[timekey] = x_out
 
                 val_unsliced = RegularTimeSeries(
                     sampling_rate=self.resample_frequency,
-                    **tmp,
+                    **resampled_time_based_values,
                     domain=copy.copy(val._domain),
                 )
+                # same as above
                 out.__dict__[key] = val_unsliced.slice(start, end, reset_origin=False)
 
             else:

--- a/torch_brain/transforms/resampling.py
+++ b/torch_brain/transforms/resampling.py
@@ -1,0 +1,65 @@
+import copy
+
+import numpy as np
+from scipy.signal import resample
+from temporaldata import Data, IrregularTimeSeries, RegularTimeSeries
+
+
+class Resampler:
+    def __init__(self, base_frequency: float, resample_frequency: float):
+        self.base_frequency = base_frequency
+        self.resample_frequency = resample_frequency
+        self.extra_window_length = 10 * self.resample_frequency / self.base_frequency
+
+    def __call__(self, data: Data, start: float, end: float):
+        return self.resample(data, start, end)
+
+    def resample(self, data: Data, start: float, end: float):
+        r"""Resample the data to a new time interval.
+
+        Args:
+            data (Data): The data to resample.
+            start (float): The start time of the new interval.
+            end (float): The end time of the new interval.
+        """
+        # TODO center the interval around the start and end time
+        out = data.__class__.__new__(data.__class__)
+        data = copy.deepcopy(data)
+        new_data = data.slice(start, end + self.extra_window_length)
+        for key, value in new_data.__dict__.items():
+            if isinstance(value, IrregularTimeSeries):
+                val = copy.copy(value)
+                timestamps = np.arange(
+                    start,
+                    end + self.extra_window_length,
+                    1 / self.resample_frequency,
+                    dtype=np.float64,
+                )
+                num = len(timestamps)
+                tmp = {}
+
+                for timekey in val._timekeys:
+                    if timekey == "timestamps":
+                        continue
+                    tmp[timekey] = resample(getattr(val, timekey), num)
+
+                out.__dict__[key] = IrregularTimeSeries(
+                    timestamps=timestamps,
+                    **tmp,
+                    domain="auto",
+                )
+
+            elif isinstance(value, RegularTimeSeries):
+                val = copy.copy(value)
+                val._sampling_rate = self.resample_frequency
+                val._domain = copy.copy(value._domain)
+                for timekey in value.get("_timekeys", []):
+                    if timekey == "timestamps":
+                        continue
+                    val.__dict__[timekey] = resample(val.timekey, num)
+                out.__dict__[key] = val
+
+            else:
+                out.__dict__[key] = copy.copy(value)
+
+        return out

--- a/torch_brain/transforms/resampling.py
+++ b/torch_brain/transforms/resampling.py
@@ -6,10 +6,26 @@ from temporaldata import Data, IrregularTimeSeries, RegularTimeSeries
 
 
 class Resampler:
-    def __init__(self, base_frequency: float, resample_frequency: float):
+    def __init__(
+        self,
+        base_frequency: float,
+        resample_frequency: float,
+        extra_window_factor: int = 10,
+    ):
         self.base_frequency = base_frequency
         self.resample_frequency = resample_frequency
-        self.extra_window_length = 10 * self.resample_frequency / self.base_frequency
+        # TODO add the ref from where this come from
+        if extra_window_factor < 4 or 10 < extra_window_factor:
+            raise ValueError("extra_window_factor must be between 4 and 10, inclusive.")
+        self.extra_window_factor = extra_window_factor
+        # TODO not sure of this check
+        if self.base_frequency / self.resample_frequency % 1 != 0:
+            raise ValueError(
+                "The base frequency must be a multiple of the resample frequency."
+            )
+        self.extra_window_length = (
+            extra_window_factor * self.base_frequency / self.resample_frequency
+        )
 
     def __call__(self, data: Data, start: float, end: float):
         return self.resample(data, start, end)
@@ -22,42 +38,73 @@ class Resampler:
             start (float): The start time of the new interval.
             end (float): The end time of the new interval.
         """
-        # TODO center the interval around the start and end time
         out = data.__class__.__new__(data.__class__)
         data = copy.deepcopy(data)
-        new_data = data.slice(start, end + self.extra_window_length)
+
+        # TODO: intersting in you opinion about this
+        # When we are in a center window, because we divide by two the extra_window_length we could
+        # be benefical to ensure we are using an offset to keep start and end in the sampled point in the new window
+        offsett = self.extra_window_length / 2 % self.resample_frequency
+        if (
+            data.domain.start <= start - self.extra_window_length / 2 - offsett
+            and end + self.extra_window_length / 2 - offsett < data.domain.end
+        ):
+            window_start = start - self.extra_window_length / 2 - offsett
+            window_end = end + self.extra_window_length / 2 - offsett
+        elif end + self.extra_window_length < data.domain.end:
+            window_start = start
+            window_end = end + self.extra_window_length
+        elif data.domain.start <= start - self.extra_window_length:
+            window_start = start - self.extra_window_length
+            window_end = end
+        else:
+            raise ValueError(
+                f"Data domain {data.domain} does not contain the requested interval [{start}, {end}]"
+            )
+
+        new_data = data.slice(window_start, window_end, reset_origin=False)
         for key, value in new_data.__dict__.items():
             if isinstance(value, IrregularTimeSeries):
                 val = copy.copy(value)
                 timestamps = np.arange(
-                    start,
-                    end + self.extra_window_length,
+                    window_start,
+                    window_end,
                     1 / self.resample_frequency,
                     dtype=np.float64,
                 )
                 num = len(timestamps)
                 tmp = {}
-
                 for timekey in val._timekeys:
                     if timekey == "timestamps":
                         continue
+
                     tmp[timekey] = resample(getattr(val, timekey), num)
 
-                out.__dict__[key] = IrregularTimeSeries(
+                val_unsliced = IrregularTimeSeries(
                     timestamps=timestamps,
                     **tmp,
                     domain="auto",
                 )
 
+                # TODO the slicing will be process after anyway and could be ommited
+                # However it could be clean to have it already sliced (and optimized memory in case of big window_length)
+                # Intersted about feedback here
+                out.__dict__[key] = val_unsliced.slice(start, end, reset_origin=False)
+
             elif isinstance(value, RegularTimeSeries):
                 val = copy.copy(value)
-                val._sampling_rate = self.resample_frequency
-                val._domain = copy.copy(value._domain)
-                for timekey in value.get("_timekeys", []):
-                    if timekey == "timestamps":
-                        continue
-                    val.__dict__[timekey] = resample(val.timekey, num)
-                out.__dict__[key] = val
+                window_length = window_start - window_start
+                num = int(window_length * self.resample_frequency)
+                tmp = {}
+                for timekey in val.keys():
+                    tmp[timekey] = resample(getattr(val, timekey), num)
+
+                val_unsliced = RegularTimeSeries(
+                    sampling_rate=self.resample_frequency,
+                    **tmp,
+                    domain=copy.copy(val._domain),
+                )
+                out.__dict__[key] = val_unsliced.slice(start, end, reset_origin=False)
 
             else:
                 out.__dict__[key] = copy.copy(value)


### PR DESCRIPTION
In some cases, we need to have the decoding behavior at a specific sample rate and require resampling (either upsampling or downsampling) the data. Currently, our framework does not support resampling.

To address this, we introduce a new feature: `pre_split_transform`.

This feature allows applying a transformation to the data before it is sliced, as opposed to the standard transform, which operates on already-sliced data. This is particularly useful for resampling, as it enables us to process a larger window than the final slice size. By doing so, we can better mitigate edge artifacts commonly introduced during resampling operations.