### PR TITLE
Fixed Device bug in infinite_vocab_embedding

### DIFF
--- a/torch_brain/nn/infinite_vocab_embedding.py
+++ b/torch_brain/nn/infinite_vocab_embedding.py
@@ -182,7 +182,7 @@ class InfiniteVocabEmbedding(nn.Module):
         embeddings_for_existing_words = self.weight.clone().detach()
 
         # reinitalize weight matrix after extending it
-        self.weight = UninitializedParameter()
+        self.weight = UninitializedParameter(device=self.weight.device)
         self.initialize_parameters(len(self.vocab))
 
         # copy existing embeddings into new weight matrix


### PR DESCRIPTION
This would move the embedding layer back to the CPU. 