### PR TITLE
TorchBrainModel base class and Dataset configuration

### DIFF
--- a/examples/poyo/finetune.py
+++ b/examples/poyo/finetune.py
@@ -1,0 +1,61 @@
+import torch
+import torch_brain
+from torch_brain.models import POYO
+from torch_brain.registry import ModalitySpec, DataType
+
+
+# User defines readout properties
+readout_modality_name = "wheel"
+readout_value_key = "wheel.vel"
+readout_timestamp_key = "wheel.timestamps"
+
+# Helper class method to create minimal dataset config 
+dataset_config = POYO.create_basic_dataset_config(
+    dir_path=".",
+    brainset="ibl",
+    sessions=["sub-CSH-ZAD-024_ses-8207abc6-6b23-4762-92b4-82e05bed5143-processed-only_behavior"],
+    readout_id=readout_modality_name,
+    value_key=readout_value_key,
+    timestamp_key=readout_timestamp_key,
+)
+
+# Define readout specification
+# PS: we could probably automatize this using the dataset config
+readout_spec = ModalitySpec(
+    id=100,
+    name=readout_modality_name,
+    value_key=readout_value_key,
+    timestamp_key=readout_timestamp_key,
+    dim=1,
+    type=DataType.CONTINUOUS,
+    loss_fn=torch_brain.nn.loss.MSELoss(),
+)
+
+# Helper class method to load pre-trained model checkpoint
+model = POYO.load_pretrained(
+    checkpoint_path="poyo_mp.ckpt",
+    readout_spec=readout_spec,
+    skip_readout=True,
+)
+
+# Load model to device
+# PS: we could probably automatically do this (by default)
+device = (
+    torch.device("mps") if torch.backends.mps.is_available()
+    else torch.device("cuda:0") if torch.cuda.is_available()
+    else torch.device("cpu")
+)
+model.to(device)
+
+# Helper method to bind dataset to model
+model.set_datasets(
+    dir_path=".",
+    dataset_config=dataset_config,
+)
+
+# Helper method finetune model with provided Brainset
+poyo_ft_r2_log, poyo_ft_loss_log, poyo_ft_train_outputs = model.finetune(
+    num_epochs=2,
+    epoch_to_unfreeze=10,
+    data_loader_batch_size=16,
+)

--- a/examples/poyo/finetune.py
+++ b/examples/poyo/finetune.py
@@ -9,11 +9,13 @@ readout_modality_name = "wheel"
 readout_value_key = "wheel.vel"
 readout_timestamp_key = "wheel.timestamps"
 
-# Helper class method to create minimal dataset config 
+# Helper class method to create minimal dataset config
 dataset_config = POYO.create_basic_dataset_config(
     dir_path=".",
     brainset="ibl",
-    sessions=["sub-CSH-ZAD-024_ses-8207abc6-6b23-4762-92b4-82e05bed5143-processed-only_behavior"],
+    sessions=[
+        "sub-CSH-ZAD-024_ses-8207abc6-6b23-4762-92b4-82e05bed5143-processed-only_behavior"
+    ],
     readout_id=readout_modality_name,
     value_key=readout_value_key,
     timestamp_key=readout_timestamp_key,
@@ -41,9 +43,9 @@ model = POYO.load_pretrained(
 # Load model to device
 # PS: we could probably automatically do this (by default)
 device = (
-    torch.device("mps") if torch.backends.mps.is_available()
-    else torch.device("cuda:0") if torch.cuda.is_available()
-    else torch.device("cpu")
+    torch.device("mps")
+    if torch.backends.mps.is_available()
+    else torch.device("cuda:0") if torch.cuda.is_available() else torch.device("cpu")
 )
 model.to(device)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,14 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-dev = ["pytest<9", "black==24.2.0", "pre-commit>=3.5.0", "flake8"]
+dev = [
+    "pytest<9",
+    "black==24.2.0",
+    "pre-commit>=3.5.0",
+    "flake8",
+    "boto3",
+    "tqdm",
+]
 
 [project.urls]
 Homepage = "https://github.com/neuro-galaxy/torch_brain"

--- a/tests/test_poyo.py
+++ b/tests/test_poyo.py
@@ -14,27 +14,33 @@ def pretrained_checkpoint():
     """Download the pretrained POYO model checkpoint from S3."""
     checkpoint_filename = "poyo_mp.ckpt"
     checkpoint_path = Path(checkpoint_filename)
-    
+
     # Only download if the file doesn't exist
     if not checkpoint_path.exists():
-        s3 = boto3.client('s3', config=Config(signature_version=UNSIGNED))
-        
+        s3 = boto3.client("s3", config=Config(signature_version=UNSIGNED))
+
         # Get file size for progress bar
-        file_info = s3.head_object(Bucket="torch-brain", Key=f"model-zoo/{checkpoint_filename}")
-        file_size = file_info['ContentLength']
-        
+        file_info = s3.head_object(
+            Bucket="torch-brain", Key=f"model-zoo/{checkpoint_filename}"
+        )
+        file_size = file_info["ContentLength"]
+
         # Download with progress bar
-        with tqdm(total=file_size, unit='B', unit_scale=True, 
-                  desc=f"Downloading {checkpoint_filename}") as pbar:
+        with tqdm(
+            total=file_size,
+            unit="B",
+            unit_scale=True,
+            desc=f"Downloading {checkpoint_filename}",
+        ) as pbar:
             s3.download_file(
                 "torch-brain",
                 f"model-zoo/{checkpoint_filename}",
                 checkpoint_filename,
-                Callback=lambda bytes_transferred: pbar.update(bytes_transferred)
+                Callback=lambda bytes_transferred: pbar.update(bytes_transferred),
             )
-    
+
     yield str(checkpoint_path)
-    
+
     # Cleanup: remove the downloaded checkpoint after tests
     if checkpoint_path.exists():
         checkpoint_path.unlink()
@@ -44,50 +50,50 @@ def pretrained_checkpoint():
 def readout_spec():
     """Create a readout spec for testing"""
     from torch_brain.registry import MODALITY_REGISTRY
-    
+
     return MODALITY_REGISTRY["cursor_velocity_2d"]
 
 
 def test_load_pretrained_basic(pretrained_checkpoint, readout_spec):
     """Test loading a pretrained POYO model with default settings"""
-    
+
     # Load the pretrained model
     model = POYO.load_pretrained(
         checkpoint_path=pretrained_checkpoint,
         readout_spec=readout_spec,
     )
-    
+
     assert isinstance(model, POYO)
-    
-    assert hasattr(model, 'sequence_length')
-    assert hasattr(model, 'latent_step')
-    assert hasattr(model, 'num_latents_per_step')
-    assert hasattr(model, 'readout_spec')
-    
-    assert hasattr(model, 'readout')
+
+    assert hasattr(model, "sequence_length")
+    assert hasattr(model, "latent_step")
+    assert hasattr(model, "num_latents_per_step")
+    assert hasattr(model, "readout_spec")
+
+    assert hasattr(model, "readout")
     assert isinstance(model.readout, torch.nn.Linear)
     assert model.readout.out_features == readout_spec.dim
 
 
 def test_load_pretrained_skip_readout(pretrained_checkpoint, readout_spec):
     """Test loading a pretrained POYO model with skip_readout=True"""
-    
+
     # Load the pretrained model with skip_readout
     model = POYO.load_pretrained(
         checkpoint_path=pretrained_checkpoint,
         readout_spec=readout_spec,
         skip_readout=True,
     )
-    
+
     # The readout layer should still exist but be newly initialized
-    assert hasattr(model, 'readout')
+    assert hasattr(model, "readout")
     assert isinstance(model.readout, torch.nn.Linear)
     assert model.readout.out_features == readout_spec.dim
 
 
 def test_load_pretrained_forward_pass(pretrained_checkpoint, readout_spec):
     """Test that the loaded model can perform a forward pass"""
-    
+
     model = POYO.load_pretrained(
         checkpoint_path=pretrained_checkpoint,
         readout_spec=readout_spec,
@@ -98,27 +104,32 @@ def test_load_pretrained_forward_pass(pretrained_checkpoint, readout_spec):
     model.unit_emb.subset_vocab([f"unit_{i}" for i in range(100)])
     model.session_emb.extend_vocab([f"session_{i}" for i in range(10)])
     model.session_emb.subset_vocab([f"session_{i}" for i in range(10)])
-    
+
     # Create dummy input data
     batch_size = 2
     n_in = 10
-    n_latent = int(model.sequence_length / model.latent_step) * model.num_latents_per_step
+    n_latent = (
+        int(model.sequence_length / model.latent_step) * model.num_latents_per_step
+    )
     n_out = 4
-    
+
     inputs = {
         "input_unit_index": torch.randint(0, 100, (batch_size, n_in)),
         "input_timestamps": torch.rand(batch_size, n_in) * model.sequence_length,
         "input_token_type": torch.randint(0, 4, (batch_size, n_in)),
         "input_mask": torch.ones(batch_size, n_in, dtype=torch.bool),
-        "latent_index": torch.arange(n_latent).repeat(batch_size, 1) % model.num_latents_per_step,
-        "latent_timestamps": torch.linspace(0, model.sequence_length, n_latent).repeat(batch_size, 1),
+        "latent_index": torch.arange(n_latent).repeat(batch_size, 1)
+        % model.num_latents_per_step,
+        "latent_timestamps": torch.linspace(0, model.sequence_length, n_latent).repeat(
+            batch_size, 1
+        ),
         "output_session_index": torch.zeros(batch_size, n_out, dtype=torch.long),
         "output_timestamps": torch.rand(batch_size, n_out) * model.sequence_length,
     }
-    
+
     # Forward pass
     with torch.no_grad():
         outputs = model(**inputs)
-    
+
     # Verify output shape
     assert outputs.shape == (batch_size, n_out, readout_spec.dim)

--- a/tests/test_poyo.py
+++ b/tests/test_poyo.py
@@ -1,0 +1,124 @@
+import pytest
+import torch
+from pathlib import Path
+import boto3
+from botocore import UNSIGNED
+from botocore.config import Config
+from tqdm import tqdm
+
+from torch_brain.models.poyo import POYO
+
+
+@pytest.fixture(scope="session")
+def pretrained_checkpoint():
+    """Download the pretrained POYO model checkpoint from S3."""
+    checkpoint_filename = "poyo_mp.ckpt"
+    checkpoint_path = Path(checkpoint_filename)
+    
+    # Only download if the file doesn't exist
+    if not checkpoint_path.exists():
+        s3 = boto3.client('s3', config=Config(signature_version=UNSIGNED))
+        
+        # Get file size for progress bar
+        file_info = s3.head_object(Bucket="torch-brain", Key=f"model-zoo/{checkpoint_filename}")
+        file_size = file_info['ContentLength']
+        
+        # Download with progress bar
+        with tqdm(total=file_size, unit='B', unit_scale=True, 
+                  desc=f"Downloading {checkpoint_filename}") as pbar:
+            s3.download_file(
+                "torch-brain",
+                f"model-zoo/{checkpoint_filename}",
+                checkpoint_filename,
+                Callback=lambda bytes_transferred: pbar.update(bytes_transferred)
+            )
+    
+    yield str(checkpoint_path)
+    
+    # Cleanup: remove the downloaded checkpoint after tests
+    if checkpoint_path.exists():
+        checkpoint_path.unlink()
+
+
+@pytest.fixture
+def readout_spec():
+    """Create a readout spec for testing"""
+    from torch_brain.registry import MODALITY_REGISTRY
+    
+    return MODALITY_REGISTRY["cursor_velocity_2d"]
+
+
+def test_load_pretrained_basic(pretrained_checkpoint, readout_spec):
+    """Test loading a pretrained POYO model with default settings"""
+    
+    # Load the pretrained model
+    model = POYO.load_pretrained(
+        checkpoint_path=pretrained_checkpoint,
+        readout_spec=readout_spec,
+    )
+    
+    assert isinstance(model, POYO)
+    
+    assert hasattr(model, 'sequence_length')
+    assert hasattr(model, 'latent_step')
+    assert hasattr(model, 'num_latents_per_step')
+    assert hasattr(model, 'readout_spec')
+    
+    assert hasattr(model, 'readout')
+    assert isinstance(model.readout, torch.nn.Linear)
+    assert model.readout.out_features == readout_spec.dim
+
+
+def test_load_pretrained_skip_readout(pretrained_checkpoint, readout_spec):
+    """Test loading a pretrained POYO model with skip_readout=True"""
+    
+    # Load the pretrained model with skip_readout
+    model = POYO.load_pretrained(
+        checkpoint_path=pretrained_checkpoint,
+        readout_spec=readout_spec,
+        skip_readout=True,
+    )
+    
+    # The readout layer should still exist but be newly initialized
+    assert hasattr(model, 'readout')
+    assert isinstance(model.readout, torch.nn.Linear)
+    assert model.readout.out_features == readout_spec.dim
+
+
+def test_load_pretrained_forward_pass(pretrained_checkpoint, readout_spec):
+    """Test that the loaded model can perform a forward pass"""
+    
+    model = POYO.load_pretrained(
+        checkpoint_path=pretrained_checkpoint,
+        readout_spec=readout_spec,
+    )
+
+    # Reinitialize the vocabs for the new units and sessions
+    model.unit_emb.extend_vocab([f"unit_{i}" for i in range(100)])
+    model.unit_emb.subset_vocab([f"unit_{i}" for i in range(100)])
+    model.session_emb.extend_vocab([f"session_{i}" for i in range(10)])
+    model.session_emb.subset_vocab([f"session_{i}" for i in range(10)])
+    
+    # Create dummy input data
+    batch_size = 2
+    n_in = 10
+    n_latent = int(model.sequence_length / model.latent_step) * model.num_latents_per_step
+    n_out = 4
+    
+    inputs = {
+        "input_unit_index": torch.randint(0, 100, (batch_size, n_in)),
+        "input_timestamps": torch.rand(batch_size, n_in) * model.sequence_length,
+        "input_token_type": torch.randint(0, 4, (batch_size, n_in)),
+        "input_mask": torch.ones(batch_size, n_in, dtype=torch.bool),
+        "latent_index": torch.arange(n_latent).repeat(batch_size, 1) % model.num_latents_per_step,
+        "latent_timestamps": torch.linspace(0, model.sequence_length, n_latent).repeat(batch_size, 1),
+        "output_session_index": torch.zeros(batch_size, n_out, dtype=torch.long),
+        "output_timestamps": torch.rand(batch_size, n_out) * model.sequence_length,
+    }
+    
+    # Forward pass
+    with torch.no_grad():
+        outputs = model(**inputs)
+    
+    # Verify output shape
+    assert outputs.shape == (batch_size, n_out, readout_spec.dim)

--- a/tests/test_poyo_dataset_schema.py
+++ b/tests/test_poyo_dataset_schema.py
@@ -1,0 +1,75 @@
+"""Tests for POYO dataset configuration schemas."""
+
+import pytest
+from pathlib import Path
+from omegaconf import OmegaConf
+from torch_brain.schemas.base_class.dataset_schema import BaseDatasetConfig
+
+
+# List of all dataset config files to test
+DATASET_CONFIG_FILES = [
+    "examples/poyo/configs/dataset/pei_pandarinath_nlb_2021.yaml",
+    "examples/poyo/configs/dataset/perich_miller_population_2018.yaml",
+    "examples/poyo/configs/dataset/poyo_1.yaml",
+]
+
+
+@pytest.mark.parametrize("config_path", DATASET_CONFIG_FILES)
+def test_validate_real_dataset_configs(config_path):
+    """Test that all real POYO dataset configs validate successfully."""
+    # Load config
+    cfg = OmegaConf.load(config_path)
+    config_dict = OmegaConf.to_container(cfg, resolve=True)
+
+    # Validate - should not raise ValidationError
+    validated = BaseDatasetConfig.model_validate(config_dict)
+
+    # Basic assertions
+    assert len(validated) > 0, "Config should have at least one selection block"
+
+    # Check first block has required structure
+    first_block = validated[0]
+    assert hasattr(first_block, "selection"), "Block should have selection"
+    assert hasattr(first_block, "config"), "Block should have config"
+    assert hasattr(first_block.config, "readout"), "Config should have readout"
+
+    # Check readout has required field
+    readout = first_block.config.readout
+    assert hasattr(readout, "readout_id"), "Readout should have readout_id"
+    assert readout.readout_id is not None, "Readout ID should not be None"
+
+
+def test_schema_rejects_invalid_config():
+    """Test that schema rejects invalid configurations."""
+    invalid_config = [
+        {
+            "selection": [{"brainset": "test"}],
+            "config": {
+                "readout": {
+                    "readout_id": "test",
+                    "normalize_std": 0.0,  # Invalid: std cannot be 0
+                }
+            },
+        }
+    ]
+
+    with pytest.raises(ValueError, match="cannot be 0"):
+        POYODatasetConfig.model_validate(invalid_config)
+
+
+def test_schema_rejects_unknown_fields():
+    """Test that schema rejects configs with unknown fields."""
+    invalid_config = [
+        {
+            "selection": [{"brainset": "test"}],
+            "config": {
+                "readout": {
+                    "readout_id": "test",
+                    "unknown_field": "value",  # Invalid: unknown field
+                }
+            },
+        }
+    ]
+
+    with pytest.raises(Exception):  # Pydantic ValidationError
+        POYODatasetConfig.model_validate(invalid_config)

--- a/tests/test_poyo_dataset_schema.py
+++ b/tests/test_poyo_dataset_schema.py
@@ -1,7 +1,6 @@
 """Tests for POYO dataset configuration schemas."""
 
 import pytest
-from pathlib import Path
 from omegaconf import OmegaConf
 from torch_brain.schemas.base_class.dataset_schema import BaseDatasetConfig
 

--- a/torch_brain/data/dataset.py
+++ b/torch_brain/data/dataset.py
@@ -83,7 +83,7 @@ class Dataset(torch.utils.data.Dataset):
         self,
         root: str,
         *,
-        config: Optional[str] = None,
+        config: Optional[str | Path | dict] = None,
         recording_id: Optional[str] = None,
         split: Optional[str] = None,
         transform: Optional[Callable[[Data], Any]] = None,
@@ -111,6 +111,8 @@ class Dataset(torch.utils.data.Dataset):
                 config = omegaconf.OmegaConf.to_container(config)
             elif Path(config).is_file():
                 config = omegaconf.OmegaConf.load(config)
+            elif isinstance(config, dict):
+                config = omegaconf.OmegaConf.create(config)
             else:
                 raise ValueError(f"Could not open configuration file: '{config}'")
 

--- a/torch_brain/data/dataset.py
+++ b/torch_brain/data/dataset.py
@@ -109,10 +109,10 @@ class Dataset(torch.utils.data.Dataset):
 
             if isinstance(config, omegaconf.listconfig.ListConfig):
                 config = omegaconf.OmegaConf.to_container(config)
+            elif isinstance(config, list):
+                config = omegaconf.OmegaConf.create(config)
             elif Path(config).is_file():
                 config = omegaconf.OmegaConf.load(config)
-            elif isinstance(config, dict):
-                config = omegaconf.OmegaConf.create(config)
             else:
                 raise ValueError(f"Could not open configuration file: '{config}'")
 

--- a/torch_brain/models/__init__.py
+++ b/torch_brain/models/__init__.py
@@ -1,3 +1,4 @@
 from .poyo import POYO, poyo_mp
 from .poyo_plus import POYOPlus
 from .capoyo import CaPOYO
+from .mlp import MLPNeuralDecoder

--- a/torch_brain/models/base_class.py
+++ b/torch_brain/models/base_class.py
@@ -154,7 +154,7 @@ class TorchBrainModel(nn.Module, ABC):
         raise NotImplementedError(
             "Subclasses must implement the get_val_data_sampler method"
         )
-    
+
     @abstractmethod
     def get_test_data_sampler(self):
         raise NotImplementedError(

--- a/torch_brain/models/base_class.py
+++ b/torch_brain/models/base_class.py
@@ -8,7 +8,10 @@ import torch.nn as nn
 from torch_brain.registry import ModalitySpec, register_modality, MODALITY_REGISTRY
 from torch_brain.schemas.base_class.dataset_schema import BaseDatasetConfig
 from torch_brain.data import Dataset
-from torch_brain.data.sampler import RandomFixedWindowSampler, SequentialFixedWindowSampler
+from torch_brain.data.sampler import (
+    RandomFixedWindowSampler,
+    SequentialFixedWindowSampler,
+)
 
 
 logger = logging.getLogger(__name__)
@@ -48,7 +51,7 @@ class TorchBrainModel(nn.Module, ABC):
     def get_dataset_config_schema(cls) -> type[BaseDatasetConfig]:
         """Return the dataset configuration schema class for this model."""
         return BaseDatasetConfig
-    
+
     def validate_dataset_config(self, dataset_config: dict):
         """Validate a dataset configuration against the model's schema and readout_spec."""
         schema = self.get_dataset_config_schema()
@@ -70,7 +73,7 @@ class TorchBrainModel(nn.Module, ABC):
             raise ValueError(
                 f"Dataset config readout timestamp_key '{readout_timestamp_key}' does not match model readout_spec '{self.readout_spec.timestamp_key}'"
             )
-        
+
     def set_datasets(
         self,
         brainset_path: str,
@@ -81,7 +84,7 @@ class TorchBrainModel(nn.Module, ABC):
         if isinstance(dataset_config, (str, Path)):
             with open(dataset_config, "r") as f:
                 dataset_config = yaml.safe_load(f)
-            
+
         self.validate_dataset_config(dataset_config)
 
         # Training
@@ -133,9 +136,11 @@ class TorchBrainModel(nn.Module, ABC):
     @abstractmethod
     def forward(self, x):
         raise NotImplementedError("Subclasses must implement the forward method")
-    
+
     @abstractmethod
     @classmethod
     def load_pretrained(cls) -> "TorchBrainModel":
         """Load a pretrained model from a checkpoint."""
-        raise NotImplementedError("Subclasses must implement the load_pretrained method")
+        raise NotImplementedError(
+            "Subclasses must implement the load_pretrained method"
+        )

--- a/torch_brain/models/base_class.py
+++ b/torch_brain/models/base_class.py
@@ -54,15 +54,16 @@ class TorchBrainModel(nn.Module, ABC):
         """Return the dataset configuration schema class for this model."""
         return BaseDatasetConfig
 
-    def validate_dataset_config(self, dataset_config: dict):
+    def validate_dataset_config(self, dataset_config: list[dict]):
         """Validate a dataset configuration against the model's schema and readout_spec."""
         schema = self.get_dataset_config_schema()
-        schema(**dataset_config)
+        schema(root=dataset_config)
 
         # Validate dataset config against model readout_spec used to initialize the model
-        readout_id = dataset_config["readout"]["readout_id"]
-        readout_value_key = dataset_config["readout"]["value_key"]
-        readout_timestamp_key = dataset_config["readout"]["timestamp_key"]
+        selection_config = dataset_config[0]["config"]
+        readout_id = selection_config["readout"]["readout_id"]
+        readout_value_key = selection_config["readout"]["value_key"]
+        readout_timestamp_key = selection_config["readout"]["timestamp_key"]
         if readout_id != self.readout_spec.name:
             raise ValueError(
                 f"Dataset config readout_id '{readout_id}' does not match model readout_spec '{self.readout_spec.name}'"
@@ -79,7 +80,7 @@ class TorchBrainModel(nn.Module, ABC):
     def set_datasets(
         self,
         brainset_path: str,
-        dataset_config: str | Path | dict,
+        dataset_config: str | Path | list[dict],
     ):
         """Set datasets (train, valid, test) for this model based on the provided configuration."""
         # Load from yaml file if a path is provided

--- a/torch_brain/models/base_class.py
+++ b/torch_brain/models/base_class.py
@@ -108,30 +108,17 @@ class TorchBrainModel(nn.Module, ABC):
             split="test",
         )
 
-    def get_train_data_sampler(self) -> torch.utils.data.Sampler:
-        train_sampling_intervals = self.train_dataset.get_sampling_intervals()
-        train_sampler = RandomFixedWindowSampler(
-            sampling_intervals=train_sampling_intervals,
-            window_length=1.0,
-            generator=torch.Generator().manual_seed(self.seed),
+    @abstractmethod
+    def get_train_data_sampler(self):
+        raise NotImplementedError(
+            "Subclasses must implement the get_train_data_sampler method"
         )
-        return train_sampler
 
-    def get_val_data_sampler(self) -> torch.utils.data.Sampler:
-        val_sampling_intervals = self.val_dataset.get_sampling_intervals()
-        val_sampler = SequentialFixedWindowSampler(
-            sampling_intervals=val_sampling_intervals,
-            window_length=1.0,
+    @abstractmethod
+    def get_val_data_sampler(self):
+        raise NotImplementedError(
+            "Subclasses must implement the get_val_data_sampler method"
         )
-        return val_sampler
-
-    def get_test_data_sampler(self) -> torch.utils.data.Sampler:
-        test_sampling_intervals = self.test_dataset.get_sampling_intervals()
-        test_sampler = SequentialFixedWindowSampler(
-            sampling_intervals=test_sampling_intervals,
-            window_length=1.0,
-        )
-        return test_sampler
 
     @abstractmethod
     def forward(self, x):

--- a/torch_brain/models/base_class.py
+++ b/torch_brain/models/base_class.py
@@ -164,8 +164,8 @@ class TorchBrainModel(nn.Module, ABC):
     def forward(self, x):
         raise NotImplementedError("Subclasses must implement the forward method")
 
-    @abstractmethod
     @classmethod
+    @abstractmethod
     def load_pretrained(cls) -> "TorchBrainModel":
         """Load a pretrained model from a checkpoint."""
         raise NotImplementedError(

--- a/torch_brain/models/base_class.py
+++ b/torch_brain/models/base_class.py
@@ -112,6 +112,7 @@ class TorchBrainModel(nn.Module, ABC):
 
     def get_data_loader(
         self,
+        *,
         mode: Literal["train", "valid", "test"],
         batch_size: int,
         collate_fn: Callable | None = collate,

--- a/torch_brain/models/base_class.py
+++ b/torch_brain/models/base_class.py
@@ -1,0 +1,141 @@
+from abc import ABC, abstractmethod
+from pathlib import Path
+import logging
+import yaml
+import torch
+import torch.nn as nn
+
+from torch_brain.registry import ModalitySpec, register_modality, MODALITY_REGISTRY
+from torch_brain.schemas.base_class.dataset_schema import BaseDatasetConfig
+from torch_brain.data import Dataset
+from torch_brain.data.sampler import RandomFixedWindowSampler, SequentialFixedWindowSampler
+
+
+logger = logging.getLogger(__name__)
+
+
+class TorchBrainModel(nn.Module, ABC):
+    """Base class for all TorchBrain models."""
+
+    def __init__(
+        self,
+        *,
+        readout_spec: ModalitySpec,
+        seed: int = 42,
+        **torch_kwargs,
+    ):
+        super().__init__(**torch_kwargs)
+        self.seed = seed
+        self.validate_and_register_modality(readout_spec)
+
+    def validate_and_register_modality(self, readout_spec: ModalitySpec):
+        """Validate and register the model's readout modality."""
+        modality_name = readout_spec.name
+        if modality_name not in MODALITY_REGISTRY:
+            logger.info(f"Registering new modality: {modality_name}")
+            register_modality(
+                name=modality_name,
+                dim=readout_spec.dim,
+                type=readout_spec.type,
+                timestamp_key=readout_spec.timestamp_key,
+                value_key=readout_spec.value_key,
+                loss_fn=readout_spec.loss_fn,
+            )
+        logger.info(f"Set modality: {modality_name}")
+        self.readout_spec = readout_spec
+
+    @classmethod
+    def get_dataset_config_schema(cls) -> type[BaseDatasetConfig]:
+        """Return the dataset configuration schema class for this model."""
+        return BaseDatasetConfig
+    
+    def validate_dataset_config(self, dataset_config: dict):
+        """Validate a dataset configuration against the model's schema and readout_spec."""
+        schema = self.get_dataset_config_schema()
+        schema(**dataset_config)
+
+        # Validate dataset config against model readout_spec used to initialize the model
+        readout_id = dataset_config["readout"]["readout_id"]
+        readout_value_key = dataset_config["readout"]["value_key"]
+        readout_timestamp_key = dataset_config["readout"]["timestamp_key"]
+        if readout_id != self.readout_spec.name:
+            raise ValueError(
+                f"Dataset config readout_id '{readout_id}' does not match model readout_spec '{self.readout_spec.name}'"
+            )
+        if readout_value_key != self.readout_spec.value_key:
+            raise ValueError(
+                f"Dataset config readout value_key '{readout_value_key}' does not match model readout_spec '{self.readout_spec.value_key}'"
+            )
+        if readout_timestamp_key != self.readout_spec.timestamp_key:
+            raise ValueError(
+                f"Dataset config readout timestamp_key '{readout_timestamp_key}' does not match model readout_spec '{self.readout_spec.timestamp_key}'"
+            )
+        
+    def set_datasets(
+        self,
+        brainset_path: str,
+        dataset_config: str | Path | dict,
+    ):
+        """Set datasets (train, valid, test) for this model based on the provided configuration."""
+        # Load from yaml file if a path is provided
+        if isinstance(dataset_config, (str, Path)):
+            with open(dataset_config, "r") as f:
+                dataset_config = yaml.safe_load(f)
+            
+        self.validate_dataset_config(dataset_config)
+
+        # Training
+        self.train_dataset = Dataset(
+            root=brainset_path,
+            config=dataset_config,
+            split="train",
+        )
+
+        # Validation
+        self.val_dataset = Dataset(
+            root=brainset_path,
+            config=dataset_config,
+            split="valid",
+        )
+
+        # Testing
+        self.test_dataset = Dataset(
+            root=brainset_path,
+            config=dataset_config,
+            split="test",
+        )
+
+    def get_train_data_sampler(self) -> torch.utils.data.Sampler:
+        train_sampling_intervals = self.train_dataset.get_sampling_intervals()
+        train_sampler = RandomFixedWindowSampler(
+            sampling_intervals=train_sampling_intervals,
+            window_length=1.0,
+            generator=torch.Generator().manual_seed(self.seed),
+        )
+        return train_sampler
+
+    def get_val_data_sampler(self) -> torch.utils.data.Sampler:
+        val_sampling_intervals = self.val_dataset.get_sampling_intervals()
+        val_sampler = SequentialFixedWindowSampler(
+            sampling_intervals=val_sampling_intervals,
+            window_length=1.0,
+        )
+        return val_sampler
+
+    def get_test_data_sampler(self) -> torch.utils.data.Sampler:
+        test_sampling_intervals = self.test_dataset.get_sampling_intervals()
+        test_sampler = SequentialFixedWindowSampler(
+            sampling_intervals=test_sampling_intervals,
+            window_length=1.0,
+        )
+        return test_sampler
+
+    @abstractmethod
+    def forward(self, x):
+        raise NotImplementedError("Subclasses must implement the forward method")
+    
+    @abstractmethod
+    @classmethod
+    def load_pretrained(cls) -> "TorchBrainModel":
+        """Load a pretrained model from a checkpoint."""
+        raise NotImplementedError("Subclasses must implement the load_pretrained method")

--- a/torch_brain/models/base_class.py
+++ b/torch_brain/models/base_class.py
@@ -175,8 +175,8 @@ class TorchBrainModel(nn.Module, ABC):
             # Select training data based on the training domain interval
             train_data = session_data.select_by_interval(session_data.train_domain)
             train_vals = deep_getattr(train_data, value_key)
-            mean_val = np.mean(train_vals)
-            std_val = np.std(train_vals)
+            mean_val = float(np.mean(train_vals))
+            std_val = float(np.std(train_vals))
 
         # Dataset dictionary
         dataset_dict = [

--- a/torch_brain/models/base_class.py
+++ b/torch_brain/models/base_class.py
@@ -141,7 +141,7 @@ class TorchBrainModel(nn.Module, ABC):
             persistent_workers=persistent_workers,
             **dataloader_kwargs,
         )
-    
+
     @classmethod
     def create_basic_dataset_config(
         cls,
@@ -153,14 +153,17 @@ class TorchBrainModel(nn.Module, ABC):
         timestamp_key: str,
     ) -> list[dict]:
         """Create a minimal dataset configuration dictionary for the given brainset and sessions."""
+
         def deep_getattr(obj, attr_path):
             """Get a nested attribute from an object using a dotted path."""
             try:
-                for attr in attr_path.split('.'):
+                for attr in attr_path.split("."):
                     obj = getattr(obj, attr)
                 return obj
             except AttributeError:
-                raise AttributeError(f"Attribute path '{attr_path}' not found in the object.")
+                raise AttributeError(
+                    f"Attribute path '{attr_path}' not found in the object."
+                )
 
         # Estimate z-score statistics from training data
         session = sessions[0]
@@ -174,7 +177,7 @@ class TorchBrainModel(nn.Module, ABC):
             train_vals = deep_getattr(train_data, value_key)
             mean_val = np.mean(train_vals)
             std_val = np.std(train_vals)
-        
+
         # Dataset dictionary
         dataset_dict = [
             {
@@ -193,13 +196,9 @@ class TorchBrainModel(nn.Module, ABC):
                         "value_key": value_key,
                         "weights": {},
                         "eval_interval": None,
-                        "metrics": [
-                            {
-                                "metric": {"_target_": "torchmetrics.R2Score"}
-                            }
-                        ]
+                        "metrics": [{"metric": {"_target_": "torchmetrics.R2Score"}}],
                     }
-                }
+                },
             }
         ]
 

--- a/torch_brain/models/mlp.py
+++ b/torch_brain/models/mlp.py
@@ -139,7 +139,7 @@ class MLPNeuralDecoder(TorchBrainModel):
         # Remove readout layer from checkpoint if we're using a new one
         if skip_readout:
             state_dict = {
-                k: v for k, v in state_dict.items() if not k.startswith("readout.")
+                k: v for k, v in state_dict.items() if not k.startswith("net.4.")
             }
 
         missing_keys, unexpected_keys = model.load_state_dict(state_dict, strict=False)

--- a/torch_brain/models/mlp.py
+++ b/torch_brain/models/mlp.py
@@ -1,0 +1,154 @@
+from pathlib import Path
+import torch
+import torch.nn as nn
+from temporaldata import Data
+import numpy as np
+import logging
+
+from torch_brain.models.base_class import TorchBrainModel
+from torch_brain.registry import ModalitySpec
+from torch_brain.data.sampler import (
+    RandomFixedWindowSampler,
+    SequentialFixedWindowSampler,
+)
+
+
+def bin_spikes(spikes, num_units, bin_size, num_bins=None):
+    """
+    Bins spike timestamps into a 2D array: [num_units x num_bins].
+    """
+    rate = 1 / bin_size  # avoid precision issues
+    binned_spikes = np.zeros((num_units, num_bins))
+    bin_index = np.floor((spikes.timestamps) * rate).astype(int)
+    np.add.at(binned_spikes, (spikes.unit_index, bin_index), 1)
+    return binned_spikes
+
+
+class MLPNeuralDecoder(TorchBrainModel):
+    def __init__(
+        self,
+        readout_spec: ModalitySpec,
+        sequence_length: float,
+        num_units: int,
+        bin_size: int,
+        hidden_dim: int,
+    ):
+        """Initialize the neural net layers."""
+        super().__init__(readout_spec=readout_spec)
+
+        self.sequence_length = sequence_length
+        self.num_timesteps = int(sequence_length / bin_size)
+        self.bin_size = bin_size
+        self.input_dim = num_units * self.num_timesteps
+        self.output_dim = readout_spec.dim * self.num_timesteps
+
+        self.net = nn.Sequential(
+            nn.Linear(self.input_dim, hidden_dim),
+            nn.ReLU(),
+            nn.Linear(hidden_dim, hidden_dim),
+            nn.ReLU(),
+            nn.Linear(hidden_dim, self.output_dim),
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Produces predictions from a binned spiketrain.
+        This is pure PyTorch code.
+
+        Shape of x: (B, T, N)
+        """
+        x = x.flatten(1)                          # (B, T, N)    -> (B, T*N)
+        x = self.net(x)                           # (B, T*N)     -> (B, T*D_out)
+        x = x.reshape(-1, self.num_timesteps, 2)  # (B, T*D_out) -> (B, T, D_out)
+        return x
+
+    def tokenize(self, data: Data) -> dict:
+        """tokenizes a data sample, which is a sliced Data object"""
+        # Extract and bin neural activity (data.spikes)
+        # Final shape of x here is (timestamps, num_neurons)
+        spikes = data.spikes
+        x = bin_spikes(
+            spikes=spikes,
+            num_units=len(data.units),
+            bin_size=self.bin_size,
+            num_bins=self.num_timesteps
+        ).T
+
+        # Target variable
+        y = getattr(data, self.readout_spec.value_key)
+
+        # Output the "tokenized" data in the form of a dictionary
+        data_dict = {
+            "model_inputs": {
+                "x": torch.tensor(x, dtype=torch.float32),
+            },
+            "target_values": torch.tensor(y, dtype=torch.float32),
+        }
+        return data_dict
+    
+    def set_datasets(self, dir_path: str, dataset_config: str | Path | list[dict]):
+        super().set_datasets(dir_path, dataset_config)
+
+        # Connect tokenizers to Datasets
+        self.train_dataset.transform = self.tokenize
+        self.val_dataset.transform = self.tokenize
+        self.test_dataset.transform = self.tokenize
+
+    def get_train_data_sampler(self) -> torch.utils.data.Sampler:
+        return RandomFixedWindowSampler(
+            sampling_intervals=self.train_dataset.get_sampling_intervals(),
+            window_length=self.sequence_length,
+            generator=torch.Generator().manual_seed(self.seed),
+            drop_short=True,
+        )
+
+    def get_val_data_sampler(self) -> torch.utils.data.Sampler:
+        return SequentialFixedWindowSampler(
+            sampling_intervals=self.val_dataset.get_sampling_intervals(),
+            window_length=self.sequence_length,
+            step=None,
+            drop_short=False,
+        )
+
+    def get_test_data_sampler(self) -> torch.utils.data.Sampler:
+        return SequentialFixedWindowSampler(
+            sampling_intervals=self.test_dataset.get_sampling_intervals(),
+            window_length=self.sequence_length,
+            step=None,
+            drop_short=False,
+        )
+    
+    @classmethod
+    def load_pretrained(
+        cls,
+        checkpoint_path: str | Path,
+        readout_spec: ModalitySpec,
+        skip_readout: bool = False,
+    ) -> "MLPNeuralDecoder":
+        """Load a pretrained MLPNeuralDecoder model from a checkpoint file."""
+        checkpoint_path = Path(checkpoint_path)
+        checkpoint = torch.load(checkpoint_path, map_location="cpu")
+        model_args = checkpoint["model_args"]
+        model = cls(readout_spec=readout_spec, **model_args)
+
+        # Load model weights
+        # If model is pretrained using lightning, model weights are prefixed with "model."
+        state_dict = {
+            k.replace("model.", ""): v for k, v in checkpoint["state_dict"].items()
+        }
+
+        # Remove readout layer from checkpoint if we're using a new one
+        if skip_readout:
+            state_dict = {
+                k: v for k, v in state_dict.items() if not k.startswith("readout.")
+            }
+
+        missing_keys, unexpected_keys = model.load_state_dict(state_dict, strict=False)
+        if len(missing_keys) > 0:
+            logging.warning(
+                f"Missing keys when loading pretrained MLPNeuralDecoder: {missing_keys}"
+            )
+        if len(unexpected_keys) > 0:
+            logging.warning(
+                f"Unexpected keys when loading pretrained MLPNeuralDecoder: {unexpected_keys}"
+            )
+        return model

--- a/torch_brain/models/mlp.py
+++ b/torch_brain/models/mlp.py
@@ -42,7 +42,7 @@ class MLPNeuralDecoder(TorchBrainModel):
         super().__init__(readout_spec=readout_spec)
 
         self.sequence_length = sequence_length
-        
+
         self.input_bin_size = input_bin_size
         self.input_num_timesteps = int(sequence_length / input_bin_size)
         self.input_dim = num_units * self.input_num_timesteps
@@ -67,7 +67,9 @@ class MLPNeuralDecoder(TorchBrainModel):
         """
         x = x.flatten(1)  # (B, T, N)    -> (B, T*N)
         y = self.net(x)  # (B, T*N)     -> (B, T*D_out)
-        y = y.reshape(-1, self.output_num_timesteps, self.readout_spec.dim)  # (B, T*D_out) -> (B, T, D_out)
+        y = y.reshape(
+            -1, self.output_num_timesteps, self.readout_spec.dim
+        )  # (B, T*D_out) -> (B, T, D_out)
         return y
 
     def tokenize(self, data: Data) -> dict:
@@ -88,7 +90,7 @@ class MLPNeuralDecoder(TorchBrainModel):
         # Handle length mismatches by cropping or padding
         if len(y) > self.output_num_timesteps:
             # Too many samples - drop the last ones
-            y = y[:self.output_num_timesteps]
+            y = y[: self.output_num_timesteps]
         elif len(y) < self.output_num_timesteps:
             # Too few samples - pad by repeating the last value
             padding_needed = self.output_num_timesteps - len(y)

--- a/torch_brain/models/mlp.py
+++ b/torch_brain/models/mlp.py
@@ -56,8 +56,8 @@ class MLPNeuralDecoder(TorchBrainModel):
 
         Shape of x: (B, T, N)
         """
-        x = x.flatten(1)                          # (B, T, N)    -> (B, T*N)
-        x = self.net(x)                           # (B, T*N)     -> (B, T*D_out)
+        x = x.flatten(1)  # (B, T, N)    -> (B, T*N)
+        x = self.net(x)  # (B, T*N)     -> (B, T*D_out)
         x = x.reshape(-1, self.num_timesteps, 2)  # (B, T*D_out) -> (B, T, D_out)
         return x
 
@@ -70,7 +70,7 @@ class MLPNeuralDecoder(TorchBrainModel):
             spikes=spikes,
             num_units=len(data.units),
             bin_size=self.bin_size,
-            num_bins=self.num_timesteps
+            num_bins=self.num_timesteps,
         ).T
 
         # Target variable
@@ -84,7 +84,7 @@ class MLPNeuralDecoder(TorchBrainModel):
             "target_values": torch.tensor(y, dtype=torch.float32),
         }
         return data_dict
-    
+
     def set_datasets(self, dir_path: str, dataset_config: str | Path | list[dict]):
         super().set_datasets(dir_path, dataset_config)
 
@@ -116,7 +116,7 @@ class MLPNeuralDecoder(TorchBrainModel):
             step=None,
             drop_short=False,
         )
-    
+
     @classmethod
     def load_pretrained(
         cls,

--- a/torch_brain/models/poyo.py
+++ b/torch_brain/models/poyo.py
@@ -19,7 +19,10 @@ from torch_brain.nn import (
     RotaryTimeEmbedding,
 )
 from torch_brain.registry import ModalitySpec
-
+from torch_brain.data.sampler import (
+    RandomFixedWindowSampler,
+    SequentialFixedWindowSampler,
+)
 from torch_brain.utils import (
     create_linspace_latent_tokens,
     create_start_end_unit_tokens,
@@ -369,6 +372,22 @@ class POYO(TorchBrainModel):
         self.train_dataset.transform = self.tokenize
         self.val_dataset.transform = self.tokenize
         self.test_dataset.transform = self.tokenize
+
+    def get_train_data_sampler(self) -> torch.utils.data.Sampler:
+        return RandomFixedWindowSampler(
+            sampling_intervals=self.train_dataset.get_sampling_intervals(),
+            window_length=self.sequence_length,
+            generator=torch.Generator().manual_seed(self.seed),
+            drop_short=True,
+        )
+
+    def get_val_data_sampler(self) -> torch.utils.data.Sampler:
+        return SequentialFixedWindowSampler(
+            sampling_intervals=self.val_dataset.get_sampling_intervals(),
+            window_length=self.sequence_length,
+            step=None,
+            drop_short=False,
+        )
 
     @classmethod
     def load_pretrained(

--- a/torch_brain/models/poyo.py
+++ b/torch_brain/models/poyo.py
@@ -371,8 +371,8 @@ class POYO(TorchBrainModel):
                 f"({latent_step}). This is a simple warning, and this behavior is allowed."
             )
 
-    def set_datasets(self, brainset_path: str, dataset_config: str | Path | list[dict]):
-        super().set_datasets(brainset_path, dataset_config)
+    def set_datasets(self, dir_path: str, dataset_config: str | Path | list[dict]):
+        super().set_datasets(dir_path, dataset_config)
 
         # Connect tokenizers to Datasets
         self.train_dataset.transform = self.tokenize

--- a/torch_brain/models/poyo.py
+++ b/torch_brain/models/poyo.py
@@ -444,6 +444,13 @@ class POYO(TorchBrainModel):
 
         return model
 
+    def reinitialize_vocabs(self):
+        """Reinitialize the vocabs for the new units and sessions"""
+        self.unit_emb.extend_vocab(self.train_dataset.get_unit_ids())
+        self.unit_emb.subset_vocab(self.train_dataset.get_unit_ids())
+        self.session_emb.extend_vocab(self.train_dataset.get_session_ids())
+        self.session_emb.subset_vocab(self.train_dataset.get_session_ids())
+
 
 def poyo_mp(readout_spec: ModalitySpec, ckpt_path=None):
     if ckpt_path is not None:

--- a/torch_brain/models/poyo.py
+++ b/torch_brain/models/poyo.py
@@ -379,6 +379,16 @@ class POYO(TorchBrainModel):
         self.val_dataset.transform = self.tokenize
         self.test_dataset.transform = self.tokenize
 
+        # Reinitialize vocabs
+        self.reinitialize_vocabs()
+
+    def reinitialize_vocabs(self):
+        """Reinitialize the vocabs for the new units and sessions"""
+        self.unit_emb.extend_vocab(self.train_dataset.get_unit_ids())
+        self.unit_emb.subset_vocab(self.train_dataset.get_unit_ids())
+        self.session_emb.extend_vocab(self.train_dataset.get_session_ids())
+        self.session_emb.subset_vocab(self.train_dataset.get_session_ids())
+
     def get_train_data_sampler(self) -> torch.utils.data.Sampler:
         return RandomFixedWindowSampler(
             sampling_intervals=self.train_dataset.get_sampling_intervals(),
@@ -457,13 +467,6 @@ class POYO(TorchBrainModel):
             )
 
         return model
-
-    def reinitialize_vocabs(self):
-        """Reinitialize the vocabs for the new units and sessions"""
-        self.unit_emb.extend_vocab(self.train_dataset.get_unit_ids())
-        self.unit_emb.subset_vocab(self.train_dataset.get_unit_ids())
-        self.session_emb.extend_vocab(self.train_dataset.get_session_ids())
-        self.session_emb.subset_vocab(self.train_dataset.get_session_ids())
 
     def finetune(
         self,
@@ -545,9 +548,6 @@ class POYO(TorchBrainModel):
 
         train_loader = self.get_data_loader(mode="train", **data_loader_kwargs)
         val_loader = self.get_data_loader(mode="valid", **data_loader_kwargs)
-
-        # Reinitialize vocabs
-        self.reinitialize_vocabs()
 
         # Main progress bar for epochs
         epoch_pbar = tqdm(range(num_epochs), desc="Finetuning Progress", leave=True)

--- a/torch_brain/models/poyo.py
+++ b/torch_brain/models/poyo.py
@@ -376,12 +376,16 @@ class POYO(nn.Module):
 
         # Load model weights
         # POYO is pretrained using lightning, so model weights are prefixed with "model."
-        state_dict = {k.replace("model.", ""): v for k, v in checkpoint["state_dict"].items()}
+        state_dict = {
+            k.replace("model.", ""): v for k, v in checkpoint["state_dict"].items()
+        }
 
         # Remove readout layer from checkpoint if we're using a new one
         if skip_readout:
-            state_dict = {k: v for k, v in state_dict.items() if not k.startswith("readout.")}
-        
+            state_dict = {
+                k: v for k, v in state_dict.items() if not k.startswith("readout.")
+            }
+
         # model.load_state_dict(state_dict)
         missing_keys, unexpected_keys = model.load_state_dict(state_dict, strict=False)
         if len(missing_keys) > 0:

--- a/torch_brain/models/poyo.py
+++ b/torch_brain/models/poyo.py
@@ -8,6 +8,7 @@ import torch.nn as nn
 from torchtyping import TensorType
 from temporaldata import Data
 
+from torch_brain.models.base_class import TorchBrainModel
 from torch_brain.data import chain, pad8, track_mask8
 from torch_brain.nn import (
     Embedding,
@@ -26,7 +27,7 @@ from torch_brain.utils import (
 )
 
 
-class POYO(nn.Module):
+class POYO(TorchBrainModel):
     """POYO model from `Azabou et al. 2023, A Unified, Scalable Framework for Neural Population Decoding
     <https://arxiv.org/abs/2310.16046>`_.
 
@@ -83,7 +84,7 @@ class POYO(nn.Module):
         t_min: float = 1e-4,
         t_max: float = 2.0627,
     ):
-        super().__init__()
+        super().__init__(readout_spec=readout_spec)
 
         self._validate_params(sequence_length, latent_step)
 
@@ -360,6 +361,14 @@ class POYO(nn.Module):
                 f"sequence_length ({sequence_length}) is not a multiple of latent_step "
                 f"({latent_step}). This is a simple warning, and this behavior is allowed."
             )
+
+    def set_datasets(self, brainset_path: str, dataset_config: str | Path | Dict):
+        super().set_datasets(brainset_path, dataset_config)
+
+        # Connect tokenizers to Datasets
+        self.train_dataset.transform = self.tokenize
+        self.val_dataset.transform = self.tokenize
+        self.test_dataset.transform = self.tokenize
 
     @classmethod
     def load_pretrained(

--- a/torch_brain/models/poyo.py
+++ b/torch_brain/models/poyo.py
@@ -404,7 +404,6 @@ class POYO(nn.Module):
                 k: v for k, v in state_dict.items() if not k.startswith("readout.")
             }
 
-        # model.load_state_dict(state_dict)
         missing_keys, unexpected_keys = model.load_state_dict(state_dict, strict=False)
         if len(missing_keys) > 0:
             print(f"Missing keys when loading pretrained POYO: {missing_keys}")

--- a/torch_brain/models/poyo.py
+++ b/torch_brain/models/poyo.py
@@ -368,6 +368,24 @@ class POYO(nn.Module):
         readout_spec: ModalitySpec,
         skip_readout: bool = False,
     ) -> "POYO":
+        """
+        Load a pretrained POYO model from a checkpoint file.
+
+        Args:
+            checkpoint_path (str or Path): Path to the checkpoint file containing model weights and hyperparameters.
+            readout_spec (ModalitySpec): Specification for the readout modality, used to initialize the model.
+            skip_readout (bool, optional): If True, the readout layer weights from the checkpoint are ignored and a new readout layer is initialized. Default is False.
+
+        Returns:
+            POYO: An instance of the POYO model with weights loaded from the checkpoint.
+
+        Usage:
+            model = POYO.load_pretrained("path/to/checkpoint.ckpt", readout_spec)
+
+        Notes:
+            - The checkpoint is expected to contain both model hyperparameters and weights.
+            - If `skip_readout` is True, the readout layer weights are not loaded from the checkpoint.
+        """
         # Instantiate model object from checkpoint hyperparameters
         checkpoint = torch.load(checkpoint_path, map_location="cpu", weights_only=False)
         model_kwargs = checkpoint["hyper_parameters"]["model"]

--- a/torch_brain/models/poyo.py
+++ b/torch_brain/models/poyo.py
@@ -458,7 +458,6 @@ class POYO(TorchBrainModel):
 
         return model
 
-
     def reinitialize_vocabs(self):
         """Reinitialize the vocabs for the new units and sessions"""
         self.unit_emb.extend_vocab(self.train_dataset.get_unit_ids())

--- a/torch_brain/models/poyo.py
+++ b/torch_brain/models/poyo.py
@@ -9,7 +9,6 @@ import torch.nn.functional as F
 from torchtyping import TensorType
 from temporaldata import Data
 
-from tests.test_rotary_attention import batch_size
 from torch_brain.models.base_class import TorchBrainModel
 from torch_brain.data import collate, pad8, track_mask8
 from torch_brain.nn import (

--- a/torch_brain/models/poyo.py
+++ b/torch_brain/models/poyo.py
@@ -406,9 +406,13 @@ class POYO(nn.Module):
 
         missing_keys, unexpected_keys = model.load_state_dict(state_dict, strict=False)
         if len(missing_keys) > 0:
-            logging.warning(f"Missing keys when loading pretrained POYO: {missing_keys}")
+            logging.warning(
+                f"Missing keys when loading pretrained POYO: {missing_keys}"
+            )
         if len(unexpected_keys) > 0:
-            logging.warning(f"Unexpected keys when loading pretrained POYO: {unexpected_keys}")
+            logging.warning(
+                f"Unexpected keys when loading pretrained POYO: {unexpected_keys}"
+            )
 
         return model
 

--- a/torch_brain/models/poyo.py
+++ b/torch_brain/models/poyo.py
@@ -406,9 +406,9 @@ class POYO(nn.Module):
 
         missing_keys, unexpected_keys = model.load_state_dict(state_dict, strict=False)
         if len(missing_keys) > 0:
-            print(f"Missing keys when loading pretrained POYO: {missing_keys}")
+            logging.warning(f"Missing keys when loading pretrained POYO: {missing_keys}")
         if len(unexpected_keys) > 0:
-            print(f"Unexpected keys when loading pretrained POYO: {unexpected_keys}")
+            logging.warning(f"Unexpected keys when loading pretrained POYO: {unexpected_keys}")
 
         return model
 

--- a/torch_brain/models/poyo.py
+++ b/torch_brain/models/poyo.py
@@ -371,7 +371,7 @@ class POYO(TorchBrainModel):
                 f"({latent_step}). This is a simple warning, and this behavior is allowed."
             )
 
-    def set_datasets(self, brainset_path: str, dataset_config: str | Path | Dict):
+    def set_datasets(self, brainset_path: str, dataset_config: str | Path | list[dict]):
         super().set_datasets(brainset_path, dataset_config)
 
         # Connect tokenizers to Datasets

--- a/torch_brain/models/poyo.py
+++ b/torch_brain/models/poyo.py
@@ -541,6 +541,9 @@ class POYO(TorchBrainModel):
         train_loader = self.get_data_loader(mode="train", **data_loader_kwargs)
         val_loader = self.get_data_loader(mode="valid", **data_loader_kwargs)
 
+        # Reinitialize vocabs
+        self.reinitialize_vocabs()
+
         # Main progress bar for epochs
         epoch_pbar = tqdm(range(num_epochs), desc="Finetuning Progress", leave=True)
         for epoch in epoch_pbar:
@@ -553,7 +556,7 @@ class POYO(TorchBrainModel):
             # Validation before training step
             with torch.no_grad():
                 self.eval()  # make sure we're in eval mode during validation
-                r2, target, pred = compute_r2(val_loader, self)
+                r2, target, pred = compute_r2(val_loader, self, device)
                 r2_log.append(r2)
 
             # Switch back to training mode
@@ -590,7 +593,7 @@ class POYO(TorchBrainModel):
             del target, pred
 
         # Final validation
-        r2, _, _ = compute_r2(val_loader, self)
+        r2, _, _ = compute_r2(val_loader, self, device)
         r2_log.append(r2)
         print(f"\n✅ Done! Final validation R² = {r2:.3f}")
 

--- a/torch_brain/models/poyo.py
+++ b/torch_brain/models/poyo.py
@@ -5,7 +5,6 @@ from pathlib import Path
 import numpy as np
 import torch
 import torch.nn as nn
-import torch.nn.functional as F
 from torchtyping import TensorType
 from temporaldata import Data
 

--- a/torch_brain/registry.py
+++ b/torch_brain/registry.py
@@ -97,7 +97,7 @@ def get_modality_by_id(modality_id: int) -> ModalitySpec:
 
 
 register_modality(
-    "cursor_velocity_2d",
+    name="cursor_velocity_2d",
     dim=2,
     type=DataType.CONTINUOUS,
     timestamp_key="cursor.timestamps",
@@ -106,7 +106,7 @@ register_modality(
 )
 
 register_modality(
-    "cursor_position_2d",
+    name="cursor_position_2d",
     dim=2,
     type=DataType.CONTINUOUS,
     timestamp_key="cursor.timestamps",
@@ -115,7 +115,7 @@ register_modality(
 )
 
 register_modality(
-    "arm_velocity_2d",
+    name="arm_velocity_2d",
     dim=2,
     type=DataType.CONTINUOUS,
     timestamp_key="behavior.timestamps",
@@ -124,7 +124,7 @@ register_modality(
 )
 
 register_modality(
-    "drifting_gratings_orientation",
+    name="drifting_gratings_orientation",
     dim=8,
     type=DataType.MULTINOMIAL,
     timestamp_key="drifting_gratings.timestamps",
@@ -133,7 +133,7 @@ register_modality(
 )
 
 register_modality(
-    "drifting_gratings_temporal_frequency",
+    name="drifting_gratings_temporal_frequency",
     dim=5,  # [1,2,4,8,15]
     type=DataType.MULTINOMIAL,
     timestamp_key="drifting_gratings.timestamps",
@@ -142,7 +142,7 @@ register_modality(
 )
 
 register_modality(
-    "natural_movie_one_frame",
+    name="natural_movie_one_frame",
     dim=900,
     type=DataType.MULTINOMIAL,
     timestamp_key="natural_movie_one.timestamps",
@@ -151,7 +151,7 @@ register_modality(
 )
 
 register_modality(
-    "natural_movie_two_frame",
+    name="natural_movie_two_frame",
     dim=900,
     type=DataType.MULTINOMIAL,
     timestamp_key="natural_movie_two.timestamps",
@@ -160,7 +160,7 @@ register_modality(
 )
 
 register_modality(
-    "natural_movie_three_frame",
+    name="natural_movie_three_frame",
     dim=3600,
     type=DataType.MULTINOMIAL,
     timestamp_key="natural_movie_three.timestamps",
@@ -169,7 +169,7 @@ register_modality(
 )
 
 register_modality(
-    "locally_sparse_noise_frame",
+    name="locally_sparse_noise_frame",
     dim=8000,
     type=DataType.MULTINOMIAL,
     timestamp_key="locally_sparse_noise.timestamps",
@@ -178,7 +178,7 @@ register_modality(
 )
 
 register_modality(
-    "static_gratings_orientation",
+    name="static_gratings_orientation",
     dim=6,
     type=DataType.MULTINOMIAL,
     timestamp_key="static_gratings.timestamps",
@@ -187,7 +187,7 @@ register_modality(
 )
 
 register_modality(
-    "static_gratings_spatial_frequency",
+    name="static_gratings_spatial_frequency",
     dim=5,
     type=DataType.MULTINOMIAL,
     timestamp_key="static_gratings.timestamps",
@@ -196,7 +196,7 @@ register_modality(
 )
 
 register_modality(
-    "static_gratings_phase",
+    name="static_gratings_phase",
     dim=5,
     type=DataType.MULTINOMIAL,
     timestamp_key="static_gratings.timestamps",
@@ -205,7 +205,7 @@ register_modality(
 )
 
 register_modality(
-    "natural_scenes",
+    name="natural_scenes",
     dim=119,  # image classes [0,...,118]
     type=DataType.MULTINOMIAL,
     timestamp_key="natural_scenes.timestamps",
@@ -214,7 +214,7 @@ register_modality(
 )
 
 register_modality(
-    "gabor_orientation",
+    name="gabor_orientation",
     dim=4,  # [0, 1, 2, 3]
     type=DataType.MULTINOMIAL,
     timestamp_key="gabors.timestamps",
@@ -223,7 +223,7 @@ register_modality(
 )
 
 register_modality(
-    "gabor_pos_2d",  # 9x9 grid modeled as (x, y) coordinates
+    name="gabor_pos_2d",  # 9x9 grid modeled as (x, y) coordinates
     dim=2,
     type=DataType.CONTINUOUS,
     timestamp_key="gabors.timestamps",
@@ -232,7 +232,7 @@ register_modality(
 )
 
 register_modality(
-    "running_speed",
+    name="running_speed",
     dim=1,
     type=DataType.CONTINUOUS,
     timestamp_key="running.timestamps",
@@ -241,7 +241,7 @@ register_modality(
 )
 
 register_modality(
-    "gaze_pos_2d",
+    name="gaze_pos_2d",
     dim=2,
     type=DataType.CONTINUOUS,
     timestamp_key="gaze.timestamps",
@@ -250,7 +250,7 @@ register_modality(
 )
 
 register_modality(
-    "pupil_location",
+    name="pupil_location",
     dim=2,
     type=DataType.CONTINUOUS,
     timestamp_key="pupil.timestamps",
@@ -259,7 +259,7 @@ register_modality(
 )
 
 register_modality(
-    "pupil_size_2d",
+    name="pupil_size_2d",
     dim=2,
     type=DataType.CONTINUOUS,
     timestamp_key="pupil.timestamps",

--- a/torch_brain/registry.py
+++ b/torch_brain/registry.py
@@ -26,6 +26,7 @@ class ModalitySpec:
     """Specification for a modality.
 
     Attributes:
+        name: Unique name for this modality
         dim: Dimension for this modality
         type: DataType enum specifying the data type
         loss_fn: Name of loss function to use for this modality
@@ -34,6 +35,7 @@ class ModalitySpec:
         id: Unique numeric ID assigned to this modality
     """
 
+    name: str
     id: int
     dim: int
     type: DataType
@@ -46,7 +48,7 @@ MODALITY_REGISTRY: Dict[str, ModalitySpec] = {}
 _ID_TO_MODALITY: Dict[int, str] = {}
 
 
-def register_modality(name: str, **kwargs: Any) -> int:
+def register_modality(**kwargs: Any) -> int:
     """Register a new modality specification in the global registry.
 
     Args:
@@ -61,8 +63,8 @@ def register_modality(name: str, **kwargs: Any) -> int:
         ValueError: If a modality with the given name already exists
     """
     # Check if modality already exists
-    if name in MODALITY_REGISTRY:
-        raise ValueError(f"Modality {name} already exists in registry")
+    if kwargs["name"] in MODALITY_REGISTRY:
+        raise ValueError(f"Modality {kwargs['name']} already exists in registry")
 
     # Get next available ID
     next_id = len(MODALITY_REGISTRY) + 1
@@ -71,8 +73,8 @@ def register_modality(name: str, **kwargs: Any) -> int:
     decoder_spec = ModalitySpec(**kwargs, id=next_id)
 
     # Add to registries
-    MODALITY_REGISTRY[name] = decoder_spec
-    _ID_TO_MODALITY[next_id] = name
+    MODALITY_REGISTRY[kwargs["name"]] = decoder_spec
+    _ID_TO_MODALITY[next_id] = kwargs["name"]
 
     return next_id
 

--- a/torch_brain/schemas/base_class/__init__.py
+++ b/torch_brain/schemas/base_class/__init__.py
@@ -1,0 +1,15 @@
+from .dataset_schema import (
+    ReadoutConfig,
+    SelectionConfig,
+    DatasetLevelConfig,
+    DatasetSelectionBlock,
+    BaseDatasetConfig,
+)
+
+__all__ = [
+    "ReadoutConfig",
+    "SelectionConfig",
+    "DatasetLevelConfig",
+    "DatasetSelectionBlock",
+    "BaseDatasetConfig",
+]

--- a/torch_brain/schemas/base_class/dataset_schema.py
+++ b/torch_brain/schemas/base_class/dataset_schema.py
@@ -1,0 +1,159 @@
+from typing import Dict, List, Optional, Union, Any
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    RootModel,
+    field_validator,
+    model_validator,
+)
+
+
+class ReadoutConfig(BaseModel):
+    """Configuration for readout."""
+
+    # Required fields
+    readout_id: Union[str, int] = Field(
+        ..., description="Modality identifier from MODALITY_REGISTRY"
+    )
+
+    # Normalization
+    normalize_mean: Optional[float] = Field(
+        None, description="Mean for z-score normalization."
+    )
+    normalize_std: Optional[float] = Field(
+        None,
+        description="Standard deviation for z-score normalization. Must be non-zero.",
+    )
+
+    # Data location
+    timestamp_key: Optional[str] = Field(
+        None,
+        description="Timestamp location (e.g., 'hand.timestamps')",
+        examples=["cursor.timestamps", "hand.timestamps", "wheel.timestamps"],
+    )
+    value_key: Optional[str] = Field(
+        None,
+        description="Value location (e.g., 'cursor.vel')",
+        examples=["cursor.vel", "hand.vel", "wheel.vel"],
+    )
+
+    # Loss weighting
+    weights: Optional[Dict[str, float]] = Field(
+        None,
+        description="Mapping of interval paths to weight multipliers for loss computation",
+    )
+
+    # Evaluation
+    eval_interval: Optional[str] = Field(
+        None,
+        description="Interval path for filtering evaluation periods",
+        examples=["movement_phases.reach_period", "movement_phases.random_period"],
+    )
+
+    metrics: Optional[List[Dict[str, Any]]] = Field(
+        None, description="List of metric configurations for evaluation"
+    )
+
+    model_config = ConfigDict(extra="forbid")
+
+    @field_validator("normalize_std")
+    @classmethod
+    def validate_std_not_zero(cls, v):
+        """Ensure normalization std is not zero."""
+        if v is not None:
+            if v == 0:
+                raise ValueError("normalize_std cannot be 0")
+        return v
+
+    @field_validator("weights")
+    @classmethod
+    def validate_weights(cls, v):
+        """Ensure all weight values are numeric."""
+        if v is not None:
+            for key, value in v.items():
+                if not isinstance(value, (int, float)):
+                    raise ValueError(
+                        f"Weight value for interval '{key}' must be numeric, got {type(value).__name__}"
+                    )
+        return v
+
+
+class SelectionConfig(BaseModel):
+    """Configuration for dataset selection criteria."""
+
+    brainset: str = Field(
+        ..., description="Brainset identifier (e.g., 'perich_miller_population_2018')"
+    )
+
+    sessions: Optional[List[str]] = Field(
+        None, description="List of sessions to include"
+    )
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class DatasetLevelConfig(BaseModel):
+    """Configuration options at the dataset level."""
+
+    readout: ReadoutConfig = Field(
+        ..., description="Readout configuration for this dataset selection"
+    )
+
+    sampling_intervals_modifier: Optional[str] = Field(
+        None, description="Python code to modify sampling intervals (advanced usage)"
+    )
+
+    model_config = ConfigDict(extra="allow")
+
+
+class DatasetSelectionBlock(BaseModel):
+    """A single selection block with associated configuration."""
+
+    selection: List[SelectionConfig] = Field(
+        ...,
+        description="List of selection criteria (can select from multiple brainsets)",
+    )
+
+    config: DatasetLevelConfig = Field(
+        ..., description="Configuration for this selection"
+    )
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class BaseDatasetConfig(RootModel):
+    """
+    Base model Dataset configuration schema.
+
+    This represents the full dataset YAML config structure,
+    which can contain multiple selection blocks, each with
+    their own readout configuration.
+
+    Example:
+        config = BaseDatasetConfig.model_validate(yaml_data)
+    """
+
+    root: List[DatasetSelectionBlock]
+
+    def __iter__(self):
+        """Allow iterating over selection blocks."""
+        return iter(self.root)
+
+    def __getitem__(self, item):
+        """Allow indexing selection blocks."""
+        return self.root[item]
+
+    def __len__(self):
+        """Get number of selection blocks."""
+        return len(self.root)
+
+
+# Export main classes
+__all__ = [
+    "ReadoutConfig",
+    "SelectionConfig",
+    "DatasetLevelConfig",
+    "DatasetSelectionBlock",
+    "BaseDatasetConfig",
+]

--- a/torch_brain/schemas/base_class/dataset_schema.py
+++ b/torch_brain/schemas/base_class/dataset_schema.py
@@ -5,7 +5,6 @@ from pydantic import (
     Field,
     RootModel,
     field_validator,
-    model_validator,
 )
 
 

--- a/torch_brain/utils/training.py
+++ b/torch_brain/utils/training.py
@@ -107,6 +107,17 @@ def compute_r2(dataloader, model, device):
 
 
 def training_step(batch, model, optimizer):
+    """
+    Performs a single training step: forward pass, loss computation, backward pass, and optimizer step.
+
+    Args:
+        batch (dict): A batch of data containing 'model_inputs' and 'target_values'.
+        model (torch.nn.Module): The model to be trained.
+        optimizer (torch.optim.Optimizer): The optimizer used to update model parameters.
+
+    Returns:
+        torch.Tensor: The computed loss for the batch.
+    """
     optimizer.zero_grad()  # Step 0. Clear old gradients
 
     inputs = batch["model_inputs"]

--- a/torch_brain/utils/training.py
+++ b/torch_brain/utils/training.py
@@ -63,18 +63,18 @@ def compute_r2(dataloader, model, device):
 
 
 def training_step(batch, model, optimizer):
-    optimizer.zero_grad()                  # Step 0. Clear old gradients
+    optimizer.zero_grad()  # Step 0. Clear old gradients
 
     inputs = batch["model_inputs"]
     target = batch["target_values"]
-    
+
     pred = model(**inputs)  # Step 1. Do forward pass
 
     # shapes: [B, T, 1] -> [B, T]
     if pred.dim() == 3 and pred.size(-1) == 1:
         pred = pred.squeeze(-1)
-    
-    loss = F.mse_loss(pred, target)        # Step 2. Compute loss
-    loss.backward()                        # Step 3. Backward pass
-    optimizer.step()                       # Step 4. Update model params
+
+    loss = F.mse_loss(pred, target)  # Step 2. Compute loss
+    loss.backward()  # Step 3. Backward pass
+    optimizer.step()  # Step 4. Update model params
     return loss

--- a/torch_brain/utils/training.py
+++ b/torch_brain/utils/training.py
@@ -1,0 +1,80 @@
+import torch
+import torch.nn.functional as F
+
+
+def move_to_device(data, device):
+    """Recursively move data to the specified device."""
+    if isinstance(data, torch.Tensor):
+        # Specify dtype on the move for float tensors.
+        if data.is_floating_point():
+            return data.to(device=device, dtype=torch.float32)
+        else:
+            return data.to(device)
+    elif isinstance(data, dict):
+        return {k: move_to_device(v, device) for k, v in data.items()}
+    elif isinstance(data, list):
+        return [move_to_device(v, device) for v in data]
+    else:
+        return data
+
+
+def r2_score(y_pred, y_true):
+    # Compute total sum of squares (variance of the true values)
+    y_true_mean = torch.mean(y_true, dim=0, keepdim=True)
+    ss_total = torch.sum((y_true - y_true_mean) ** 2)
+
+    # Compute residual sum of squares
+    ss_res = torch.sum((y_true - y_pred) ** 2)
+
+    # Compute R^2
+    r2 = 1 - ss_res / ss_total
+
+    return r2
+
+
+def compute_r2(dataloader, model):
+    model.eval()  # turn off dropout, etc.
+    total_target = []
+    total_pred = []
+    with torch.no_grad():  # <-- crucial: no graph, no huge memory
+        for batch in dataloader:
+            batch = move_to_device(batch)
+            pred = model(**batch["model_inputs"])
+            target = batch["target_values"]
+
+            # If your model returns [B, T, 1], squeeze to [B, T]
+            if pred.dim() == 3 and pred.size(-1) == 1:
+                pred = pred.squeeze(-1)
+
+            mask = torch.ones_like(target, dtype=torch.bool)
+            if "output_mask" in batch["model_inputs"]:
+                mask = batch["model_inputs"]["output_mask"]
+                if mask.dim() == 3 and mask.size(-1) == 1:
+                    mask = mask.squeeze(-1)
+
+            total_target.append(target[mask])
+            total_pred.append(pred[mask])
+
+    total_target = torch.cat(total_target)
+    total_pred = torch.cat(total_pred)
+
+    r2 = r2_score(total_pred.flatten(), total_target.flatten())
+    return r2.item(), total_target, total_pred
+
+
+def training_step(batch, model, optimizer):
+    optimizer.zero_grad()                  # Step 0. Clear old gradients
+
+    inputs = batch["model_inputs"]
+    target = batch["target_values"]
+    
+    pred = model(**inputs)  # Step 1. Do forward pass
+
+    # shapes: [B, T, 1] -> [B, T]
+    if pred.dim() == 3 and pred.size(-1) == 1:
+        pred = pred.squeeze(-1)
+    
+    loss = F.mse_loss(pred, target)        # Step 2. Compute loss
+    loss.backward()                        # Step 3. Backward pass
+    optimizer.step()                       # Step 4. Update model params
+    return loss

--- a/torch_brain/utils/training.py
+++ b/torch_brain/utils/training.py
@@ -33,6 +33,23 @@ def r2_score(y_pred, y_true):
 
 
 def compute_r2(dataloader, model, device):
+    """
+    Compute the R^2 score for a model over a given dataloader.
+
+    Parameters:
+        dataloader: DataLoader
+            An iterable over batches of data, each containing model inputs and target values.
+        model: torch.nn.Module
+            The model to evaluate.
+        device: torch.device or str
+            The device on which computation is performed.
+
+    Returns:
+        tuple:
+            r2 (float): The R^2 score computed over all batches.
+            total_target (torch.Tensor): Concatenated ground truth target values.
+            total_pred (torch.Tensor): Concatenated model predictions.
+    """
     model.eval()  # turn off dropout, etc.
     total_target = []
     total_pred = []

--- a/torch_brain/utils/training.py
+++ b/torch_brain/utils/training.py
@@ -33,6 +33,19 @@ def move_to_device(data, device):
 
 
 def r2_score(y_pred, y_true):
+    """
+    Computes the coefficient of determination (R² score) between predictions and true values.
+
+    R² is calculated as: R² = 1 - (SS_res / SS_tot)
+    where SS_res is the sum of squared residuals and SS_tot is the total sum of squares.
+
+    Args:
+        y_pred (torch.Tensor): Predicted values. Shape should match y_true.
+        y_true (torch.Tensor): Ground truth (target) values.
+
+    Returns:
+        torch.Tensor: The R² score as a scalar tensor.
+    """
     # Compute total sum of squares (variance of the true values)
     y_true_mean = torch.mean(y_true, dim=0, keepdim=True)
     ss_total = torch.sum((y_true - y_true_mean) ** 2)

--- a/torch_brain/utils/training.py
+++ b/torch_brain/utils/training.py
@@ -214,16 +214,16 @@ def train_model(
             )
 
         avg_loss = running_loss / len(train_loader)
-        epoch_pbar.set_postfix(
-            {"Avg Loss": f"{avg_loss:.4f}", "Val R2": f"{r2:.3f}"}
-        )
+        epoch_pbar.set_postfix({"Avg Loss": f"{avg_loss:.4f}", "Val R2": f"{r2:.3f}"})
 
         # Store intermediate outputs
         if store_params is not None and len(store_params) > 0:
             for param in store_params:
                 if not hasattr(model, param):
                     raise ValueError(f"Model has no parameter named '{param}'")
-                train_outputs[param].append(getattr(model, param).weight[1:].detach().cpu().numpy())
+                train_outputs[param].append(
+                    getattr(model, param).weight[1:].detach().cpu().numpy()
+                )
 
         train_outputs["output_gt"].append(target.detach().cpu().numpy())
         train_outputs["output_pred"].append(pred.detach().cpu().numpy())

--- a/torch_brain/utils/training.py
+++ b/torch_brain/utils/training.py
@@ -32,13 +32,13 @@ def r2_score(y_pred, y_true):
     return r2
 
 
-def compute_r2(dataloader, model):
+def compute_r2(dataloader, model, device):
     model.eval()  # turn off dropout, etc.
     total_target = []
     total_pred = []
     with torch.no_grad():  # <-- crucial: no graph, no huge memory
         for batch in dataloader:
-            batch = move_to_device(batch)
+            batch = move_to_device(batch, device)
             pred = model(**batch["model_inputs"])
             target = batch["target_values"]
 

--- a/torch_brain/utils/training.py
+++ b/torch_brain/utils/training.py
@@ -3,7 +3,21 @@ import torch.nn.functional as F
 
 
 def move_to_device(data, device):
-    """Recursively move data to the specified device."""
+    """
+    Recursively move data to the specified device.
+
+    Parameters
+    ----------
+    data : torch.Tensor, dict, list, or other
+        The data to move. Can be a tensor, a dictionary of tensors, a list of tensors, or nested structures thereof.
+    device : torch.device or str
+        The device to move the data to (e.g., 'cpu', 'cuda', or a torch.device object).
+
+    Returns
+    -------
+    Moved data of the same structure as input, with all tensors moved to the specified device.
+    Non-tensor objects are returned unchanged.
+    """
     if isinstance(data, torch.Tensor):
         # Specify dtype on the move for float tensors.
         if data.is_floating_point():

--- a/torch_brain/visualization/__init__.py
+++ b/torch_brain/visualization/__init__.py
@@ -1,0 +1,1 @@
+from .plots import *

--- a/torch_brain/visualization/plots.py
+++ b/torch_brain/visualization/plots.py
@@ -1,0 +1,23 @@
+import matplotlib.pyplot as plt
+import numpy as np
+
+
+def plot_training_curves(r2_log, loss_log):
+    """
+    Plots the training curves: training loss and validation R2 score.
+    """
+    plt.figure(figsize=(12, 4))
+    plt.subplot(1, 2, 1)
+    plt.plot(np.linspace(0, len(loss_log), len(loss_log)), loss_log)
+    plt.title("Training Loss")
+    plt.xlabel("Training Steps")
+    plt.ylabel("MSE Loss")
+    plt.grid()
+    plt.subplot(1, 2, 2)
+    plt.plot(r2_log)
+    plt.title("Validation R2")
+    plt.xlabel("Epochs")
+    plt.ylabel("R2 Score")
+    plt.grid()
+    plt.tight_layout()
+    plt.show()


### PR DESCRIPTION
**WIP - this is preliminary attempt, and open to discussion and changes!**

This PR brings a couple of significant changes:
- A base class `TorchBrainModel` to be inherited by all torch_brain models. 
- New methods for the parent and child classes
- Pydantic classes defining Dataset configurations
- Helper functions at `utils/training.py`
- [An example](https://github.com/neuro-galaxy/torch_brain/blob/torchbrainmodel/examples/poyo/finetune.py) of how much easier it will be for a new user to use a pre-trained model with their own Brainset, after these changes (compare it to the Cosyne tutorial)


## Base class
The current base class is inspired on POYO and what I could extrapolate from it. I do expect us to change it as we go looking at other models and observe other needs for abstraction. For example, @vinamarora8  raised a valid point that not every torch_model will be a decoding model. A potential extension then would be to have `TorchBrainModel` with more basic methods and e.g. `DecodeTorchBrainModel` which inherits from it with readout_spec related operations. Examples:

- `TorchBrainModel` -> `DecodeTorchBrainModel` -> `POYO`
- `TorchBrainModel` -> `EmbeddingTorchBrainModel` -> `MyEmbModel`

I think that this first round already illustrates how useful such abstractions can be. See e.g. the `set_datasets` method in [parent](https://github.com/neuro-galaxy/torch_brain/blob/878f3d72e0d7e73efb6c466c16f08e0a5069416e/torch_brain/models/base_class.py#L79-L111) and [child](https://github.com/neuro-galaxy/torch_brain/blob/878f3d72e0d7e73efb6c466c16f08e0a5069416e/torch_brain/models/poyo.py#L374-L383) classes.

## New methods for the parent and child classes
Implementing some operations as modular methods allows torch_brain to:
- be user friendly, with minimal usage configuration using sensible defaults
- be flexible enough to allow override of any specific methods

Example of things that can be automatized / enforced:
- given a dataset configuration, the model class should be able to know it will bind it's own tokenize method to that dataset, and that it should reinitialize vocab, [see here](https://github.com/neuro-galaxy/torch_brain/blob/878f3d72e0d7e73efb6c466c16f08e0a5069416e/torch_brain/models/poyo.py#L374-L383)
- given a model hyperparameter configuration, the data sampler `window_length` should match the model `sequence_length`, [see here](https://github.com/neuro-galaxy/torch_brain/blob/878f3d72e0d7e73efb6c466c16f08e0a5069416e/torch_brain/models/poyo.py#L392-L398)

Again, those a sensible defaults, and it is very simple to override them for more advanced users.

## Dataset configurations as Pydantic classes
[See them here](https://github.com/neuro-galaxy/torch_brain/blob/torchbrainmodel/torch_brain/schemas/base_class/dataset_schema.py). The original PR for that is [here](https://github.com/neuro-galaxy/torch_brain/pull/113), but I brought them to this one so the models methods can make proper use of them.

This will help standardize the usage and documentations of the dataset configuration across the project. This is necessary for:
- Easing the creation and understanding of such configurations by the users
- Validation and quick error detection
- Automatize some operations across models methods and helper functions

Pydantic classes are composable, that means we could follow a similar pattern of inheritance from parent configs to child configs, and each model can define it’s own needs while respecting a basic common structure.

Right now, users still need to manually set values for `readout_spec` and `dataset_config`, which feels unnecessary, since `dataset_config` seems to contain `readout_spec`. This is something we can discuss how to improve, but right now you can see that we can already validate basic stuff, e.g. make sure they contain the same values, [see here](https://github.com/neuro-galaxy/torch_brain/blob/878f3d72e0d7e73efb6c466c16f08e0a5069416e/torch_brain/models/base_class.py#L56-L77).

Since each model might need different `dataset_config`, they can also implement helper methods that output a minimal valid config, including (optionally) calculating statistics necessary for that specific model, [see here](https://github.com/neuro-galaxy/torch_brain/blob/878f3d72e0d7e73efb6c466c16f08e0a5069416e/torch_brain/models/base_class.py#L146-L207)

## Helper functions
I copied them from the Cosyne tutorials, I brought the basic necessary ones for finetuning, and haven’t put much work on generalizing or improving them. Something to work on!