### PR TITLE
Revert brainsets ref in testing.yml

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -36,7 +36,7 @@ jobs:
     - name: Install brainsets
       run: |
         source venv/bin/activate
-        uv pip install git+https://github.com/neuro-galaxy/brainsets.git@refs/pull/67/head
+        uv pip install git+https://github.com/neuro-galaxy/brainsets
     - name: Test with pytest
       run: |
         source venv/bin/activate


### PR DESCRIPTION
For the purpose of merging #154, an updated ref was used for `brainsets` in `testing.yml`. Since the previously referred PR has been merged into brainsets (neuro-galaxy/brainsets#67), we can now revert back the ref in `testing.yml` to be the main branch of `brainsets`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow to install brainsets from the main repository instead of a specific branch reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->