### PR TITLE
Improve numerical stability in bin_spikes with epsilon tolerance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,15 @@
 All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-- Added `eps` parameter to `bin_spikes` to improve numerical stability when computing bin boundaries.
+
+## [Unreleased]
+### Added
+- Added `eps` parameter to `bin_spikes` to improve numerical stability when computing bin boundaries. ([#160](https://github.com/neuro-galaxy/torch_brain/pull/160))
+
+### Removed
+
+### Changed
+- Fix bug when start time is non-zero in `bin_spikes` ([#160](https://github.com/neuro-galaxy/torch_brain/pull/160))
 
 ## [0.1.0] - 2025-03-26
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+- Added `eps` parameter to `bin_spikes` to improve numerical stability when computing bin boundaries.
+
 ## [0.1.0] - 2025-03-26
 ### Added
 - Added a method to resolve weights based on interval membership of timestamps. ([#31](https://github.com/neuro-galaxy/torch_brain/pull/31))

--- a/tests/test_binning.py
+++ b/tests/test_binning.py
@@ -79,13 +79,11 @@ def test_bin_data():
     # floating-point error.
     # for base in [0., 1e3, 1e6]:
     for base in [0.0]:
-        ts = base + np.array(
-            [0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9999999999]
-        )
+        ts = base + np.array([0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.99998])
         spikes = IrregularTimeSeries(
             timestamps=ts,
             unit_index=np.zeros(10, dtype=int),
-            domain="auto",
+            domain=Interval(0, 10),
         )
 
         binned_data = bin_spikes(

--- a/tests/test_binning.py
+++ b/tests/test_binning.py
@@ -85,12 +85,7 @@ def test_bin_data():
             timestamps=ts, unit_index=np.zeros(10, dtype=int), domain="auto"
         )
 
-        binned_data = bin_spikes(
-            spikes,
-            num_units=1,
-            bin_size=0.1,
-            right=False,
-        )
+        binned_data = bin_spikes(spikes, num_units=1, bin_size=0.1)
 
         expected = np.array([[1, 1, 1, 1, 1, 1, 1, 1, 1, 1]])
 

--- a/tests/test_binning.py
+++ b/tests/test_binning.py
@@ -77,9 +77,10 @@ def test_bin_data():
     # fix numerical instability
     # Duration is intended to be exactly 1.0, but represented with
     # floating-point error.
-    # for base in [0., 1e3, 1e6]:
-    for base in [0.0]:
-        ts = base + np.array([0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.99998])
+    for base in [0.0, 1e3, 1e6]:
+        ts = base + np.array(
+            [0.05, 0.15, 0.25, 0.35, 0.45, 0.55, 0.65, 0.75, 0.89999999, 0.95]
+        )
         spikes = IrregularTimeSeries(
             timestamps=ts,
             unit_index=np.zeros(10, dtype=int),

--- a/tests/test_binning.py
+++ b/tests/test_binning.py
@@ -80,7 +80,7 @@ def test_bin_data():
     # for base in [0.0, 1e3, 1e6]:
     for base in [0.0]:
         ts = base + np.array(
-            [0.05, 0.15, 0.25, 0.35, 0.45, 0.55, 0.65, 0.75, 0.85, 0.99999999]
+            [0.05, 0.15, 0.25, 0.35, 0.45, 0.55, 0.65, 0.75, 0.85, 0.9999999]
         )
         spikes = IrregularTimeSeries(
             timestamps=ts, unit_index=np.zeros(10, dtype=int), domain="auto"

--- a/tests/test_binning.py
+++ b/tests/test_binning.py
@@ -77,7 +77,8 @@ def test_bin_data():
     # fix numerical instability
     # Duration is intended to be exactly 1.0, but represented with
     # floating-point error.
-    for base in [0.0, 1e3, 1e6]:
+    # for base in [0.0, 1e3, 1e6]:
+    for base in [0.0]:
         ts = base + np.array(
             [0.05, 0.15, 0.25, 0.35, 0.45, 0.55, 0.65, 0.75, 0.85, 0.99999999]
         )

--- a/tests/test_binning.py
+++ b/tests/test_binning.py
@@ -79,12 +79,10 @@ def test_bin_data():
     # floating-point error.
     for base in [0.0, 1e3, 1e6]:
         ts = base + np.array(
-            [0.05, 0.15, 0.25, 0.35, 0.45, 0.55, 0.65, 0.75, 0.89999999, 0.95]
+            [0.05, 0.15, 0.25, 0.35, 0.45, 0.55, 0.65, 0.75, 0.85, 0.99999999]
         )
         spikes = IrregularTimeSeries(
-            timestamps=ts,
-            unit_index=np.zeros(10, dtype=int),
-            domain=Interval(0, 1),
+            timestamps=ts, unit_index=np.zeros(10, dtype=int), domain="auto"
         )
 
         binned_data = bin_spikes(

--- a/tests/test_binning.py
+++ b/tests/test_binning.py
@@ -77,7 +77,8 @@ def test_bin_data():
     # fix numerical instability
     # Duration is intended to be exactly 1.0, but represented with
     # floating-point error.
-    for base in [0, 1e3, 1e6]:
+    # for base in [0., 1e3, 1e6]:
+    for base in [0.0]:
         ts = base + np.array(
             [0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9999999999]
         )

--- a/tests/test_binning.py
+++ b/tests/test_binning.py
@@ -89,7 +89,7 @@ def test_bin_data():
             spikes,
             num_units=1,
             bin_size=0.1,
-            right=True,
+            right=False,
         )
 
         expected = np.array([[1, 1, 1, 1, 1, 1, 1, 1, 1, 1]])

--- a/tests/test_binning.py
+++ b/tests/test_binning.py
@@ -77,8 +77,7 @@ def test_bin_data():
     # fix numerical instability
     # Duration is intended to be exactly 1.0, but represented with
     # floating-point error.
-    # for base in [0.0, 1e3, 1e6]:
-    for base in [0.0]:
+    for base in [0.0, 1e3, 1e6]:
         ts = base + np.array(
             [0.0, 0.15, 0.25, 0.35, 0.45, 0.55, 0.65, 0.75, 0.85, 0.9999999]
         )

--- a/tests/test_binning.py
+++ b/tests/test_binning.py
@@ -77,22 +77,24 @@ def test_bin_data():
     # fix numerical instability
     # Duration is intended to be exactly 1.0, but represented with
     # floating-point error.
-    spikes = IrregularTimeSeries(
-        timestamps=np.array(
+    for base in [0, 1e3, 1e6]:
+        ts = base + np.array(
             [0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9999999999]
-        ),
-        unit_index=np.zeros(10, dtype=int),
-        domain="auto",
-    )
+        )
+        spikes = IrregularTimeSeries(
+            timestamps=ts,
+            unit_index=np.zeros(10, dtype=int),
+            domain="auto",
+        )
 
-    binned_data = bin_spikes(
-        spikes,
-        num_units=1,
-        bin_size=0.1,
-        right=True,
-    )
+        binned_data = bin_spikes(
+            spikes,
+            num_units=1,
+            bin_size=0.1,
+            right=True,
+        )
 
-    expected = np.array([[1, 1, 1, 1, 1, 1, 1, 1, 1, 1]])
+        expected = np.array([[1, 1, 1, 1, 1, 1, 1, 1, 1, 1]])
 
-    assert binned_data.shape == expected.shape
-    assert np.allclose(binned_data, expected)
+        assert binned_data.shape == expected.shape
+        assert np.allclose(binned_data, expected)

--- a/tests/test_binning.py
+++ b/tests/test_binning.py
@@ -73,3 +73,26 @@ def test_bin_data():
     print(binned_data)
     assert binned_data.shape == expected.shape
     assert np.allclose(binned_data, expected)
+
+    # fix numerical instability
+    # Duration is intended to be exactly 1.0, but represented with
+    # floating-point error.
+    spikes = IrregularTimeSeries(
+        timestamps=np.array(
+            [0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9999999999]
+        ),
+        unit_index=np.zeros(10, dtype=int),
+        domain="auto",
+    )
+
+    binned_data = bin_spikes(
+        spikes,
+        num_units=1,
+        bin_size=0.1,
+        right=True,
+    )
+
+    expected = np.array([[1, 1, 1, 1, 1, 1, 1, 1, 1, 1]])
+
+    assert binned_data.shape == expected.shape
+    assert np.allclose(binned_data, expected)

--- a/tests/test_binning.py
+++ b/tests/test_binning.py
@@ -80,7 +80,7 @@ def test_bin_data():
     # for base in [0.0, 1e3, 1e6]:
     for base in [0.0]:
         ts = base + np.array(
-            [0.05, 0.15, 0.25, 0.35, 0.45, 0.55, 0.65, 0.75, 0.85, 0.9999999]
+            [0.0, 0.15, 0.25, 0.35, 0.45, 0.55, 0.65, 0.75, 0.85, 0.9999999]
         )
         spikes = IrregularTimeSeries(
             timestamps=ts, unit_index=np.zeros(10, dtype=int), domain="auto"

--- a/tests/test_binning.py
+++ b/tests/test_binning.py
@@ -84,7 +84,7 @@ def test_bin_data():
         spikes = IrregularTimeSeries(
             timestamps=ts,
             unit_index=np.zeros(10, dtype=int),
-            domain=Interval(0, 10),
+            domain=Interval(0, 1),
         )
 
         binned_data = bin_spikes(

--- a/torch_brain/utils/binning.py
+++ b/torch_brain/utils/binning.py
@@ -53,8 +53,6 @@ def bin_spikes(
 
     num_bins = round((end - start) / bin_size)
 
-    print(spikes.timestamps)
-
     rate = 1 / bin_size  # avoid precision issues
     binned_spikes = np.zeros((num_units, num_bins), dtype=dtype)
     bin_index = np.floor(spikes.timestamps * rate).astype(int)

--- a/torch_brain/utils/binning.py
+++ b/torch_brain/utils/binning.py
@@ -41,8 +41,9 @@ def bin_spikes(
     # is an exact multiple of `bin_size`. The epsilon stabilizes
     # the floor operation under floating-point roundoff.
     discard = (end - start) - np.floor(((end - start) / bin_size) + eps) * bin_size
-    # Note the discard should in theory always be positive except the numerical instability mention above can make it negative
-    # in this case we dont want to reslice it to potentialy loose the last point
+    # In theory, `discard` should always be non-negative.
+    # Floating-point roundoff may make it slightly negative,
+    # in that case, we avoid reslicing to prevent dropping the last spike.
     if discard > 0:
         if right:
             start += discard

--- a/torch_brain/utils/binning.py
+++ b/torch_brain/utils/binning.py
@@ -55,7 +55,7 @@ def bin_spikes(
 
     rate = 1 / bin_size  # avoid precision issues
     binned_spikes = np.zeros((num_units, num_bins), dtype=dtype)
-    # Handle case of timestamps with non 0 domain start
+    # Handle timestamps when the domain start is non-zero
     ts = spikes.timestamps - spikes.domain.start[0]
     bin_index = np.floor(ts * rate).astype(int)
     np.add.at(binned_spikes, (spikes.unit_index, bin_index), 1)

--- a/torch_brain/utils/binning.py
+++ b/torch_brain/utils/binning.py
@@ -55,7 +55,9 @@ def bin_spikes(
 
     rate = 1 / bin_size  # avoid precision issues
     binned_spikes = np.zeros((num_units, num_bins), dtype=dtype)
-    bin_index = np.floor(spikes.timestamps * rate).astype(int)
+    # Handle case of timestamps with non 0 domain start
+    ts = spikes.timestamps - spikes.domain.start[0]
+    bin_index = np.floor(ts * rate).astype(int)
     np.add.at(binned_spikes, (spikes.unit_index, bin_index), 1)
 
     return binned_spikes

--- a/torch_brain/utils/binning.py
+++ b/torch_brain/utils/binning.py
@@ -41,7 +41,9 @@ def bin_spikes(
     # is an exact multiple of `bin_size`. The epsilon stabilizes
     # the floor operation under floating-point roundoff.
     discard = (end - start) - np.floor(((end - start) / bin_size) + eps) * bin_size
-    if discard != 0:
+    # Note the discard should in theory always be positive except the numerical instability mention above can make it negative
+    # in this case we dont want to reslice it to potentialy loose the last point
+    if discard > 0:
         if right:
             start += discard
         else:

--- a/torch_brain/utils/binning.py
+++ b/torch_brain/utils/binning.py
@@ -41,8 +41,7 @@ def bin_spikes(
     # is an exact multiple of `bin_size`. The epsilon stabilizes
     # the floor operation under floating-point roundoff.
     discard = (end - start) - np.floor(((end - start) / bin_size) + eps) * bin_size
-    eps_2 = 1e-6
-    if discard >= eps_2:
+    if discard != 0:
         if right:
             start += discard
         else:

--- a/torch_brain/utils/binning.py
+++ b/torch_brain/utils/binning.py
@@ -41,7 +41,8 @@ def bin_spikes(
     # is an exact multiple of `bin_size`. The epsilon stabilizes
     # the floor operation under floating-point roundoff.
     discard = (end - start) - np.floor(((end - start) / bin_size) + eps) * bin_size
-    if discard != 0:
+    eps_2 = 1e-6
+    if discard >= eps_2:
         if right:
             start += discard
         else:

--- a/torch_brain/utils/binning.py
+++ b/torch_brain/utils/binning.py
@@ -51,9 +51,11 @@ def bin_spikes(
 
     num_bins = round((end - start) / bin_size)
 
+    print(spikes.timestamps)
+
     rate = 1 / bin_size  # avoid precision issues
     binned_spikes = np.zeros((num_units, num_bins), dtype=dtype)
-    bin_index = np.floor((spikes.timestamps) * rate).astype(int)
+    bin_index = np.floor(spikes.timestamps * rate).astype(int)
     np.add.at(binned_spikes, (spikes.unit_index, bin_index), 1)
 
     return binned_spikes


### PR DESCRIPTION
### Summary
This PR improves the numerical robustness of spike binning by introducing a small tolerance parameter `eps` to the `bin_spikes` function. The change prevents floating-point precision issues when computing the number of bins for durations that are very close to an integer multiple of the bin size.

### Motivation
When `(end - start) / bin_size` is affected by floating-point roundoff, it can evaluate to a value slightly below an integer (e.g. 9.99999999 instead of 10.0). This may cause an extra bin to be dropped during truncation.
Adding a small epsilon before flooring stabilizes this computation and ensures consistent bin counts.

### Changes

- Added an `eps` parameter to `bin_spikes` to improve numerical stability when determining the number of bins.
- Updated docstrings and inline comments to document the motivation and behavior of `eps`.
- Added a regression test covering floating-point boundary conditions near exact bin multiples.
- Added corretion for spikes with domain not staring at 0 

### Backward Compatibility

- Default behavior is unchanged for well-behaved inputs.
- The new eps parameter has a default value and does not affect existing callers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved numerical stability in spike binning so near‑boundary floating‑point timestamps no longer produce incorrect counts.
* **New Features**
  * Added a configurable stability option for binning to reduce rounding issues (defaults preserve prior behavior).
* **Tests**
  * Added an edge‑case test covering near‑boundary floating‑point timestamps to ensure consistent binning.
* **Documentation**
  * Updated changelog and docstrings to describe the new stability option and its impact.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->