### PR TITLE
Add max_spikes optional parameter to bin_spikes function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [0.1.0] - 2025-03-26
 ### Added
-- Added a `max_spikes` parameters to `bin_spikes`. ([#158](https://github.com/neuro-galaxy/torch_brain/pull/158))
 - Added a method to resolve weights based on interval membership of timestamps. ([#31](https://github.com/neuro-galaxy/torch_brain/pull/31))
 - Added multitask decoder taxonomy. ([#8](https://github.com/neuro-galaxy/torch_brain/pull/8))
 - Added stitching callback that takes care of stitching. ([#16](https://github.com/neuro-galaxy/torch_brain/pull/16))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [0.1.0] - 2025-03-26
 ### Added
+- Added a `max_spikes` parameters to `bin_spikes`. ([#158](https://github.com/neuro-galaxy/torch_brain/pull/158))
 - Added a method to resolve weights based on interval membership of timestamps. ([#31](https://github.com/neuro-galaxy/torch_brain/pull/31))
 - Added multitask decoder taxonomy. ([#8](https://github.com/neuro-galaxy/torch_brain/pull/8))
 - Added stitching callback that takes care of stitching. ([#16](https://github.com/neuro-galaxy/torch_brain/pull/16))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased]
 ### Added
 - Added `eps` parameter to `bin_spikes` to improve numerical stability when computing bin boundaries. ([#160](https://github.com/neuro-galaxy/torch_brain/pull/160))
+- Added `max_spikes` parameter to `bin_spikes`. ([#158](https://github.com/neuro-galaxy/torch_brain/pull/158))
 
 ### Removed
 

--- a/tests/test_binning.py
+++ b/tests/test_binning.py
@@ -70,9 +70,27 @@ def test_bin_data():
             [0, 0, 1, 0, 0, 0, 0, 0, 0, 0],
         ]
     )
-    print(binned_data)
     assert binned_data.shape == expected.shape
     assert np.allclose(binned_data, expected)
+
+    # test max_spikes
+    spikes = IrregularTimeSeries(
+        timestamps=np.array(
+            [0, 0, 1, 1, 1.1, 1.2, 1.3, 1.4, 1.5, 2, 3, 4, 4.5, 6, 7, 8, 9]
+        ),
+        unit_index=np.array([0, 1, 0, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0]),
+        domain=Interval(0, 10),
+    )
+    binned_data = bin_spikes(
+        spikes, num_units=2, bin_size=1.0, right=True, max_spikes=3
+    )
+
+    expected = np.array(
+        [[1, 1, 1, 1, 2, 0, 1, 1, 1, 1], [1, 3, 0, 0, 0, 0, 0, 0, 0, 0]]
+    )
+    assert binned_data.shape == expected.shape
+    assert np.allclose(binned_data, expected)
+    assert binned_data.dtype == np.float32
 
     # fix numerical instability
     # Duration is intended to be exactly 1.0, but represented with

--- a/torch_brain/utils/binning.py
+++ b/torch_brain/utils/binning.py
@@ -9,9 +9,9 @@ def bin_spikes(
     num_units: int,
     bin_size: float,
     max_spikes: Optional[int] = None,
-    right: bool = True,
-    eps: float = 1e-3,
-    dtype: np.dtype = np.float32,
+    right: Optional[bool] = True,
+    eps: Optional[float] = 1e-3,
+    dtype: Optional[np.dtype] = np.float32,
 ) -> np.ndarray:
     r"""Bins spikes into time bins of size `bin_size`. If the total time spanned by
     the spikes is not a multiple of `bin_size`, the spikes are truncated to the nearest

--- a/torch_brain/utils/binning.py
+++ b/torch_brain/utils/binning.py
@@ -9,9 +9,9 @@ def bin_spikes(
     num_units: int,
     bin_size: float,
     max_spikes: Optional[int] = None,
-    right: Optional[bool] = True,
-    eps: Optional[float] = 1e-3,
-    dtype: Optional[np.dtype] = np.float32,
+    right: bool = True,
+    eps: float = 1e-3,
+    dtype: np.dtype = np.float32,
 ) -> np.ndarray:
     r"""Bins spikes into time bins of size `bin_size`. If the total time spanned by
     the spikes is not a multiple of `bin_size`, the spikes are truncated to the nearest

--- a/torch_brain/utils/binning.py
+++ b/torch_brain/utils/binning.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 import numpy as np
 from temporaldata import IrregularTimeSeries
 
@@ -6,6 +8,7 @@ def bin_spikes(
     spikes: IrregularTimeSeries,
     num_units: int,
     bin_size: float,
+    max_spikes: Optional[int] = None,
     right: bool = True,
     eps: float = 1e-3,
     dtype: np.dtype = np.float32,
@@ -60,5 +63,7 @@ def bin_spikes(
     ts = spikes.timestamps - spikes.domain.start[0]
     bin_index = np.floor(ts * rate).astype(int)
     np.add.at(binned_spikes, (spikes.unit_index, bin_index), 1)
+    if max_spikes is not None:
+        np.clip(binned_spikes, None, max_spikes, out=binned_spikes)
 
     return binned_spikes

--- a/torch_brain/utils/binning.py
+++ b/torch_brain/utils/binning.py
@@ -30,6 +30,8 @@ def bin_spikes(
         spikes: IrregularTimeSeries object containing the spikes.
         num_units: Number of units in the population.
         bin_size: Size of the time bins in seconds.
+        max_spikes: If provided, the maximum number of spikes per bin. Any bins
+            exceeding this count will be clipped.
         right: If True, any excess spikes are truncated from the left end of the time
             series. Otherwise, they are truncated from the right end.
         eps : float, default=1e-3


### PR DESCRIPTION
### Summary
In some cases, when tokenizing binned spikes, it is useful to cap (max-clip) the maximum number of spikes allowed per bin. This attribute can be aligned with the size of the embedding table (bin spikes tokens).

### Changes
Introduces an optional max_spikes: Optional[int] = None parameter to allow max-clipping of spike counts per bin.
When set, spike counts are clipped to the specified maximum.
When None (default), the existing behavior is preserved.

### Testing
This functionality is tested.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an option to cap the maximum spike count per bin when aggregating spike times.

* **Tests**
  * Added coverage validating the spike-count capping across multiple units and windows.
  * Removed an obsolete debug print from the test suite.

* **Documentation**
  * Updated changelog/release notes to document the new spike-capping option.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->