### PR TITLE
Proposal - Dataset config schema definition for POYO

### DIFF
--- a/tests/test_poyo_dataset_schema.py
+++ b/tests/test_poyo_dataset_schema.py
@@ -20,22 +20,22 @@ def test_validate_real_dataset_configs(config_path):
     # Load config
     cfg = OmegaConf.load(config_path)
     config_dict = OmegaConf.to_container(cfg, resolve=True)
-    
+
     # Validate - should not raise ValidationError
     validated = POYODatasetConfig.model_validate(config_dict)
-    
+
     # Basic assertions
     assert len(validated) > 0, "Config should have at least one selection block"
-    
+
     # Check first block has required structure
     first_block = validated[0]
-    assert hasattr(first_block, 'selection'), "Block should have selection"
-    assert hasattr(first_block, 'config'), "Block should have config"
-    assert hasattr(first_block.config, 'readout'), "Config should have readout"
-    
+    assert hasattr(first_block, "selection"), "Block should have selection"
+    assert hasattr(first_block, "config"), "Block should have config"
+    assert hasattr(first_block.config, "readout"), "Config should have readout"
+
     # Check readout has required field
     readout = first_block.config.readout
-    assert hasattr(readout, 'readout_id'), "Readout should have readout_id"
+    assert hasattr(readout, "readout_id"), "Readout should have readout_id"
     assert readout.readout_id is not None, "Readout ID should not be None"
 
 
@@ -47,12 +47,12 @@ def test_schema_rejects_invalid_config():
             "config": {
                 "readout": {
                     "readout_id": "test",
-                    "normalize_std": 0.0  # Invalid: std cannot be 0
+                    "normalize_std": 0.0,  # Invalid: std cannot be 0
                 }
-            }
+            },
         }
     ]
-    
+
     with pytest.raises(ValueError, match="cannot be 0"):
         POYODatasetConfig.model_validate(invalid_config)
 
@@ -65,11 +65,11 @@ def test_schema_rejects_unknown_fields():
             "config": {
                 "readout": {
                     "readout_id": "test",
-                    "unknown_field": "value"  # Invalid: unknown field
+                    "unknown_field": "value",  # Invalid: unknown field
                 }
-            }
+            },
         }
     ]
-    
+
     with pytest.raises(Exception):  # Pydantic ValidationError
         POYODatasetConfig.model_validate(invalid_config)

--- a/tests/test_poyo_dataset_schema.py
+++ b/tests/test_poyo_dataset_schema.py
@@ -1,0 +1,75 @@
+"""Tests for POYO dataset configuration schemas."""
+
+import pytest
+from pathlib import Path
+from omegaconf import OmegaConf
+from torch_brain.schemas.poyo_dataset import POYODatasetConfig
+
+
+# List of all dataset config files to test
+DATASET_CONFIG_FILES = [
+    "examples/poyo/configs/dataset/pei_pandarinath_nlb_2021.yaml",
+    "examples/poyo/configs/dataset/perich_miller_population_2018.yaml",
+    "examples/poyo/configs/dataset/poyo_1.yaml",
+]
+
+
+@pytest.mark.parametrize("config_path", DATASET_CONFIG_FILES)
+def test_validate_real_dataset_configs(config_path):
+    """Test that all real POYO dataset configs validate successfully."""
+    # Load config
+    cfg = OmegaConf.load(config_path)
+    config_dict = OmegaConf.to_container(cfg, resolve=True)
+    
+    # Validate - should not raise ValidationError
+    validated = POYODatasetConfig.model_validate(config_dict)
+    
+    # Basic assertions
+    assert len(validated) > 0, "Config should have at least one selection block"
+    
+    # Check first block has required structure
+    first_block = validated[0]
+    assert hasattr(first_block, 'selection'), "Block should have selection"
+    assert hasattr(first_block, 'config'), "Block should have config"
+    assert hasattr(first_block.config, 'readout'), "Config should have readout"
+    
+    # Check readout has required field
+    readout = first_block.config.readout
+    assert hasattr(readout, 'readout_id'), "Readout should have readout_id"
+    assert readout.readout_id is not None, "Readout ID should not be None"
+
+
+def test_schema_rejects_invalid_config():
+    """Test that schema rejects invalid configurations."""
+    invalid_config = [
+        {
+            "selection": [{"brainset": "test"}],
+            "config": {
+                "readout": {
+                    "readout_id": "test",
+                    "normalize_std": 0.0  # Invalid: std cannot be 0
+                }
+            }
+        }
+    ]
+    
+    with pytest.raises(ValueError, match="cannot be 0"):
+        POYODatasetConfig.model_validate(invalid_config)
+
+
+def test_schema_rejects_unknown_fields():
+    """Test that schema rejects configs with unknown fields."""
+    invalid_config = [
+        {
+            "selection": [{"brainset": "test"}],
+            "config": {
+                "readout": {
+                    "readout_id": "test",
+                    "unknown_field": "value"  # Invalid: unknown field
+                }
+            }
+        }
+    ]
+    
+    with pytest.raises(Exception):  # Pydantic ValidationError
+        POYODatasetConfig.model_validate(invalid_config)

--- a/torch_brain/schemas/__init__.py
+++ b/torch_brain/schemas/__init__.py
@@ -7,9 +7,9 @@ from .poyo_dataset import (
 )
 
 __all__ = [
-    'ReadoutConfig',
-    'SelectionConfig',
-    'DatasetLevelConfig',
-    'DatasetSelectionBlock',
-    'POYODatasetConfig',
+    "ReadoutConfig",
+    "SelectionConfig",
+    "DatasetLevelConfig",
+    "DatasetSelectionBlock",
+    "POYODatasetConfig",
 ]

--- a/torch_brain/schemas/__init__.py
+++ b/torch_brain/schemas/__init__.py
@@ -1,0 +1,15 @@
+from .poyo_dataset import (
+    ReadoutConfig,
+    SelectionConfig,
+    DatasetLevelConfig,
+    DatasetSelectionBlock,
+    POYODatasetConfig,
+)
+
+__all__ = [
+    'ReadoutConfig',
+    'SelectionConfig',
+    'DatasetLevelConfig',
+    'DatasetSelectionBlock',
+    'POYODatasetConfig',
+]

--- a/torch_brain/schemas/poyo_dataset.py
+++ b/torch_brain/schemas/poyo_dataset.py
@@ -1,0 +1,168 @@
+"""
+Pydantic schemas for POYO dataset configurations.
+
+This module provides type-safe validation for dataset configurations
+used with POYO models. The schemas ensure configs are valid before
+being passed to the Dataset and model tokenizers.
+"""
+
+from typing import Dict, List, Optional, Union, Any
+from pydantic import BaseModel, ConfigDict, Field, RootModel, field_validator, model_validator
+
+
+class ReadoutConfig(BaseModel):
+    """Configuration for POYO readout (single-task)."""
+    
+    # Required fields
+    readout_id: Union[str, int] = Field(
+        ...,
+        description="Modality identifier from MODALITY_REGISTRY"
+    )
+    
+    # Normalization
+    normalize_mean: Optional[float] = Field(
+        None,
+        description="Mean for z-score normalization."
+    )
+    normalize_std: Optional[float] = Field(
+        None,
+        description="Standard deviation for z-score normalization. Must be non-zero."
+    )
+    
+    # Data location
+    timestamp_key: Optional[str] = Field(
+        None,
+        description="Timestamp location (e.g., 'hand.timestamps')",
+        examples=["cursor.timestamps", "hand.timestamps", "wheel.timestamps"]
+    )
+    value_key: Optional[str] = Field(
+        None,
+        description="Value location (e.g., 'cursor.vel')",
+        examples=["cursor.vel", "hand.vel", "wheel.vel"]
+    )
+    
+    # Loss weighting
+    weights: Optional[Dict[str, float]] = Field(
+        None,
+        description="Mapping of interval paths to weight multipliers for loss computation"
+    )
+    
+    # Evaluation
+    eval_interval: Optional[str] = Field(
+        None,
+        description="Interval path for filtering evaluation periods",
+        examples=["movement_phases.reach_period", "movement_phases.random_period"]
+    )
+    
+    metrics: Optional[List[Dict[str, Any]]] = Field(
+        None,
+        description="List of metric configurations for evaluation"
+    )
+    
+    model_config = ConfigDict(extra="forbid")
+        
+    @field_validator('normalize_std')
+    @classmethod
+    def validate_std_not_zero(cls, v):
+        """Ensure normalization std is not zero."""
+        if v is not None:
+            if v == 0:
+                raise ValueError("normalize_std cannot be 0")
+        return v
+    
+    @field_validator('weights')
+    @classmethod
+    def validate_weights(cls, v):
+        """Ensure all weight values are numeric."""
+        if v is not None:
+            for key, value in v.items():
+                if not isinstance(value, (int, float)):
+                    raise ValueError(
+                        f"Weight value for interval '{key}' must be numeric, got {type(value).__name__}"
+                    )
+        return v
+
+
+class SelectionConfig(BaseModel):
+    """Configuration for dataset selection criteria."""
+    
+    brainset: str = Field(
+        ...,
+        description="Brainset identifier (e.g., 'perich_miller_population_2018')"
+    )
+    
+    sessions: Optional[List[str]] = Field(
+        None,
+        description="List of sessions to include"
+    )
+    
+    model_config = ConfigDict(extra="forbid")
+
+
+class DatasetLevelConfig(BaseModel):
+    """Configuration options at the dataset level."""
+    
+    readout: ReadoutConfig = Field(
+        ...,
+        description="Readout configuration for this dataset selection"
+    )
+    
+    sampling_intervals_modifier: Optional[str] = Field(
+        None,
+        description="Python code to modify sampling intervals (advanced usage)"
+    )
+    
+    model_config = ConfigDict(extra="allow")
+
+
+class DatasetSelectionBlock(BaseModel):
+    """A single selection block with associated configuration."""
+    
+    selection: List[SelectionConfig] = Field(
+        ...,
+        description="List of selection criteria (can select from multiple brainsets)"
+    )
+    
+    config: DatasetLevelConfig = Field(
+        ...,
+        description="Configuration for this selection"
+    )
+    
+    model_config = ConfigDict(extra="forbid")
+
+
+class POYODatasetConfig(RootModel):
+    """
+    Complete POYO Dataset configuration schema.
+    
+    This represents the full dataset YAML config structure,
+    which can contain multiple selection blocks, each with
+    their own readout configuration.
+    
+    Example:
+        config = POYODatasetConfig.model_validate(yaml_data)
+    """
+    
+    root: List[DatasetSelectionBlock]
+    
+    def __iter__(self):
+        """Allow iterating over selection blocks."""
+        return iter(self.root)
+    
+    def __getitem__(self, item):
+        """Allow indexing selection blocks."""
+        return self.root[item]
+    
+    def __len__(self):
+        """Get number of selection blocks."""
+        return len(self.root)
+
+
+# Export main classes
+__all__ = [
+    'ReadoutConfig',
+    'SelectionConfig',
+    'DatasetLevelConfig',
+    'DatasetSelectionBlock',
+    'POYODatasetConfig',
+]

--- a/torch_brain/schemas/poyo_dataset.py
+++ b/torch_brain/schemas/poyo_dataset.py
@@ -7,61 +7,65 @@ being passed to the Dataset and model tokenizers.
 """
 
 from typing import Dict, List, Optional, Union, Any
-from pydantic import BaseModel, ConfigDict, Field, RootModel, field_validator, model_validator
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    RootModel,
+    field_validator,
+    model_validator,
+)
 
 
 class ReadoutConfig(BaseModel):
     """Configuration for POYO readout (single-task)."""
-    
+
     # Required fields
     readout_id: Union[str, int] = Field(
-        ...,
-        description="Modality identifier from MODALITY_REGISTRY"
+        ..., description="Modality identifier from MODALITY_REGISTRY"
     )
-    
+
     # Normalization
     normalize_mean: Optional[float] = Field(
-        None,
-        description="Mean for z-score normalization."
+        None, description="Mean for z-score normalization."
     )
     normalize_std: Optional[float] = Field(
         None,
-        description="Standard deviation for z-score normalization. Must be non-zero."
+        description="Standard deviation for z-score normalization. Must be non-zero.",
     )
-    
+
     # Data location
     timestamp_key: Optional[str] = Field(
         None,
         description="Timestamp location (e.g., 'hand.timestamps')",
-        examples=["cursor.timestamps", "hand.timestamps", "wheel.timestamps"]
+        examples=["cursor.timestamps", "hand.timestamps", "wheel.timestamps"],
     )
     value_key: Optional[str] = Field(
         None,
         description="Value location (e.g., 'cursor.vel')",
-        examples=["cursor.vel", "hand.vel", "wheel.vel"]
+        examples=["cursor.vel", "hand.vel", "wheel.vel"],
     )
-    
+
     # Loss weighting
     weights: Optional[Dict[str, float]] = Field(
         None,
-        description="Mapping of interval paths to weight multipliers for loss computation"
+        description="Mapping of interval paths to weight multipliers for loss computation",
     )
-    
+
     # Evaluation
     eval_interval: Optional[str] = Field(
         None,
         description="Interval path for filtering evaluation periods",
-        examples=["movement_phases.reach_period", "movement_phases.random_period"]
+        examples=["movement_phases.reach_period", "movement_phases.random_period"],
     )
-    
+
     metrics: Optional[List[Dict[str, Any]]] = Field(
-        None,
-        description="List of metric configurations for evaluation"
+        None, description="List of metric configurations for evaluation"
     )
-    
+
     model_config = ConfigDict(extra="forbid")
-        
-    @field_validator('normalize_std')
+
+    @field_validator("normalize_std")
     @classmethod
     def validate_std_not_zero(cls, v):
         """Ensure normalization std is not zero."""
@@ -69,8 +73,8 @@ class ReadoutConfig(BaseModel):
             if v == 0:
                 raise ValueError("normalize_std cannot be 0")
         return v
-    
-    @field_validator('weights')
+
+    @field_validator("weights")
     @classmethod
     def validate_weights(cls, v):
         """Ensure all weight values are numeric."""
@@ -85,74 +89,69 @@ class ReadoutConfig(BaseModel):
 
 class SelectionConfig(BaseModel):
     """Configuration for dataset selection criteria."""
-    
+
     brainset: str = Field(
-        ...,
-        description="Brainset identifier (e.g., 'perich_miller_population_2018')"
+        ..., description="Brainset identifier (e.g., 'perich_miller_population_2018')"
     )
-    
+
     sessions: Optional[List[str]] = Field(
-        None,
-        description="List of sessions to include"
+        None, description="List of sessions to include"
     )
-    
+
     model_config = ConfigDict(extra="forbid")
 
 
 class DatasetLevelConfig(BaseModel):
     """Configuration options at the dataset level."""
-    
+
     readout: ReadoutConfig = Field(
-        ...,
-        description="Readout configuration for this dataset selection"
+        ..., description="Readout configuration for this dataset selection"
     )
-    
+
     sampling_intervals_modifier: Optional[str] = Field(
-        None,
-        description="Python code to modify sampling intervals (advanced usage)"
+        None, description="Python code to modify sampling intervals (advanced usage)"
     )
-    
+
     model_config = ConfigDict(extra="allow")
 
 
 class DatasetSelectionBlock(BaseModel):
     """A single selection block with associated configuration."""
-    
+
     selection: List[SelectionConfig] = Field(
         ...,
-        description="List of selection criteria (can select from multiple brainsets)"
+        description="List of selection criteria (can select from multiple brainsets)",
     )
-    
+
     config: DatasetLevelConfig = Field(
-        ...,
-        description="Configuration for this selection"
+        ..., description="Configuration for this selection"
     )
-    
+
     model_config = ConfigDict(extra="forbid")
 
 
 class POYODatasetConfig(RootModel):
     """
     Complete POYO Dataset configuration schema.
-    
+
     This represents the full dataset YAML config structure,
     which can contain multiple selection blocks, each with
     their own readout configuration.
-    
+
     Example:
         config = POYODatasetConfig.model_validate(yaml_data)
     """
-    
+
     root: List[DatasetSelectionBlock]
-    
+
     def __iter__(self):
         """Allow iterating over selection blocks."""
         return iter(self.root)
-    
+
     def __getitem__(self, item):
         """Allow indexing selection blocks."""
         return self.root[item]
-    
+
     def __len__(self):
         """Get number of selection blocks."""
         return len(self.root)
@@ -160,9 +159,9 @@ class POYODatasetConfig(RootModel):
 
 # Export main classes
 __all__ = [
-    'ReadoutConfig',
-    'SelectionConfig',
-    'DatasetLevelConfig',
-    'DatasetSelectionBlock',
-    'POYODatasetConfig',
+    "ReadoutConfig",
+    "SelectionConfig",
+    "DatasetLevelConfig",
+    "DatasetSelectionBlock",
+    "POYODatasetConfig",
 ]


### PR DESCRIPTION
This is a proposal to systematize the way in which we define Dataset configurations schema for POYO, using Pydantic models.

**Problem:**
I noticed that  `data.config`:
- defines data-related configuration parameters specific to a given model (e.g. readout vs multitask_readout)
- some of these parameters are required (readout_id) and some are optional (weights)
- values filled are specific to that Brainset

I’m discovering how to use it by trial and error, and suggest a more systematic approach:
- torch_brain models should explicitly define the schema for their dataset configs. This will allow for validation not only of presence of keys, but also types of values, and provide better documentation on these fields
- since this is model-dependent, I believe this should be implemented either as a classmethod or with pydantic models for each torch_brain model
- we can then perform proper validation when calling a model

Ps.: if we move forward with this, we would probably want to think on how to better organize these schemas within the project. The current placement is just a first idea, but probably insufficient, since other model-related schemas might also be necessary.