### PR TITLE
Add MultiChannelDatasetMixin hook and export it

### DIFF
--- a/docs/source/package/dataset/mixins.rst
+++ b/docs/source/package/dataset/mixins.rst
@@ -17,11 +17,3 @@ Mixins
     :members:
     :show-inheritance:
     :undoc-members:
-
-.. autoclass:: SEEGDatasetMixin.ChannelView
-    :members:
-    :undoc-members:
-
-.. autoclass:: SEEGDatasetMixin.RecordingInfo
-    :members:
-    :undoc-members:

--- a/docs/source/package/dataset/mixins.rst
+++ b/docs/source/package/dataset/mixins.rst
@@ -17,7 +17,3 @@ Mixins
     :members:
     :show-inheritance:
     :undoc-members:
-
-Default channel-id uniquification behavior:
-``seeg_dataset_mixin_uniquify_channel_ids_with_subject=True`` and
-``seeg_dataset_mixin_uniquify_channel_ids_with_session=False``.

--- a/docs/source/package/dataset/mixins.rst
+++ b/docs/source/package/dataset/mixins.rst
@@ -13,7 +13,11 @@ Mixins
     :show-inheritance:
     :undoc-members:
 
-.. autoclass:: SEEGDatasetMixin
+.. autoclass:: MultiChannelDatasetMixin
     :members:
     :show-inheritance:
     :undoc-members:
+
+Default channel-id uniquification behavior:
+``seeg_dataset_mixin_uniquify_channel_ids_with_subject=True`` and
+``seeg_dataset_mixin_uniquify_channel_ids_with_session=False``.

--- a/docs/source/package/dataset/mixins.rst
+++ b/docs/source/package/dataset/mixins.rst
@@ -12,3 +12,16 @@ Mixins
     :members:
     :show-inheritance:
     :undoc-members:
+
+.. autoclass:: SEEGDatasetMixin
+    :members:
+    :show-inheritance:
+    :undoc-members:
+
+.. autoclass:: SEEGDatasetMixin.ChannelView
+    :members:
+    :undoc-members:
+
+.. autoclass:: SEEGDatasetMixin.RecordingInfo
+    :members:
+    :undoc-members:

--- a/tests/test_new_dataset.py
+++ b/tests/test_new_dataset.py
@@ -414,6 +414,22 @@ class TestMultiChannelDatasetMixin:
         ):
             ds.get_recording("session1")
 
+    def test_get_recording_hook_warns_for_session_only_uniquify(
+        self, dummy_seeg_brainset
+    ):
+        ds = _MultiChannelDatasetWithConstant(dummy_seeg_brainset)
+        ds.seeg_dataset_mixin_uniquify_channel_ids_with_subject = False
+        ds.seeg_dataset_mixin_uniquify_channel_ids_with_session = True
+
+        with pytest.warns(UserWarning, match="session only"):
+            rec = ds.get_recording("session1")
+
+        assert rec.channels.id.tolist() == [
+            "session1/ch0",
+            "session1/ch1",
+            "session1/ch2",
+        ]
+
 
 def test_ensure_index_has_namespace():
     from torch_brain.dataset.dataset import _ensure_index_has_namespace

--- a/tests/test_new_dataset.py
+++ b/tests/test_new_dataset.py
@@ -20,7 +20,7 @@ from brainsets.descriptions import (
 from brainsets.taxonomy import Species
 
 from torch_brain.dataset import Dataset, DatasetIndex, NestedDataset
-from torch_brain.dataset.mixins import SpikingDatasetMixin
+from torch_brain.dataset.mixins import SpikingDatasetMixin, SEEGDatasetMixin
 
 
 def create_spiking_data(brainset_id, subject_id, session_id, length):
@@ -51,6 +51,115 @@ def create_spiking_data(brainset_id, subject_id, session_id, length):
     )
 
 
+def create_seeg_data(brainset_id, subject_id, session_id, length, sampling_rate=256.0):
+    n_channels = 3
+    return Data(
+        brainset=BrainsetDescription(
+            id=brainset_id,
+            origin_version="",
+            derived_version="",
+            source="",
+            description="",
+        ),
+        subject=SubjectDescription(subject_id, Species.UNKNOWN),
+        session=SessionDescription(session_id, datetime.now()),
+        seeg_data=RegularTimeSeries(
+            sampling_rate=sampling_rate,
+            value=np.random.normal(
+                0.0, 1.0, (int(length * sampling_rate), n_channels)
+            ),
+            domain="auto",
+        ),
+        channels=ArrayDict(
+            id=np.array([f"ch{i}" for i in range(n_channels)]),
+            name=np.array([f"C{i}" for i in range(n_channels)]),
+            included=np.array([True, False, True]),
+            localization_L=np.array([1.0, 2.0, 3.0]),
+            localization_I=np.array([4.0, 5.0, 6.0]),
+            localization_P=np.array([7.0, 8.0, 9.0]),
+        ),
+        domain=Interval(0, length),
+    )
+
+
+def build_seeg_channel_view_cache(ds):
+    channel_views = {}
+    for rid in ds.recording_ids:
+        rec = ds.get_recording(rid)
+        channels = rec.channels
+        ids = np.asarray(channels.id)
+        names = np.asarray(getattr(channels, "name", ids))
+        included_mask = np.asarray(
+            getattr(channels, "included", np.ones(len(ids), dtype=bool)),
+            dtype=bool,
+        )
+        lip = None
+        if all(
+            hasattr(channels, attr)
+            for attr in ("localization_L", "localization_I", "localization_P")
+        ):
+            lip = np.stack(
+                (
+                    np.asarray(channels.localization_L, dtype=float),
+                    np.asarray(channels.localization_I, dtype=float),
+                    np.asarray(channels.localization_P, dtype=float),
+                ),
+                axis=1,
+            )
+
+        channel_views[rid] = SEEGDatasetMixin.ChannelView(
+            ids=ids,
+            names=names,
+            included_mask=included_mask,
+            lip=lip,
+        )
+    return channel_views
+
+
+def build_seeg_recording_info_cache(ds):
+    infos = {}
+    for rid in ds.recording_ids:
+        rec = ds.get_recording(rid)
+        channel_view = ds.seeg_dataset_mixin_channel_views[rid]
+        infos[rid] = SEEGDatasetMixin.RecordingInfo(
+            recording_id=rid,
+            subject_id=rec.subject.id,
+            session_id=rec.session.id,
+            sampling_rate_hz=ds.get_sampling_rate(rid),
+            domain=ds.seeg_dataset_mixin_domain_intervals[rid],
+            n_channels=int(len(channel_view.ids)),
+            n_included_channels=int(np.sum(channel_view.included_mask)),
+        )
+    return infos
+
+
+class _SEEGDatasetWithConstant(SEEGDatasetMixin, Dataset):
+    seeg_dataset_mixin_sampling_rate_hz = 256.0
+
+
+def configure_seeg_dataset_caches(
+    ds,
+    *,
+    domain: bool = False,
+    channel_views: bool = False,
+    recording_infos: bool = False,
+):
+    if domain:
+        ds.seeg_dataset_mixin_domain_intervals = {
+            rid: ds.get_recording(rid).seeg_data.domain for rid in ds.recording_ids
+        }
+    if channel_views:
+        ds.seeg_dataset_mixin_channel_views = build_seeg_channel_view_cache(ds)
+    if recording_infos:
+        if not domain:
+            ds.seeg_dataset_mixin_domain_intervals = {
+                rid: ds.get_recording(rid).seeg_data.domain for rid in ds.recording_ids
+            }
+        if not channel_views:
+            ds.seeg_dataset_mixin_channel_views = build_seeg_channel_view_cache(ds)
+        ds.seeg_dataset_mixin_recording_infos = build_seeg_recording_info_cache(ds)
+
+
 @pytest.fixture
 def dummy_spiking_brainset(tmp_path):
     BRAINSET_ID = "mock_brainset"
@@ -70,6 +179,23 @@ def dummy_spiking_brainset(tmp_path):
         data.to_hdf5(f, serialize_fn_map=serialize_fn_map)
 
     data = create_spiking_data(BRAINSET_ID, "charlie", "session4", 2.0)
+    with h5py.File(store_path / f"{data.session.id}.h5", "w") as f:
+        data.to_hdf5(f, serialize_fn_map=serialize_fn_map)
+
+    return store_path
+
+
+@pytest.fixture
+def dummy_seeg_brainset(tmp_path):
+    BRAINSET_ID = "mock_seeg_brainset"
+    store_path = tmp_path / BRAINSET_ID
+    os.makedirs(store_path, exist_ok=True)
+
+    data = create_seeg_data(BRAINSET_ID, "alice", "session1", 1.0)
+    with h5py.File(store_path / f"{data.session.id}.h5", "w") as f:
+        data.to_hdf5(f, serialize_fn_map=serialize_fn_map)
+
+    data = create_seeg_data(BRAINSET_ID, "bob", "session2", 1.2)
     with h5py.File(store_path / f"{data.session.id}.h5", "w") as f:
         data.to_hdf5(f, serialize_fn_map=serialize_fn_map)
 
@@ -266,6 +392,129 @@ class TestSpikingDatasetMixin:
         )
         actual_unit_ids = ds.get_unit_ids()
         assert actual_unit_ids == expected_unit_ids
+
+
+class TestSEEGDatasetMixin:
+    def test_get_sampling_rate(self, dummy_seeg_brainset):
+        ds = _SEEGDatasetWithConstant(dummy_seeg_brainset)
+        assert ds.get_sampling_rate() == 256.0
+        assert ds.get_sampling_rate("session2") == 256.0
+
+    def test_get_sampling_rate_requires_dataset_constant(self, dummy_seeg_brainset):
+        class SEEGDataset(SEEGDatasetMixin, Dataset): ...
+
+        ds = SEEGDataset(dummy_seeg_brainset)
+        with pytest.raises(NotImplementedError, match="seeg_dataset_mixin_sampling_rate_hz"):
+            ds.get_sampling_rate()
+
+    def test_get_domain_intervals_uses_dataset_cache(self, dummy_seeg_brainset):
+        ds = _SEEGDatasetWithConstant(dummy_seeg_brainset)
+        configure_seeg_dataset_caches(ds, domain=True)
+
+        all_intervals = ds.get_domain_intervals()
+        assert set(all_intervals) == set(ds.recording_ids)
+
+        subset = ds.get_domain_intervals(recording_ids=["session2"])
+        assert list(subset) == ["session2"]
+
+    def test_get_domain_intervals_requires_dataset_cache(self, dummy_seeg_brainset):
+        ds = _SEEGDatasetWithConstant(dummy_seeg_brainset)
+        with pytest.raises(NotImplementedError, match="seeg_dataset_mixin_domain_intervals"):
+            ds.get_domain_intervals()
+
+    def test_get_domain_intervals_raises_on_missing_ids(self, dummy_seeg_brainset):
+        ds = _SEEGDatasetWithConstant(dummy_seeg_brainset)
+        ds.seeg_dataset_mixin_domain_intervals = {
+            "session1": ds.get_recording("session1").seeg_data.domain
+        }
+        with pytest.raises(KeyError, match="Missing domain intervals"):
+            ds.get_domain_intervals(recording_ids=["session2"])
+
+    def test_get_channel_view(self, dummy_seeg_brainset):
+        ds = _SEEGDatasetWithConstant(dummy_seeg_brainset)
+        configure_seeg_dataset_caches(ds, domain=True, channel_views=True)
+        full_view = ds.get_channel_view("session1", included_only=False)
+        included_view = ds.get_channel_view("session1", included_only=True)
+
+        assert full_view.ids.tolist() == ["ch0", "ch1", "ch2"]
+        assert full_view.names.tolist() == ["C0", "C1", "C2"]
+        assert full_view.included_mask.tolist() == [True, False, True]
+        assert full_view.lip is not None
+        assert full_view.lip.shape == (3, 3)
+
+        assert included_view.ids.tolist() == ["ch0", "ch2"]
+        assert included_view.names.tolist() == ["C0", "C2"]
+        assert included_view.included_mask.tolist() == [True, True]
+        assert included_view.lip is not None
+        assert included_view.lip.shape == (2, 3)
+
+    def test_get_channel_view_requires_dataset_cache(self, dummy_seeg_brainset):
+        ds = _SEEGDatasetWithConstant(dummy_seeg_brainset)
+        with pytest.raises(NotImplementedError, match="seeg_dataset_mixin_channel_views"):
+            ds.get_channel_view("session1")
+
+    def test_get_channel_view_raises_on_missing_recording(self, dummy_seeg_brainset):
+        ds = _SEEGDatasetWithConstant(dummy_seeg_brainset)
+        ds.seeg_dataset_mixin_channel_views = {
+            "session1": build_seeg_channel_view_cache(ds)["session1"]
+        }
+        with pytest.raises(KeyError, match="Missing channel view"):
+            ds.get_channel_view("session2")
+
+    def test_get_channel_ids_are_recording_disambiguated(self, dummy_seeg_brainset):
+        ds = _SEEGDatasetWithConstant(dummy_seeg_brainset)
+        configure_seeg_dataset_caches(ds, channel_views=True)
+
+        all_ids = ds.get_channel_ids()
+        assert all_ids == [
+            "ch0/session1",
+            "ch0/session2",
+            "ch1/session1",
+            "ch1/session2",
+            "ch2/session1",
+            "ch2/session2",
+        ]
+
+        included_ids = ds.get_channel_ids(included_only=True)
+        assert included_ids == [
+            "ch0/session1",
+            "ch0/session2",
+            "ch2/session1",
+            "ch2/session2",
+        ]
+
+    def test_get_recording_info(self, dummy_seeg_brainset):
+        ds = _SEEGDatasetWithConstant(dummy_seeg_brainset)
+        configure_seeg_dataset_caches(ds, recording_infos=True)
+        info = ds.get_recording_info("session1")
+
+        assert info.recording_id == "session1"
+        assert info.subject_id == "alice"
+        assert info.session_id == "session1"
+        assert info.sampling_rate_hz == 256.0
+        assert info.n_channels == 3
+        assert info.n_included_channels == 2
+
+    def test_get_recording_info_requires_dataset_cache(self, dummy_seeg_brainset):
+        ds = _SEEGDatasetWithConstant(dummy_seeg_brainset)
+        with pytest.raises(NotImplementedError, match="seeg_dataset_mixin_recording_infos"):
+            ds.get_recording_info("session1")
+
+    def test_get_recording_info_raises_on_missing_recording(self, dummy_seeg_brainset):
+        ds = _SEEGDatasetWithConstant(dummy_seeg_brainset)
+        ds.seeg_dataset_mixin_recording_infos = {
+            "session1": SEEGDatasetMixin.RecordingInfo(
+                recording_id="session1",
+                subject_id="alice",
+                session_id="session1",
+                sampling_rate_hz=256.0,
+                domain=Interval(0, 1.0),
+                n_channels=3,
+                n_included_channels=2,
+            )
+        }
+        with pytest.raises(KeyError, match="Missing recording info"):
+            ds.get_recording_info("session2")
 
 
 def test_ensure_index_has_namespace():

--- a/tests/test_new_dataset.py
+++ b/tests/test_new_dataset.py
@@ -327,25 +327,25 @@ class TestSpikingDatasetMixin:
 
 
 class TestSEEGDatasetMixin:
-    def test_get_channel_ids_are_recording_disambiguated(self, dummy_seeg_brainset):
+    def test_get_channel_ids_use_recording_view_ids(self, dummy_seeg_brainset):
         ds = _SEEGDatasetWithConstant(dummy_seeg_brainset)
 
         all_ids = ds.get_channel_ids()
         assert all_ids == [
-            "ch0/session1",
-            "ch0/session2",
-            "ch1/session1",
-            "ch1/session2",
-            "ch2/session1",
-            "ch2/session2",
+            "ch0",
+            "ch0",
+            "ch1",
+            "ch1",
+            "ch2",
+            "ch2",
         ]
 
         included_ids = ds.get_channel_ids(included_only=True)
         assert included_ids == [
-            "ch0/session1",
-            "ch0/session2",
-            "ch2/session1",
-            "ch2/session2",
+            "ch0",
+            "ch0",
+            "ch2",
+            "ch2",
         ]
 
     def test_get_channel_ids_match_hook_uniquified_recording_ids(

--- a/tests/test_new_dataset.py
+++ b/tests/test_new_dataset.py
@@ -136,7 +136,11 @@ class _SEEGDatasetWithConstant(SEEGDatasetMixin, Dataset):
 
 
 class _SEEGDatasetWithConstantUniquify(_SEEGDatasetWithConstant):
-    seeg_dataset_mixin_uniquify_channel_ids = True
+    seeg_dataset_mixin_uniquify_channel_ids = {"subject_id", "session_id"}
+
+
+class _SEEGDatasetWithConstantUniquifySubjectOnly(_SEEGDatasetWithConstant):
+    seeg_dataset_mixin_uniquify_channel_ids = {"subject_id"}
 
 
 def configure_seeg_dataset_caches(
@@ -521,6 +525,37 @@ class TestSEEGDatasetMixin:
             "bob/session2/ch0",
             "bob/session2/ch2",
         ]
+
+    def test_get_channel_ids_match_hook_uniquified_subject_only_ids(
+        self, dummy_seeg_brainset
+    ):
+        ds = _SEEGDatasetWithConstantUniquifySubjectOnly(dummy_seeg_brainset)
+        configure_seeg_dataset_caches(ds, channel_views=True)
+
+        recording_ids = ds.get_recording("session1").channels.id.tolist()
+        assert recording_ids == [
+            "alice/ch0",
+            "alice/ch1",
+            "alice/ch2",
+        ]
+
+        all_ids = ds.get_channel_ids()
+        assert all_ids == [
+            "alice/ch0",
+            "alice/ch1",
+            "alice/ch2",
+            "bob/ch0",
+            "bob/ch1",
+            "bob/ch2",
+        ]
+
+    def test_get_recording_hook_rejects_invalid_uniquify_components(
+        self, dummy_seeg_brainset
+    ):
+        ds = _SEEGDatasetWithConstant(dummy_seeg_brainset)
+        ds.seeg_dataset_mixin_uniquify_channel_ids = {"subject_id", "bad_component"}
+        with pytest.raises(ValueError, match="Invalid channel uniquify components"):
+            ds.get_recording("session1")
 
     def test_get_recording_info(self, dummy_seeg_brainset):
         ds = _SEEGDatasetWithConstant(dummy_seeg_brainset)

--- a/tests/test_new_dataset.py
+++ b/tests/test_new_dataset.py
@@ -51,7 +51,9 @@ def create_spiking_data(brainset_id, subject_id, session_id, length):
     )
 
 
-def create_seeg_data(brainset_id, subject_id, session_id, length, sampling_rate=256.0):
+def create_multichannel_data(
+    brainset_id, subject_id, session_id, length, sampling_rate=256.0
+):
     n_channels = 3
     return Data(
         brainset=BrainsetDescription(
@@ -63,7 +65,7 @@ def create_seeg_data(brainset_id, subject_id, session_id, length, sampling_rate=
         ),
         subject=SubjectDescription(subject_id, Species.UNKNOWN),
         session=SessionDescription(session_id, datetime.now()),
-        seeg_data=RegularTimeSeries(
+        multichannel_data=RegularTimeSeries(
             sampling_rate=sampling_rate,
             value=np.random.normal(0.0, 1.0, (int(length * sampling_rate), n_channels)),
             domain="auto",
@@ -122,16 +124,16 @@ def dummy_spiking_brainset(tmp_path):
 
 
 @pytest.fixture
-def dummy_seeg_brainset(tmp_path):
-    BRAINSET_ID = "mock_seeg_brainset"
+def dummy_multichannel_brainset(tmp_path):
+    BRAINSET_ID = "mock_multichannel_brainset"
     store_path = tmp_path / BRAINSET_ID
     os.makedirs(store_path, exist_ok=True)
 
-    data = create_seeg_data(BRAINSET_ID, "alice", "session1", 1.0)
+    data = create_multichannel_data(BRAINSET_ID, "alice", "session1", 1.0)
     with h5py.File(store_path / f"{data.session.id}.h5", "w") as f:
         data.to_hdf5(f, serialize_fn_map=serialize_fn_map)
 
-    data = create_seeg_data(BRAINSET_ID, "bob", "session2", 1.2)
+    data = create_multichannel_data(BRAINSET_ID, "bob", "session2", 1.2)
     with h5py.File(store_path / f"{data.session.id}.h5", "w") as f:
         data.to_hdf5(f, serialize_fn_map=serialize_fn_map)
 
@@ -331,8 +333,8 @@ class TestSpikingDatasetMixin:
 
 
 class TestMultiChannelDatasetMixin:
-    def test_get_channel_ids_use_recording_view_ids(self, dummy_seeg_brainset):
-        ds = _MultiChannelDatasetWithConstant(dummy_seeg_brainset)
+    def test_get_channel_ids_use_recording_view_ids(self, dummy_multichannel_brainset):
+        ds = _MultiChannelDatasetWithConstant(dummy_multichannel_brainset)
 
         all_ids = ds.get_channel_ids()
         assert all_ids == [
@@ -345,9 +347,9 @@ class TestMultiChannelDatasetMixin:
         ]
 
     def test_get_channel_ids_match_hook_uniquified_recording_ids(
-        self, dummy_seeg_brainset
+        self, dummy_multichannel_brainset
     ):
-        ds = _MultiChannelDatasetWithConstantUniquify(dummy_seeg_brainset)
+        ds = _MultiChannelDatasetWithConstantUniquify(dummy_multichannel_brainset)
 
         recording_ids = ds.get_recording("session1").channels.id.tolist()
         assert recording_ids == [
@@ -367,9 +369,11 @@ class TestMultiChannelDatasetMixin:
         ]
 
     def test_get_channel_ids_match_hook_uniquified_subject_only_ids(
-        self, dummy_seeg_brainset
+        self, dummy_multichannel_brainset
     ):
-        ds = _MultiChannelDatasetWithConstantUniquifySubjectOnly(dummy_seeg_brainset)
+        ds = _MultiChannelDatasetWithConstantUniquifySubjectOnly(
+            dummy_multichannel_brainset
+        )
 
         recording_ids = ds.get_recording("session1").channels.id.tolist()
         assert recording_ids == [
@@ -389,9 +393,9 @@ class TestMultiChannelDatasetMixin:
         ]
 
     def test_get_recording_hook_rejects_non_boolean_uniquify_flags(
-        self, dummy_seeg_brainset
+        self, dummy_multichannel_brainset
     ):
-        ds = _MultiChannelDatasetWithConstant(dummy_seeg_brainset)
+        ds = _MultiChannelDatasetWithConstant(dummy_multichannel_brainset)
         ds.multichannel_dataset_mixin_uniquify_channel_ids_with_subject = "yes"
         with pytest.raises(
             TypeError,
@@ -400,9 +404,9 @@ class TestMultiChannelDatasetMixin:
             ds.get_recording("session1")
 
     def test_get_recording_hook_default_subject_only_uniquify(
-        self, dummy_seeg_brainset
+        self, dummy_multichannel_brainset
     ):
-        ds = _MultiChannelDatasetWithConstant(dummy_seeg_brainset)
+        ds = _MultiChannelDatasetWithConstant(dummy_multichannel_brainset)
         rec = ds.get_recording("session1")
 
         assert rec.channels.id.tolist() == [
@@ -412,9 +416,9 @@ class TestMultiChannelDatasetMixin:
         ]
 
     def test_build_channel_prefix_raises_for_missing_requested_component(
-        self, dummy_seeg_brainset
+        self, dummy_multichannel_brainset
     ):
-        ds = _MultiChannelDatasetWithConstant(dummy_seeg_brainset)
+        ds = _MultiChannelDatasetWithConstant(dummy_multichannel_brainset)
         ds.multichannel_dataset_mixin_uniquify_channel_ids_with_subject = True
         ds.multichannel_dataset_mixin_uniquify_channel_ids_with_session = False
 

--- a/tests/test_new_dataset.py
+++ b/tests/test_new_dataset.py
@@ -65,9 +65,7 @@ def create_seeg_data(brainset_id, subject_id, session_id, length, sampling_rate=
         session=SessionDescription(session_id, datetime.now()),
         seeg_data=RegularTimeSeries(
             sampling_rate=sampling_rate,
-            value=np.random.normal(
-                0.0, 1.0, (int(length * sampling_rate), n_channels)
-            ),
+            value=np.random.normal(0.0, 1.0, (int(length * sampling_rate), n_channels)),
             domain="auto",
         ),
         channels=ArrayDict(
@@ -404,7 +402,9 @@ class TestSEEGDatasetMixin:
         class SEEGDataset(SEEGDatasetMixin, Dataset): ...
 
         ds = SEEGDataset(dummy_seeg_brainset)
-        with pytest.raises(NotImplementedError, match="seeg_dataset_mixin_sampling_rate_hz"):
+        with pytest.raises(
+            NotImplementedError, match="seeg_dataset_mixin_sampling_rate_hz"
+        ):
             ds.get_sampling_rate()
 
     def test_get_domain_intervals_uses_dataset_cache(self, dummy_seeg_brainset):
@@ -419,7 +419,9 @@ class TestSEEGDatasetMixin:
 
     def test_get_domain_intervals_requires_dataset_cache(self, dummy_seeg_brainset):
         ds = _SEEGDatasetWithConstant(dummy_seeg_brainset)
-        with pytest.raises(NotImplementedError, match="seeg_dataset_mixin_domain_intervals"):
+        with pytest.raises(
+            NotImplementedError, match="seeg_dataset_mixin_domain_intervals"
+        ):
             ds.get_domain_intervals()
 
     def test_get_domain_intervals_raises_on_missing_ids(self, dummy_seeg_brainset):
@@ -450,7 +452,9 @@ class TestSEEGDatasetMixin:
 
     def test_get_channel_view_requires_dataset_cache(self, dummy_seeg_brainset):
         ds = _SEEGDatasetWithConstant(dummy_seeg_brainset)
-        with pytest.raises(NotImplementedError, match="seeg_dataset_mixin_channel_views"):
+        with pytest.raises(
+            NotImplementedError, match="seeg_dataset_mixin_channel_views"
+        ):
             ds.get_channel_view("session1")
 
     def test_get_channel_view_raises_on_missing_recording(self, dummy_seeg_brainset):
@@ -497,7 +501,9 @@ class TestSEEGDatasetMixin:
 
     def test_get_recording_info_requires_dataset_cache(self, dummy_seeg_brainset):
         ds = _SEEGDatasetWithConstant(dummy_seeg_brainset)
-        with pytest.raises(NotImplementedError, match="seeg_dataset_mixin_recording_infos"):
+        with pytest.raises(
+            NotImplementedError, match="seeg_dataset_mixin_recording_infos"
+        ):
             ds.get_recording_info("session1")
 
     def test_get_recording_info_raises_on_missing_recording(self, dummy_seeg_brainset):

--- a/tests/test_new_dataset.py
+++ b/tests/test_new_dataset.py
@@ -327,19 +327,6 @@ class TestSpikingDatasetMixin:
 
 
 class TestSEEGDatasetMixin:
-    def test_get_domain_intervals_uses_recording_domains(self, dummy_seeg_brainset):
-        ds = _SEEGDatasetWithConstant(dummy_seeg_brainset)
-
-        all_intervals = ds.get_domain_intervals()
-        assert set(all_intervals) == set(ds.recording_ids)
-
-        subset = ds.get_domain_intervals(recording_ids=["session2"])
-        assert list(subset) == ["session2"]
-
-    def test_get_domain_intervals_raises_on_unknown_ids(self, dummy_seeg_brainset):
-        ds = _SEEGDatasetWithConstant(dummy_seeg_brainset)
-        with pytest.raises(KeyError, match="Unknown recording_ids"):
-            ds.get_domain_intervals(recording_ids=["session3"])
     def test_get_channel_ids_are_recording_disambiguated(self, dummy_seeg_brainset):
         ds = _SEEGDatasetWithConstant(dummy_seeg_brainset)
 

--- a/tests/test_new_dataset.py
+++ b/tests/test_new_dataset.py
@@ -82,22 +82,6 @@ def create_multichannel_data(
     )
 
 
-class _MultiChannelDatasetWithConstant(MultiChannelDatasetMixin, Dataset):
-    pass
-
-
-class _MultiChannelDatasetWithConstantUniquify(_MultiChannelDatasetWithConstant):
-    multichannel_dataset_mixin_uniquify_channel_ids_with_subject = True
-    multichannel_dataset_mixin_uniquify_channel_ids_with_session = True
-
-
-class _MultiChannelDatasetWithConstantUniquifySubjectOnly(
-    _MultiChannelDatasetWithConstant
-):
-    multichannel_dataset_mixin_uniquify_channel_ids_with_subject = True
-    multichannel_dataset_mixin_uniquify_channel_ids_with_session = False
-
-
 @pytest.fixture
 def dummy_spiking_brainset(tmp_path):
     BRAINSET_ID = "mock_brainset"
@@ -334,7 +318,9 @@ class TestSpikingDatasetMixin:
 
 class TestMultiChannelDatasetMixin:
     def test_get_channel_ids_use_recording_view_ids(self, dummy_multichannel_brainset):
-        ds = _MultiChannelDatasetWithConstant(dummy_multichannel_brainset)
+        class MultiChannelDatasetWithConstant(MultiChannelDatasetMixin, Dataset): ...
+
+        ds = MultiChannelDatasetWithConstant(dummy_multichannel_brainset)
 
         all_ids = ds.get_channel_ids()
         assert all_ids == [
@@ -349,7 +335,13 @@ class TestMultiChannelDatasetMixin:
     def test_get_channel_ids_match_hook_uniquified_recording_ids(
         self, dummy_multichannel_brainset
     ):
-        ds = _MultiChannelDatasetWithConstantUniquify(dummy_multichannel_brainset)
+        class MultiChannelDatasetWithConstantUniquify(
+            MultiChannelDatasetMixin, Dataset
+        ):
+            multichannel_dataset_mixin_uniquify_channel_ids_with_subject = True
+            multichannel_dataset_mixin_uniquify_channel_ids_with_session = True
+
+        ds = MultiChannelDatasetWithConstantUniquify(dummy_multichannel_brainset)
 
         recording_ids = ds.get_recording("session1").channels.id.tolist()
         assert recording_ids == [
@@ -371,7 +363,13 @@ class TestMultiChannelDatasetMixin:
     def test_get_channel_ids_match_hook_uniquified_subject_only_ids(
         self, dummy_multichannel_brainset
     ):
-        ds = _MultiChannelDatasetWithConstantUniquifySubjectOnly(
+        class MultiChannelDatasetWithConstantUniquifySubjectOnly(
+            MultiChannelDatasetMixin, Dataset
+        ):
+            multichannel_dataset_mixin_uniquify_channel_ids_with_subject = True
+            multichannel_dataset_mixin_uniquify_channel_ids_with_session = False
+
+        ds = MultiChannelDatasetWithConstantUniquifySubjectOnly(
             dummy_multichannel_brainset
         )
 
@@ -392,21 +390,12 @@ class TestMultiChannelDatasetMixin:
             "bob/ch2",
         ]
 
-    def test_get_recording_hook_rejects_non_boolean_uniquify_flags(
-        self, dummy_multichannel_brainset
-    ):
-        ds = _MultiChannelDatasetWithConstant(dummy_multichannel_brainset)
-        ds.multichannel_dataset_mixin_uniquify_channel_ids_with_subject = "yes"
-        with pytest.raises(
-            TypeError,
-            match="multichannel_dataset_mixin_uniquify_channel_ids_with_subject",
-        ):
-            ds.get_recording("session1")
-
     def test_get_recording_hook_default_subject_only_uniquify(
         self, dummy_multichannel_brainset
     ):
-        ds = _MultiChannelDatasetWithConstant(dummy_multichannel_brainset)
+        class MultiChannelDatasetWithConstant(MultiChannelDatasetMixin, Dataset): ...
+
+        ds = MultiChannelDatasetWithConstant(dummy_multichannel_brainset)
         rec = ds.get_recording("session1")
 
         assert rec.channels.id.tolist() == [
@@ -415,23 +404,19 @@ class TestMultiChannelDatasetMixin:
             "alice/ch2",
         ]
 
-    def test_build_channel_prefix_raises_for_missing_requested_component(
+    def test_build_channel_prefix_raises_when_subject_metadata_missing(
         self, dummy_multichannel_brainset
     ):
-        ds = _MultiChannelDatasetWithConstant(dummy_multichannel_brainset)
+        class MultiChannelDatasetWithConstant(MultiChannelDatasetMixin, Dataset): ...
+
+        ds = MultiChannelDatasetWithConstant(dummy_multichannel_brainset)
         ds.multichannel_dataset_mixin_uniquify_channel_ids_with_subject = True
         ds.multichannel_dataset_mixin_uniquify_channel_ids_with_session = False
 
         class _MissingSubjectData:
-            @staticmethod
-            def get_nested_attribute(path):
-                if path == "subject.id":
-                    return None
-                if path == "session.id":
-                    return "session1"
-                raise AttributeError(path)
+            session = type("Session", (), {"id": "session1"})()
 
-        with pytest.raises(ValueError, match="'subject.id' is required"):
+        with pytest.raises(AttributeError):
             ds._build_multichannel_channel_id_prefix(_MissingSubjectData())
 
 

--- a/tests/test_new_dataset.py
+++ b/tests/test_new_dataset.py
@@ -135,6 +135,10 @@ class _SEEGDatasetWithConstant(SEEGDatasetMixin, Dataset):
     seeg_dataset_mixin_sampling_rate_hz = 256.0
 
 
+class _SEEGDatasetWithConstantUniquify(_SEEGDatasetWithConstant):
+    seeg_dataset_mixin_uniquify_channel_ids = True
+
+
 def configure_seeg_dataset_caches(
     ds,
     *,
@@ -485,6 +489,37 @@ class TestSEEGDatasetMixin:
             "ch0/session2",
             "ch2/session1",
             "ch2/session2",
+        ]
+
+    def test_get_channel_ids_match_hook_uniquified_recording_ids(
+        self, dummy_seeg_brainset
+    ):
+        ds = _SEEGDatasetWithConstantUniquify(dummy_seeg_brainset)
+        configure_seeg_dataset_caches(ds, channel_views=True)
+
+        recording_ids = ds.get_recording("session1").channels.id.tolist()
+        assert recording_ids == [
+            "alice/session1/ch0",
+            "alice/session1/ch1",
+            "alice/session1/ch2",
+        ]
+
+        all_ids = ds.get_channel_ids()
+        assert all_ids == [
+            "alice/session1/ch0",
+            "alice/session1/ch1",
+            "alice/session1/ch2",
+            "bob/session2/ch0",
+            "bob/session2/ch1",
+            "bob/session2/ch2",
+        ]
+
+        included_ids = ds.get_channel_ids(included_only=True)
+        assert included_ids == [
+            "alice/session1/ch0",
+            "alice/session1/ch2",
+            "bob/session2/ch0",
+            "bob/session2/ch2",
         ]
 
     def test_get_recording_info(self, dummy_seeg_brainset):

--- a/tests/test_new_dataset.py
+++ b/tests/test_new_dataset.py
@@ -80,59 +80,8 @@ def create_seeg_data(brainset_id, subject_id, session_id, length, sampling_rate=
     )
 
 
-def build_seeg_channel_view_cache(ds):
-    channel_views = {}
-    for rid in ds.recording_ids:
-        rec = ds.get_recording(rid)
-        channels = rec.channels
-        ids = np.asarray(channels.id)
-        names = np.asarray(getattr(channels, "name", ids))
-        included_mask = np.asarray(
-            getattr(channels, "included", np.ones(len(ids), dtype=bool)),
-            dtype=bool,
-        )
-        lip = None
-        if all(
-            hasattr(channels, attr)
-            for attr in ("localization_L", "localization_I", "localization_P")
-        ):
-            lip = np.stack(
-                (
-                    np.asarray(channels.localization_L, dtype=float),
-                    np.asarray(channels.localization_I, dtype=float),
-                    np.asarray(channels.localization_P, dtype=float),
-                ),
-                axis=1,
-            )
-
-        channel_views[rid] = SEEGDatasetMixin.ChannelView(
-            ids=ids,
-            names=names,
-            included_mask=included_mask,
-            lip=lip,
-        )
-    return channel_views
-
-
-def build_seeg_recording_info_cache(ds):
-    infos = {}
-    for rid in ds.recording_ids:
-        rec = ds.get_recording(rid)
-        channel_view = ds.seeg_dataset_mixin_channel_views[rid]
-        infos[rid] = SEEGDatasetMixin.RecordingInfo(
-            recording_id=rid,
-            subject_id=rec.subject.id,
-            session_id=rec.session.id,
-            sampling_rate_hz=ds.get_sampling_rate(rid),
-            domain=ds.seeg_dataset_mixin_domain_intervals[rid],
-            n_channels=int(len(channel_view.ids)),
-            n_included_channels=int(np.sum(channel_view.included_mask)),
-        )
-    return infos
-
-
 class _SEEGDatasetWithConstant(SEEGDatasetMixin, Dataset):
-    seeg_dataset_mixin_sampling_rate_hz = 256.0
+    pass
 
 
 class _SEEGDatasetWithConstantUniquify(_SEEGDatasetWithConstant):
@@ -141,29 +90,6 @@ class _SEEGDatasetWithConstantUniquify(_SEEGDatasetWithConstant):
 
 class _SEEGDatasetWithConstantUniquifySubjectOnly(_SEEGDatasetWithConstant):
     seeg_dataset_mixin_uniquify_channel_ids = {"subject_id"}
-
-
-def configure_seeg_dataset_caches(
-    ds,
-    *,
-    domain: bool = False,
-    channel_views: bool = False,
-    recording_infos: bool = False,
-):
-    if domain:
-        ds.seeg_dataset_mixin_domain_intervals = {
-            rid: ds.get_recording(rid).seeg_data.domain for rid in ds.recording_ids
-        }
-    if channel_views:
-        ds.seeg_dataset_mixin_channel_views = build_seeg_channel_view_cache(ds)
-    if recording_infos:
-        if not domain:
-            ds.seeg_dataset_mixin_domain_intervals = {
-                rid: ds.get_recording(rid).seeg_data.domain for rid in ds.recording_ids
-            }
-        if not channel_views:
-            ds.seeg_dataset_mixin_channel_views = build_seeg_channel_view_cache(ds)
-        ds.seeg_dataset_mixin_recording_infos = build_seeg_recording_info_cache(ds)
 
 
 @pytest.fixture
@@ -401,81 +327,8 @@ class TestSpikingDatasetMixin:
 
 
 class TestSEEGDatasetMixin:
-    def test_get_sampling_rate(self, dummy_seeg_brainset):
-        ds = _SEEGDatasetWithConstant(dummy_seeg_brainset)
-        assert ds.get_sampling_rate() == 256.0
-        assert ds.get_sampling_rate("session2") == 256.0
-
-    def test_get_sampling_rate_requires_dataset_constant(self, dummy_seeg_brainset):
-        class SEEGDataset(SEEGDatasetMixin, Dataset): ...
-
-        ds = SEEGDataset(dummy_seeg_brainset)
-        with pytest.raises(
-            NotImplementedError, match="seeg_dataset_mixin_sampling_rate_hz"
-        ):
-            ds.get_sampling_rate()
-
-    def test_get_domain_intervals_uses_dataset_cache(self, dummy_seeg_brainset):
-        ds = _SEEGDatasetWithConstant(dummy_seeg_brainset)
-        configure_seeg_dataset_caches(ds, domain=True)
-
-        all_intervals = ds.get_domain_intervals()
-        assert set(all_intervals) == set(ds.recording_ids)
-
-        subset = ds.get_domain_intervals(recording_ids=["session2"])
-        assert list(subset) == ["session2"]
-
-    def test_get_domain_intervals_requires_dataset_cache(self, dummy_seeg_brainset):
-        ds = _SEEGDatasetWithConstant(dummy_seeg_brainset)
-        with pytest.raises(
-            NotImplementedError, match="seeg_dataset_mixin_domain_intervals"
-        ):
-            ds.get_domain_intervals()
-
-    def test_get_domain_intervals_raises_on_missing_ids(self, dummy_seeg_brainset):
-        ds = _SEEGDatasetWithConstant(dummy_seeg_brainset)
-        ds.seeg_dataset_mixin_domain_intervals = {
-            "session1": ds.get_recording("session1").seeg_data.domain
-        }
-        with pytest.raises(KeyError, match="Missing domain intervals"):
-            ds.get_domain_intervals(recording_ids=["session2"])
-
-    def test_get_channel_view(self, dummy_seeg_brainset):
-        ds = _SEEGDatasetWithConstant(dummy_seeg_brainset)
-        configure_seeg_dataset_caches(ds, domain=True, channel_views=True)
-        full_view = ds.get_channel_view("session1", included_only=False)
-        included_view = ds.get_channel_view("session1", included_only=True)
-
-        assert full_view.ids.tolist() == ["ch0", "ch1", "ch2"]
-        assert full_view.names.tolist() == ["C0", "C1", "C2"]
-        assert full_view.included_mask.tolist() == [True, False, True]
-        assert full_view.lip is not None
-        assert full_view.lip.shape == (3, 3)
-
-        assert included_view.ids.tolist() == ["ch0", "ch2"]
-        assert included_view.names.tolist() == ["C0", "C2"]
-        assert included_view.included_mask.tolist() == [True, True]
-        assert included_view.lip is not None
-        assert included_view.lip.shape == (2, 3)
-
-    def test_get_channel_view_requires_dataset_cache(self, dummy_seeg_brainset):
-        ds = _SEEGDatasetWithConstant(dummy_seeg_brainset)
-        with pytest.raises(
-            NotImplementedError, match="seeg_dataset_mixin_channel_views"
-        ):
-            ds.get_channel_view("session1")
-
-    def test_get_channel_view_raises_on_missing_recording(self, dummy_seeg_brainset):
-        ds = _SEEGDatasetWithConstant(dummy_seeg_brainset)
-        ds.seeg_dataset_mixin_channel_views = {
-            "session1": build_seeg_channel_view_cache(ds)["session1"]
-        }
-        with pytest.raises(KeyError, match="Missing channel view"):
-            ds.get_channel_view("session2")
-
     def test_get_channel_ids_are_recording_disambiguated(self, dummy_seeg_brainset):
         ds = _SEEGDatasetWithConstant(dummy_seeg_brainset)
-        configure_seeg_dataset_caches(ds, channel_views=True)
 
         all_ids = ds.get_channel_ids()
         assert all_ids == [
@@ -499,7 +352,6 @@ class TestSEEGDatasetMixin:
         self, dummy_seeg_brainset
     ):
         ds = _SEEGDatasetWithConstantUniquify(dummy_seeg_brainset)
-        configure_seeg_dataset_caches(ds, channel_views=True)
 
         recording_ids = ds.get_recording("session1").channels.id.tolist()
         assert recording_ids == [
@@ -530,7 +382,6 @@ class TestSEEGDatasetMixin:
         self, dummy_seeg_brainset
     ):
         ds = _SEEGDatasetWithConstantUniquifySubjectOnly(dummy_seeg_brainset)
-        configure_seeg_dataset_caches(ds, channel_views=True)
 
         recording_ids = ds.get_recording("session1").channels.id.tolist()
         assert recording_ids == [
@@ -556,41 +407,6 @@ class TestSEEGDatasetMixin:
         ds.seeg_dataset_mixin_uniquify_channel_ids = {"subject_id", "bad_component"}
         with pytest.raises(ValueError, match="Invalid channel uniquify components"):
             ds.get_recording("session1")
-
-    def test_get_recording_info(self, dummy_seeg_brainset):
-        ds = _SEEGDatasetWithConstant(dummy_seeg_brainset)
-        configure_seeg_dataset_caches(ds, recording_infos=True)
-        info = ds.get_recording_info("session1")
-
-        assert info.recording_id == "session1"
-        assert info.subject_id == "alice"
-        assert info.session_id == "session1"
-        assert info.sampling_rate_hz == 256.0
-        assert info.n_channels == 3
-        assert info.n_included_channels == 2
-
-    def test_get_recording_info_requires_dataset_cache(self, dummy_seeg_brainset):
-        ds = _SEEGDatasetWithConstant(dummy_seeg_brainset)
-        with pytest.raises(
-            NotImplementedError, match="seeg_dataset_mixin_recording_infos"
-        ):
-            ds.get_recording_info("session1")
-
-    def test_get_recording_info_raises_on_missing_recording(self, dummy_seeg_brainset):
-        ds = _SEEGDatasetWithConstant(dummy_seeg_brainset)
-        ds.seeg_dataset_mixin_recording_infos = {
-            "session1": SEEGDatasetMixin.RecordingInfo(
-                recording_id="session1",
-                subject_id="alice",
-                session_id="session1",
-                sampling_rate_hz=256.0,
-                domain=Interval(0, 1.0),
-                n_channels=3,
-                n_included_channels=2,
-            )
-        }
-        with pytest.raises(KeyError, match="Missing recording info"):
-            ds.get_recording_info("session2")
 
 
 def test_ensure_index_has_namespace():

--- a/tests/test_new_dataset.py
+++ b/tests/test_new_dataset.py
@@ -327,6 +327,19 @@ class TestSpikingDatasetMixin:
 
 
 class TestSEEGDatasetMixin:
+    def test_get_domain_intervals_uses_recording_domains(self, dummy_seeg_brainset):
+        ds = _SEEGDatasetWithConstant(dummy_seeg_brainset)
+
+        all_intervals = ds.get_domain_intervals()
+        assert set(all_intervals) == set(ds.recording_ids)
+
+        subset = ds.get_domain_intervals(recording_ids=["session2"])
+        assert list(subset) == ["session2"]
+
+    def test_get_domain_intervals_raises_on_unknown_ids(self, dummy_seeg_brainset):
+        ds = _SEEGDatasetWithConstant(dummy_seeg_brainset)
+        with pytest.raises(KeyError, match="Unknown recording_ids"):
+            ds.get_domain_intervals(recording_ids=["session3"])
     def test_get_channel_ids_are_recording_disambiguated(self, dummy_seeg_brainset):
         ds = _SEEGDatasetWithConstant(dummy_seeg_brainset)
 

--- a/tests/test_new_dataset.py
+++ b/tests/test_new_dataset.py
@@ -85,14 +85,15 @@ class _MultiChannelDatasetWithConstant(MultiChannelDatasetMixin, Dataset):
 
 
 class _MultiChannelDatasetWithConstantUniquify(_MultiChannelDatasetWithConstant):
-    seeg_dataset_mixin_uniquify_channel_ids_with_subject = True
-    seeg_dataset_mixin_uniquify_channel_ids_with_session = True
+    multichannel_dataset_mixin_uniquify_channel_ids_with_subject = True
+    multichannel_dataset_mixin_uniquify_channel_ids_with_session = True
 
 
 class _MultiChannelDatasetWithConstantUniquifySubjectOnly(
     _MultiChannelDatasetWithConstant
 ):
-    seeg_dataset_mixin_uniquify_channel_ids_with_subject = True
+    multichannel_dataset_mixin_uniquify_channel_ids_with_subject = True
+    multichannel_dataset_mixin_uniquify_channel_ids_with_session = False
 
 
 @pytest.fixture
@@ -343,14 +344,6 @@ class TestMultiChannelDatasetMixin:
             "bob/ch2",
         ]
 
-        included_ids = ds.get_channel_ids(included_only=True)
-        assert included_ids == [
-            "alice/ch0",
-            "alice/ch2",
-            "bob/ch0",
-            "bob/ch2",
-        ]
-
     def test_get_channel_ids_match_hook_uniquified_recording_ids(
         self, dummy_seeg_brainset
     ):
@@ -370,14 +363,6 @@ class TestMultiChannelDatasetMixin:
             "alice/session1/ch2",
             "bob/session2/ch0",
             "bob/session2/ch1",
-            "bob/session2/ch2",
-        ]
-
-        included_ids = ds.get_channel_ids(included_only=True)
-        assert included_ids == [
-            "alice/session1/ch0",
-            "alice/session1/ch2",
-            "bob/session2/ch0",
             "bob/session2/ch2",
         ]
 
@@ -407,28 +392,43 @@ class TestMultiChannelDatasetMixin:
         self, dummy_seeg_brainset
     ):
         ds = _MultiChannelDatasetWithConstant(dummy_seeg_brainset)
-        ds.seeg_dataset_mixin_uniquify_channel_ids_with_subject = "yes"
+        ds.multichannel_dataset_mixin_uniquify_channel_ids_with_subject = "yes"
         with pytest.raises(
             TypeError,
-            match="seeg_dataset_mixin_uniquify_channel_ids_with_subject",
+            match="multichannel_dataset_mixin_uniquify_channel_ids_with_subject",
         ):
             ds.get_recording("session1")
 
-    def test_get_recording_hook_warns_for_session_only_uniquify(
+    def test_get_recording_hook_default_subject_only_uniquify(
         self, dummy_seeg_brainset
     ):
         ds = _MultiChannelDatasetWithConstant(dummy_seeg_brainset)
-        ds.seeg_dataset_mixin_uniquify_channel_ids_with_subject = False
-        ds.seeg_dataset_mixin_uniquify_channel_ids_with_session = True
-
-        with pytest.warns(UserWarning, match="session only"):
-            rec = ds.get_recording("session1")
+        rec = ds.get_recording("session1")
 
         assert rec.channels.id.tolist() == [
-            "session1/ch0",
-            "session1/ch1",
-            "session1/ch2",
+            "alice/ch0",
+            "alice/ch1",
+            "alice/ch2",
         ]
+
+    def test_build_channel_prefix_raises_for_missing_requested_component(
+        self, dummy_seeg_brainset
+    ):
+        ds = _MultiChannelDatasetWithConstant(dummy_seeg_brainset)
+        ds.multichannel_dataset_mixin_uniquify_channel_ids_with_subject = True
+        ds.multichannel_dataset_mixin_uniquify_channel_ids_with_session = False
+
+        class _MissingSubjectData:
+            @staticmethod
+            def get_nested_attribute(path):
+                if path == "subject.id":
+                    return None
+                if path == "session.id":
+                    return "session1"
+                raise AttributeError(path)
+
+        with pytest.raises(ValueError, match="'subject.id' is required"):
+            ds._build_multichannel_channel_id_prefix(_MissingSubjectData())
 
 
 def test_ensure_index_has_namespace():

--- a/tests/test_new_dataset.py
+++ b/tests/test_new_dataset.py
@@ -20,7 +20,7 @@ from brainsets.descriptions import (
 from brainsets.taxonomy import Species
 
 from torch_brain.dataset import Dataset, DatasetIndex, NestedDataset
-from torch_brain.dataset.mixins import SpikingDatasetMixin, SEEGDatasetMixin
+from torch_brain.dataset.mixins import SpikingDatasetMixin, MultiChannelDatasetMixin
 
 
 def create_spiking_data(brainset_id, subject_id, session_id, length):
@@ -80,16 +80,19 @@ def create_seeg_data(brainset_id, subject_id, session_id, length, sampling_rate=
     )
 
 
-class _SEEGDatasetWithConstant(SEEGDatasetMixin, Dataset):
+class _MultiChannelDatasetWithConstant(MultiChannelDatasetMixin, Dataset):
     pass
 
 
-class _SEEGDatasetWithConstantUniquify(_SEEGDatasetWithConstant):
-    seeg_dataset_mixin_uniquify_channel_ids = {"subject_id", "session_id"}
+class _MultiChannelDatasetWithConstantUniquify(_MultiChannelDatasetWithConstant):
+    seeg_dataset_mixin_uniquify_channel_ids_with_subject = True
+    seeg_dataset_mixin_uniquify_channel_ids_with_session = True
 
 
-class _SEEGDatasetWithConstantUniquifySubjectOnly(_SEEGDatasetWithConstant):
-    seeg_dataset_mixin_uniquify_channel_ids = {"subject_id"}
+class _MultiChannelDatasetWithConstantUniquifySubjectOnly(
+    _MultiChannelDatasetWithConstant
+):
+    seeg_dataset_mixin_uniquify_channel_ids_with_subject = True
 
 
 @pytest.fixture
@@ -326,32 +329,32 @@ class TestSpikingDatasetMixin:
         assert actual_unit_ids == expected_unit_ids
 
 
-class TestSEEGDatasetMixin:
+class TestMultiChannelDatasetMixin:
     def test_get_channel_ids_use_recording_view_ids(self, dummy_seeg_brainset):
-        ds = _SEEGDatasetWithConstant(dummy_seeg_brainset)
+        ds = _MultiChannelDatasetWithConstant(dummy_seeg_brainset)
 
         all_ids = ds.get_channel_ids()
         assert all_ids == [
-            "ch0",
-            "ch0",
-            "ch1",
-            "ch1",
-            "ch2",
-            "ch2",
+            "alice/ch0",
+            "alice/ch1",
+            "alice/ch2",
+            "bob/ch0",
+            "bob/ch1",
+            "bob/ch2",
         ]
 
         included_ids = ds.get_channel_ids(included_only=True)
         assert included_ids == [
-            "ch0",
-            "ch0",
-            "ch2",
-            "ch2",
+            "alice/ch0",
+            "alice/ch2",
+            "bob/ch0",
+            "bob/ch2",
         ]
 
     def test_get_channel_ids_match_hook_uniquified_recording_ids(
         self, dummy_seeg_brainset
     ):
-        ds = _SEEGDatasetWithConstantUniquify(dummy_seeg_brainset)
+        ds = _MultiChannelDatasetWithConstantUniquify(dummy_seeg_brainset)
 
         recording_ids = ds.get_recording("session1").channels.id.tolist()
         assert recording_ids == [
@@ -381,7 +384,7 @@ class TestSEEGDatasetMixin:
     def test_get_channel_ids_match_hook_uniquified_subject_only_ids(
         self, dummy_seeg_brainset
     ):
-        ds = _SEEGDatasetWithConstantUniquifySubjectOnly(dummy_seeg_brainset)
+        ds = _MultiChannelDatasetWithConstantUniquifySubjectOnly(dummy_seeg_brainset)
 
         recording_ids = ds.get_recording("session1").channels.id.tolist()
         assert recording_ids == [
@@ -400,12 +403,15 @@ class TestSEEGDatasetMixin:
             "bob/ch2",
         ]
 
-    def test_get_recording_hook_rejects_invalid_uniquify_components(
+    def test_get_recording_hook_rejects_non_boolean_uniquify_flags(
         self, dummy_seeg_brainset
     ):
-        ds = _SEEGDatasetWithConstant(dummy_seeg_brainset)
-        ds.seeg_dataset_mixin_uniquify_channel_ids = {"subject_id", "bad_component"}
-        with pytest.raises(ValueError, match="Invalid channel uniquify components"):
+        ds = _MultiChannelDatasetWithConstant(dummy_seeg_brainset)
+        ds.seeg_dataset_mixin_uniquify_channel_ids_with_subject = "yes"
+        with pytest.raises(
+            TypeError,
+            match="seeg_dataset_mixin_uniquify_channel_ids_with_subject",
+        ):
             ds.get_recording("session1")
 
 

--- a/torch_brain/dataset/__init__.py
+++ b/torch_brain/dataset/__init__.py
@@ -1,3 +1,3 @@
 from .dataset import Dataset, DatasetIndex
 from .nested import NestedDataset, NestedSpikingDataset
-from .mixins import SpikingDatasetMixin, CalciumImagingDatasetMixin
+from .mixins import SpikingDatasetMixin, CalciumImagingDatasetMixin, SEEGDatasetMixin

--- a/torch_brain/dataset/__init__.py
+++ b/torch_brain/dataset/__init__.py
@@ -1,3 +1,8 @@
 from .dataset import Dataset, DatasetIndex
 from .nested import NestedDataset, NestedSpikingDataset
-from .mixins import SpikingDatasetMixin, CalciumImagingDatasetMixin, SEEGDatasetMixin
+from .mixins import (
+    SpikingDatasetMixin,
+    CalciumImagingDatasetMixin,
+    MultiChannelDatasetMixin,
+    SEEGDatasetMixin,
+)

--- a/torch_brain/dataset/__init__.py
+++ b/torch_brain/dataset/__init__.py
@@ -4,5 +4,4 @@ from .mixins import (
     SpikingDatasetMixin,
     CalciumImagingDatasetMixin,
     MultiChannelDatasetMixin,
-    SEEGDatasetMixin,
 )

--- a/torch_brain/dataset/mixins.py
+++ b/torch_brain/dataset/mixins.py
@@ -160,7 +160,9 @@ class SEEGDatasetMixin:
             else:
                 prefix = ""
             if prefix:
-                data.channels.id = np_string_prefix(prefix, data.channels.id.astype(str))
+                data.channels.id = np_string_prefix(
+                    prefix, data.channels.id.astype(str)
+                )
         super().get_recording_hook(data)
 
     def get_sampling_rate(self, recording_id: str | None = None) -> float:
@@ -234,7 +236,9 @@ class SEEGDatasetMixin:
                 ids = np.asarray(rec.channels.id).astype(str)
                 if included_only:
                     included_mask = np.asarray(
-                        getattr(rec.channels, "included", np.ones(len(ids), dtype=bool)),
+                        getattr(
+                            rec.channels, "included", np.ones(len(ids), dtype=bool)
+                        ),
                         dtype=bool,
                     )
                     ids = ids[included_mask]

--- a/torch_brain/dataset/mixins.py
+++ b/torch_brain/dataset/mixins.py
@@ -92,7 +92,7 @@ class CalciumImagingDatasetMixin:
 class MultiChannelDatasetMixin:
     """
     Mixin class for :class:`torch_brain.dataset.Dataset` subclasses containing
-    multi-channel recordings (e.g., sEEG).
+    multi-channel recordings (e.g., EEG, ECoG, EMG, sEEG, etc).
 
     Provides:
         - ``get_channel_ids()`` for retrieving sorted channel IDs from
@@ -102,7 +102,10 @@ class MultiChannelDatasetMixin:
           ``multichannel_dataset_mixin_uniquify_channel_ids_with_session``
           prepends ``session.id`` (default ``False``) and
           ``multichannel_dataset_mixin_uniquify_channel_ids_with_subject``
-          prepends ``subject.id`` (default ``True``). If both are enabled,
+          prepends ``subject.id`` (default ``True``). This ``subject.id``
+          uniquification allows channels with the same name in the same
+          subject to be treated as the same channel across sessions. If both
+          are enabled,
           the prefix order is ``subject.id/session.id``.
     """
 

--- a/torch_brain/dataset/mixins.py
+++ b/torch_brain/dataset/mixins.py
@@ -123,53 +123,13 @@ class MultiChannelDatasetMixin:
             )
         super().get_recording_hook(data)
 
-    def _normalize_channel_uniquify_components(self) -> tuple[str, ...]:
-        with_subject = self.multichannel_dataset_mixin_uniquify_channel_ids_with_subject
-        with_session = self.multichannel_dataset_mixin_uniquify_channel_ids_with_session
-        if not isinstance(with_subject, bool):
-            raise TypeError(
-                "'multichannel_dataset_mixin_uniquify_channel_ids_with_subject' must be "
-                f"bool; got {type(with_subject).__name__}."
-            )
-        if not isinstance(with_session, bool):
-            raise TypeError(
-                "'multichannel_dataset_mixin_uniquify_channel_ids_with_session' must be "
-                f"bool; got {type(with_session).__name__}."
-            )
-
-        components = []
-        if with_subject:
-            components.append("subject_id")
-        if with_session:
-            components.append("session_id")
-        return tuple(components)
-
     def _build_multichannel_channel_id_prefix(self, data: Data) -> str:
-        components = self._normalize_channel_uniquify_components()
-        if not components:
-            return ""
-
-        component_paths = {
-            "subject_id": "subject.id",
-            "session_id": "session.id",
-        }
-        prefix_parts = []
-        for component in components:
-            path = component_paths[component]
-            component_name = component.split("_")[0]
-            error_msg = (
-                f"'{path}' is required when "
-                f"'multichannel_dataset_mixin_uniquify_channel_ids_with_"
-                f"{component_name}' is enabled."
-            )
-            try:
-                value = data.get_nested_attribute(path)
-            except AttributeError as exc:
-                raise ValueError(error_msg) from exc
-            if value is None:
-                raise ValueError(error_msg)
-            prefix_parts.append(str(value))
-        return "/".join(prefix_parts) + "/"
+        prefix = ""
+        if self.multichannel_dataset_mixin_uniquify_channel_ids_with_subject:
+            prefix += f"{data.subject.id}/"
+        if self.multichannel_dataset_mixin_uniquify_channel_ids_with_session:
+            prefix += f"{data.session.id}/"
+        return prefix
 
     def get_channel_ids(self) -> list[str]:
         """Return sorted channel IDs across recordings.

--- a/torch_brain/dataset/mixins.py
+++ b/torch_brain/dataset/mixins.py
@@ -94,8 +94,8 @@ class SEEGDatasetMixin:
     Mixin class for :class:`torch_brain.dataset.Dataset` subclasses containing sEEG data.
 
     Provides:
-        - ``get_channel_ids()`` for retrieving recording-disambiguated
-          channel IDs in ``<channel_id>/<recording_id>`` format.
+        - ``get_channel_ids()`` for retrieving sorted channel IDs from
+          recording views returned by ``get_recording(...)``.
     """
 
     # Channel-ID components used for hook-based uniquification.
@@ -156,9 +156,10 @@ class SEEGDatasetMixin:
     def get_channel_ids(self, *, included_only: bool = False) -> list[str]:
         """Return sorted channel IDs across recordings.
 
-        When channel-ID uniquification is enabled, this reuses ``get_recording(...)``
-        so the returned IDs exactly match the hook-mutated recording view. Otherwise
-        it falls back to ``<channel_id>/<recording_id>`` disambiguation.
+        ``get_channel_ids`` aggregates ``rec.channels.id`` from ``get_recording(...)``.
+        Any subject/session uniquification is applied there according to
+        ``seeg_dataset_mixin_uniquify_channel_ids``. ``included_only=True`` filters
+        by ``rec.channels.included`` before IDs are collected.
         """
         all_ids = []
         for rid in self.recording_ids:
@@ -170,12 +171,7 @@ class SEEGDatasetMixin:
                     dtype=bool,
                 )
                 ids = ids[included_mask]
-
-            if self.seeg_dataset_mixin_uniquify_channel_ids:
-                all_ids.append(ids)
-                continue
-            # Postfix recording ID to avoid cross-recording collisions.
-            all_ids.append(np.char.add(np.char.add(ids, "/"), rid))
+            all_ids.append(ids)
         if not all_ids:
             return []
         return np.sort(np.concatenate(all_ids).astype(str)).tolist()

--- a/torch_brain/dataset/mixins.py
+++ b/torch_brain/dataset/mixins.py
@@ -167,9 +167,7 @@ class MultiChannelDatasetMixin:
             rec = self.get_recording(rid)
             ids = np.asarray(rec.channels.id).astype(str)
             if included_only:
-                included_mask = np.asarray(rec.channels.included,
-                    dtype=bool,
-                )
+                included_mask = np.asarray(rec.channels.included, dtype=bool)
                 ids = ids[included_mask]
             all_ids.append(ids)
         if not all_ids:

--- a/torch_brain/dataset/mixins.py
+++ b/torch_brain/dataset/mixins.py
@@ -1,7 +1,6 @@
-from dataclasses import dataclass
 import numpy as np
 import pandas as pd
-from temporaldata import Data, Interval
+from temporaldata import Data
 
 from torch_brain.utils import np_string_prefix
 
@@ -95,73 +94,29 @@ class SEEGDatasetMixin:
     Mixin class for :class:`torch_brain.dataset.Dataset` subclasses containing sEEG data.
 
     Provides:
-        - ``get_sampling_rate()`` for retrieving signal sampling rate (Hz).
-          Requires dataset classes to define
-          ``seeg_dataset_mixin_sampling_rate_hz``.
-        - ``get_domain_intervals()`` for retrieving full-domain intervals.
-          Requires dataset classes to define
-          ``seeg_dataset_mixin_domain_intervals``.
-        - ``get_channel_view()`` for normalized channel metadata access.
-          Requires dataset classes to define
-          ``seeg_dataset_mixin_channel_views`` with full channel views.
+        - ``get_domain_intervals()`` for full-domain intervals
+          (inherited from :class:`torch_brain.dataset.Dataset`).
         - ``get_channel_ids()`` for retrieving recording-disambiguated
           channel IDs in ``<channel_id>/<recording_id>`` format.
-        - ``get_recording_info()`` for compact per-recording metadata.
-          Requires dataset classes to define
-          ``seeg_dataset_mixin_recording_infos``.
+        - ``get_channel_arrays()`` for normalized channel metadata access
+          (inherited from :class:`torch_brain.dataset.Dataset`).
     """
 
-    # Dataset classes should set this to expose a stable sampling-rate contract.
-    seeg_dataset_mixin_sampling_rate_hz: float | None = None
-    # Dataset classes should set this with all available recording-domain intervals.
-    seeg_dataset_mixin_domain_intervals: dict[str, Interval] | None = None
-    # Dataset classes should set this with full channel views for each recording.
-    seeg_dataset_mixin_channel_views: (
-        dict[str, "SEEGDatasetMixin.ChannelView"] | None
-    ) = None
-    # Dataset classes should set this with compact recording metadata.
-    seeg_dataset_mixin_recording_infos: (
-        dict[str, "SEEGDatasetMixin.RecordingInfo"] | None
-    ) = None
     # Channel-ID components used for hook-based uniquification.
     # Supported values are "subject_id" and "session_id".
     # Example: {"subject_id"} for subject-only prefixes.
     seeg_dataset_mixin_uniquify_channel_ids: set[str] | frozenset[str] = frozenset()
-
-    @dataclass(frozen=True)
-    class ChannelView:
-        """Channel metadata view for one recording."""
-
-        ids: np.ndarray
-        names: np.ndarray
-        included_mask: np.ndarray
-        # Channel coordinates ordered as (L, I, P), or ``None`` when unavailable.
-        lip: np.ndarray | None
-
-    @dataclass(frozen=True)
-    class RecordingInfo:
-        """Compact metadata summary for one recording."""
-
-        recording_id: str
-        subject_id: str | int | None
-        session_id: str | int | None
-        sampling_rate_hz: float
-        domain: Interval
-        n_channels: int
-        n_included_channels: int
+    _SEEG_CHANNEL_ID_COMPONENT_ORDER: tuple[str, str] = ("subject_id", "session_id")
 
     def get_recording_hook(self, data: Data):
-        if self.seeg_dataset_mixin_uniquify_channel_ids:
-            prefix = self._build_seeg_channel_id_prefix(data)
-            if prefix:
-                data.channels.id = np_string_prefix(
-                    prefix, data.channels.id.astype(str)
-                )
+        prefix = self._build_seeg_channel_id_prefix(data)
+        if prefix:
+            data.channels.id = np_string_prefix(prefix, data.channels.id.astype(str))
         super().get_recording_hook(data)
 
-    def _normalize_channel_uniquify_components(self) -> set[str]:
+    def _normalize_channel_uniquify_components(self) -> tuple[str, ...]:
         config = self.seeg_dataset_mixin_uniquify_channel_ids
-        valid_components = {"subject_id", "session_id"}
+        valid_components = set(self._SEEG_CHANNEL_ID_COMPONENT_ORDER)
 
         if not isinstance(config, (set, frozenset)):
             raise TypeError(
@@ -178,82 +133,29 @@ class SEEGDatasetMixin:
                 f"{invalid_str}. Expected subset of "
                 f"{sorted(valid_components)}."
             )
-        return normalized
+        return tuple(
+            component
+            for component in self._SEEG_CHANNEL_ID_COMPONENT_ORDER
+            if component in normalized
+        )
 
     def _build_seeg_channel_id_prefix(self, data: Data) -> str:
         components = self._normalize_channel_uniquify_components()
         if not components:
             return ""
 
-        subject_id = getattr(getattr(data, "subject", None), "id", None)
-        session_id = getattr(getattr(data, "session", None), "id", None)
-
-        # Keep deterministic ordering regardless of set iteration order.
-        prefix_parts = []
-        if "subject_id" in components and subject_id is not None:
-            prefix_parts.append(str(subject_id))
-        if "session_id" in components and session_id is not None:
-            prefix_parts.append(str(session_id))
+        component_values = {
+            "subject_id": getattr(getattr(data, "subject", None), "id", None),
+            "session_id": getattr(getattr(data, "session", None), "id", None),
+        }
+        prefix_parts = [
+            str(component_values[component])
+            for component in components
+            if component_values[component] is not None
+        ]
         if not prefix_parts:
             return ""
         return "/".join(prefix_parts) + "/"
-
-    def get_sampling_rate(self, recording_id: str | None = None) -> float:
-        """Return recording sampling rate in Hz."""
-        _ = recording_id  # keep signature compatible with per-recording datasets
-        if self.seeg_dataset_mixin_sampling_rate_hz is None:
-            raise NotImplementedError(
-                "SEEG datasets must define 'seeg_dataset_mixin_sampling_rate_hz'."
-            )
-        return float(self.seeg_dataset_mixin_sampling_rate_hz)
-
-    def get_domain_intervals(
-        self, recording_ids: list[str] | None = None
-    ) -> dict[str, Interval]:
-        """Return full-domain intervals for the provided recordings."""
-        # Domain intervals are dataset-specific and should be precomputed at init.
-        if self.seeg_dataset_mixin_domain_intervals is None:
-            raise NotImplementedError(
-                "SEEG datasets must define 'seeg_dataset_mixin_domain_intervals'."
-            )
-        ids = self.recording_ids if recording_ids is None else recording_ids
-        missing = [
-            rid for rid in ids if rid not in self.seeg_dataset_mixin_domain_intervals
-        ]
-        if missing:
-            raise KeyError(f"Missing domain intervals for recording_ids: {missing}")
-        return {rid: self.seeg_dataset_mixin_domain_intervals[rid] for rid in ids}
-
-    def get_channel_view(
-        self, recording_id: str, *, included_only: bool = False
-    ) -> "SEEGDatasetMixin.ChannelView":
-        """Return normalized channel metadata and optional LIP coordinates."""
-        # Full channel views come from dataset-managed cache so schema conversion stays local.
-        if self.seeg_dataset_mixin_channel_views is None:
-            raise NotImplementedError(
-                "SEEG datasets must define 'seeg_dataset_mixin_channel_views'."
-            )
-
-        if recording_id not in self.seeg_dataset_mixin_channel_views:
-            raise KeyError(f"Missing channel view for recording_id '{recording_id}'.")
-
-        full_view = self.seeg_dataset_mixin_channel_views[recording_id]
-        if not included_only:
-            return full_view
-
-        # Included-only views are frequently requested by samplers/evaluators.
-        # Cache the derived filtered view to avoid repeated mask application.
-        included_cache = self._get_seeg_included_channel_view_cache()
-        if recording_id in included_cache:
-            # Keep the source full-view identity so we can invalidate stale derived
-            # views if datasets replace full channel views after initialization.
-            source_view_id, included_view = included_cache[recording_id]
-            if source_view_id == id(full_view):
-                return included_view
-
-        included_view = self._filter_included_channels(full_view)
-        included_cache[recording_id] = (id(full_view), included_view)
-        return included_view
 
     def get_channel_ids(self, *, included_only: bool = False) -> list[str]:
         """Return sorted channel IDs across recordings.
@@ -264,55 +166,13 @@ class SEEGDatasetMixin:
         """
         all_ids = []
         for rid in self.recording_ids:
+            channel_arrays = self.get_channel_arrays(rid, included_only=included_only)
+            ids = np.asarray(channel_arrays["ids"]).astype(str)
             if self.seeg_dataset_mixin_uniquify_channel_ids:
-                rec = self.get_recording(rid)
-                ids = np.asarray(rec.channels.id).astype(str)
-                if included_only:
-                    included_mask = np.asarray(
-                        getattr(
-                            rec.channels, "included", np.ones(len(ids), dtype=bool)
-                        ),
-                        dtype=bool,
-                    )
-                    ids = ids[included_mask]
                 all_ids.append(ids)
-            else:
-                ids = self.get_channel_view(rid, included_only=included_only).ids
-                ids = np.asarray(ids).astype(str)
-                # Postfix recording ID to avoid cross-recording collisions.
-                all_ids.append(np.char.add(np.char.add(ids, "/"), rid))
+                continue
+            # Postfix recording ID to avoid cross-recording collisions.
+            all_ids.append(np.char.add(np.char.add(ids, "/"), rid))
         if not all_ids:
             return []
         return np.sort(np.concatenate(all_ids).astype(str)).tolist()
-
-    def get_recording_info(self, recording_id: str) -> "SEEGDatasetMixin.RecordingInfo":
-        """Return compact metadata for one recording."""
-        # RecordingInfo is also dataset-managed to avoid mixin-side schema assumptions.
-        if self.seeg_dataset_mixin_recording_infos is None:
-            raise NotImplementedError(
-                "SEEG datasets must define 'seeg_dataset_mixin_recording_infos'."
-            )
-        if recording_id not in self.seeg_dataset_mixin_recording_infos:
-            raise KeyError(f"Missing recording info for recording_id '{recording_id}'.")
-        return self.seeg_dataset_mixin_recording_infos[recording_id]
-
-    def _filter_included_channels(
-        self, view: "SEEGDatasetMixin.ChannelView"
-    ) -> "SEEGDatasetMixin.ChannelView":
-        mask = view.included_mask
-        lip = None if view.lip is None else view.lip[mask]
-        return self.ChannelView(
-            ids=view.ids[mask],
-            names=view.names[mask],
-            included_mask=np.ones(int(np.sum(mask)), dtype=bool),
-            lip=lip,
-        )
-
-    def _get_seeg_included_channel_view_cache(
-        self,
-    ) -> dict[str, tuple[int, "SEEGDatasetMixin.ChannelView"]]:
-        cache = getattr(self, "_seeg_included_channel_view_cache", None)
-        if cache is None:
-            cache = {}
-            setattr(self, "_seeg_included_channel_view_cache", cache)
-        return cache

--- a/torch_brain/dataset/mixins.py
+++ b/torch_brain/dataset/mixins.py
@@ -1,5 +1,3 @@
-import warnings
-
 import numpy as np
 import pandas as pd
 from temporaldata import Data
@@ -99,45 +97,42 @@ class MultiChannelDatasetMixin:
     Provides:
         - ``get_channel_ids()`` for retrieving sorted channel IDs from
           recording views returned by ``get_recording(...)``.
-        - Default channel-ID uniquification with ``subject.id`` only
-          (``seeg_dataset_mixin_uniquify_channel_ids_with_subject=True``,
-          ``seeg_dataset_mixin_uniquify_channel_ids_with_session=False``).
+        - Configurable channel-ID uniquification by prepending metadata
+          components before each channel id:
+          ``multichannel_dataset_mixin_uniquify_channel_ids_with_session``
+          prepends ``session.id`` (default ``False``) and
+          ``multichannel_dataset_mixin_uniquify_channel_ids_with_subject``
+          prepends ``subject.id`` (default ``True``). If both are enabled,
+          the prefix order is ``subject.id/session.id``.
     """
 
     # Channel-ID uniquification toggles used by get_recording_hook.
     # Prefix order is always subject/session when enabled.
-    seeg_dataset_mixin_uniquify_channel_ids_with_subject: bool = True
-    seeg_dataset_mixin_uniquify_channel_ids_with_session: bool = False
+    multichannel_dataset_mixin_uniquify_channel_ids_with_subject: bool = True
+    multichannel_dataset_mixin_uniquify_channel_ids_with_session: bool = False
 
     def get_recording_hook(self, data: Data):
-        prefix = self._build_seeg_channel_id_prefix(data)
+        prefix = self._build_multichannel_channel_id_prefix(data)
         if prefix:
-            data.channels.id = np_string_prefix(prefix, data.channels.id.astype(str))
+            data.channels.id = np_string_prefix(
+                prefix,
+                data.channels.id.astype(str),
+            )
         super().get_recording_hook(data)
 
     def _normalize_channel_uniquify_components(self) -> tuple[str, ...]:
-        with_subject = self.seeg_dataset_mixin_uniquify_channel_ids_with_subject
-        with_session = self.seeg_dataset_mixin_uniquify_channel_ids_with_session
+        with_subject = self.multichannel_dataset_mixin_uniquify_channel_ids_with_subject
+        with_session = self.multichannel_dataset_mixin_uniquify_channel_ids_with_session
         if not isinstance(with_subject, bool):
             raise TypeError(
-                "'seeg_dataset_mixin_uniquify_channel_ids_with_subject' must be "
+                "'multichannel_dataset_mixin_uniquify_channel_ids_with_subject' must be "
                 f"bool; got {type(with_subject).__name__}."
             )
         if not isinstance(with_session, bool):
             raise TypeError(
-                "'seeg_dataset_mixin_uniquify_channel_ids_with_session' must be "
+                "'multichannel_dataset_mixin_uniquify_channel_ids_with_session' must be "
                 f"bool; got {type(with_session).__name__}."
             )
-        if with_session and not with_subject:
-            warning_attr = "_seeg_dataset_mixin_warned_session_without_subject"
-            if not getattr(self, warning_attr, False):
-                warnings.warn(
-                    "Channel-id uniquification with session only can create "
-                    "cross-subject collisions when session.id is not globally unique.",
-                    UserWarning,
-                    stacklevel=2,
-                )
-                setattr(self, warning_attr, True)
 
         components = []
         if with_subject:
@@ -146,46 +141,40 @@ class MultiChannelDatasetMixin:
             components.append("session_id")
         return tuple(components)
 
-    def _build_seeg_channel_id_prefix(self, data: Data) -> str:
+    def _build_multichannel_channel_id_prefix(self, data: Data) -> str:
         components = self._normalize_channel_uniquify_components()
         if not components:
             return ""
 
-        component_values = {}
-        if "subject_id" in components:
-            component_values["subject_id"] = data.get_nested_attribute("subject.id")
-        if "session_id" in components:
-            component_values["session_id"] = data.get_nested_attribute("session.id")
-        prefix_parts = [
-            str(component_values[component])
-            for component in components
-            if component_values[component] is not None
-        ]
-        if not prefix_parts:
-            return ""
+        component_paths = {
+            "subject_id": "subject.id",
+            "session_id": "session.id",
+        }
+        prefix_parts = []
+        for component in components:
+            path = component_paths[component]
+            component_name = component.split("_")[0]
+            error_msg = (
+                f"'{path}' is required when "
+                f"'multichannel_dataset_mixin_uniquify_channel_ids_with_"
+                f"{component_name}' is enabled."
+            )
+            try:
+                value = data.get_nested_attribute(path)
+            except AttributeError as exc:
+                raise ValueError(error_msg) from exc
+            if value is None:
+                raise ValueError(error_msg)
+            prefix_parts.append(str(value))
         return "/".join(prefix_parts) + "/"
 
-    def get_channel_ids(self, *, included_only: bool = False) -> list[str]:
+    def get_channel_ids(self) -> list[str]:
         """Return sorted channel IDs across recordings.
 
         ``get_channel_ids`` aggregates ``rec.channels.id`` from ``get_recording(...)``.
         Any subject/session uniquification is applied there according to
-        ``seeg_dataset_mixin_uniquify_channel_ids_with_subject`` and
-        ``seeg_dataset_mixin_uniquify_channel_ids_with_session``.
-        ``included_only=True`` filters by ``rec.channels.included`` before IDs are collected.
+        ``multichannel_dataset_mixin_uniquify_channel_ids_with_subject`` and
+        ``multichannel_dataset_mixin_uniquify_channel_ids_with_session``.
         """
-        all_ids = []
-        for rid in self.recording_ids:
-            rec = self.get_recording(rid)
-            ids = np.asarray(rec.channels.id).astype(str)
-            if included_only:
-                included_mask = np.asarray(rec.channels.included, dtype=bool)
-                ids = ids[included_mask]
-            all_ids.append(ids)
-        if not all_ids:
-            return []
-        return np.sort(np.concatenate(all_ids).astype(str)).tolist()
-
-
-# Backwards-compatibility alias.
-SEEGDatasetMixin = MultiChannelDatasetMixin
+        ans = [self.get_recording(rid).channels.id for rid in self.recording_ids]
+        return np.sort(np.concatenate(ans)).tolist()

--- a/torch_brain/dataset/mixins.py
+++ b/torch_brain/dataset/mixins.py
@@ -1,3 +1,5 @@
+import warnings
+
 import numpy as np
 import pandas as pd
 from temporaldata import Data
@@ -126,6 +128,16 @@ class MultiChannelDatasetMixin:
                 "'seeg_dataset_mixin_uniquify_channel_ids_with_session' must be "
                 f"bool; got {type(with_session).__name__}."
             )
+        if with_session and not with_subject:
+            warning_attr = "_seeg_dataset_mixin_warned_session_without_subject"
+            if not getattr(self, warning_attr, False):
+                warnings.warn(
+                    "Channel-id uniquification with session only can create "
+                    "cross-subject collisions when session.id is not globally unique.",
+                    UserWarning,
+                    stacklevel=2,
+                )
+                setattr(self, warning_attr, True)
 
         components = []
         if with_subject:

--- a/torch_brain/dataset/mixins.py
+++ b/torch_brain/dataset/mixins.py
@@ -1,6 +1,6 @@
 import numpy as np
 import pandas as pd
-from temporaldata import Data
+from temporaldata import Data, Interval
 
 from torch_brain.utils import np_string_prefix
 
@@ -94,12 +94,9 @@ class SEEGDatasetMixin:
     Mixin class for :class:`torch_brain.dataset.Dataset` subclasses containing sEEG data.
 
     Provides:
-        - ``get_domain_intervals()`` for full-domain intervals
-          (inherited from :class:`torch_brain.dataset.Dataset`).
+        - ``get_domain_intervals()`` for full-domain intervals.
         - ``get_channel_ids()`` for retrieving recording-disambiguated
           channel IDs in ``<channel_id>/<recording_id>`` format.
-        - ``get_channel_arrays()`` for normalized channel metadata access
-          (inherited from :class:`torch_brain.dataset.Dataset`).
     """
 
     # Channel-ID components used for hook-based uniquification.
@@ -157,6 +154,16 @@ class SEEGDatasetMixin:
             return ""
         return "/".join(prefix_parts) + "/"
 
+    def get_domain_intervals(
+        self, recording_ids: list[str] | None = None
+    ) -> dict[str, Interval]:
+        """Return full-domain intervals for the provided recordings."""
+        ids = self.recording_ids if recording_ids is None else recording_ids
+        unknown_ids = [rid for rid in ids if rid not in self.recording_ids]
+        if unknown_ids:
+            raise KeyError(f"Unknown recording_ids: {unknown_ids}")
+        return {rid: self.get_recording(rid).domain for rid in ids}
+
     def get_channel_ids(self, *, included_only: bool = False) -> list[str]:
         """Return sorted channel IDs across recordings.
 
@@ -166,8 +173,15 @@ class SEEGDatasetMixin:
         """
         all_ids = []
         for rid in self.recording_ids:
-            channel_arrays = self.get_channel_arrays(rid, included_only=included_only)
-            ids = np.asarray(channel_arrays["ids"]).astype(str)
+            rec = self.get_recording(rid)
+            ids = np.asarray(rec.channels.id).astype(str)
+            if included_only:
+                included_mask = np.asarray(
+                    getattr(rec.channels, "included", np.ones(len(ids), dtype=bool)),
+                    dtype=bool,
+                )
+                ids = ids[included_mask]
+
             if self.seeg_dataset_mixin_uniquify_channel_ids:
                 all_ids.append(ids)
                 continue

--- a/torch_brain/dataset/mixins.py
+++ b/torch_brain/dataset/mixins.py
@@ -123,9 +123,10 @@ class SEEGDatasetMixin:
     seeg_dataset_mixin_recording_infos: (
         dict[str, "SEEGDatasetMixin.RecordingInfo"] | None
     ) = None
-    # If enabled, channel IDs are made unique in the returned recording view
-    # using subject/session context, matching the hook-based style of the other mixins.
-    seeg_dataset_mixin_uniquify_channel_ids: bool = False
+    # Channel-ID components used for hook-based uniquification.
+    # Supported values are "subject_id" and "session_id".
+    # Example: {"subject_id"} for subject-only prefixes.
+    seeg_dataset_mixin_uniquify_channel_ids: set[str] | frozenset[str] = frozenset()
 
     @dataclass(frozen=True)
     class ChannelView:
@@ -151,19 +152,51 @@ class SEEGDatasetMixin:
 
     def get_recording_hook(self, data: Data):
         if self.seeg_dataset_mixin_uniquify_channel_ids:
-            subject_id = getattr(getattr(data, "subject", None), "id", None)
-            session_id = getattr(getattr(data, "session", None), "id", None)
-            if subject_id is not None and session_id is not None:
-                prefix = f"{subject_id}/{session_id}/"
-            elif session_id is not None:
-                prefix = f"{session_id}/"
-            else:
-                prefix = ""
+            prefix = self._build_seeg_channel_id_prefix(data)
             if prefix:
                 data.channels.id = np_string_prefix(
                     prefix, data.channels.id.astype(str)
                 )
         super().get_recording_hook(data)
+
+    def _normalize_channel_uniquify_components(self) -> set[str]:
+        config = self.seeg_dataset_mixin_uniquify_channel_ids
+        valid_components = {"subject_id", "session_id"}
+
+        if not isinstance(config, (set, frozenset)):
+            raise TypeError(
+                "'seeg_dataset_mixin_uniquify_channel_ids' must be a set or "
+                f"frozenset; got {type(config).__name__}."
+            )
+
+        normalized = set(config)
+        invalid = [item for item in normalized if item not in valid_components]
+        if invalid:
+            invalid_str = ", ".join(sorted(repr(item) for item in invalid))
+            raise ValueError(
+                "Invalid channel uniquify components: "
+                f"{invalid_str}. Expected subset of "
+                f"{sorted(valid_components)}."
+            )
+        return normalized
+
+    def _build_seeg_channel_id_prefix(self, data: Data) -> str:
+        components = self._normalize_channel_uniquify_components()
+        if not components:
+            return ""
+
+        subject_id = getattr(getattr(data, "subject", None), "id", None)
+        session_id = getattr(getattr(data, "session", None), "id", None)
+
+        # Keep deterministic ordering regardless of set iteration order.
+        prefix_parts = []
+        if "subject_id" in components and subject_id is not None:
+            prefix_parts.append(str(subject_id))
+        if "session_id" in components and session_id is not None:
+            prefix_parts.append(str(session_id))
+        if not prefix_parts:
+            return ""
+        return "/".join(prefix_parts) + "/"
 
     def get_sampling_rate(self, recording_id: str | None = None) -> float:
         """Return recording sampling rate in Hz."""

--- a/torch_brain/dataset/mixins.py
+++ b/torch_brain/dataset/mixins.py
@@ -1,6 +1,6 @@
 import numpy as np
 import pandas as pd
-from temporaldata import Data, Interval
+from temporaldata import Data
 
 from torch_brain.utils import np_string_prefix
 
@@ -94,7 +94,6 @@ class SEEGDatasetMixin:
     Mixin class for :class:`torch_brain.dataset.Dataset` subclasses containing sEEG data.
 
     Provides:
-        - ``get_domain_intervals()`` for full-domain intervals.
         - ``get_channel_ids()`` for retrieving recording-disambiguated
           channel IDs in ``<channel_id>/<recording_id>`` format.
     """
@@ -153,16 +152,6 @@ class SEEGDatasetMixin:
         if not prefix_parts:
             return ""
         return "/".join(prefix_parts) + "/"
-
-    def get_domain_intervals(
-        self, recording_ids: list[str] | None = None
-    ) -> dict[str, Interval]:
-        """Return full-domain intervals for the provided recordings."""
-        ids = self.recording_ids if recording_ids is None else recording_ids
-        unknown_ids = [rid for rid in ids if rid not in self.recording_ids]
-        if unknown_ids:
-            raise KeyError(f"Unknown recording_ids: {unknown_ids}")
-        return {rid: self.get_recording(rid).domain for rid in ids}
 
     def get_channel_ids(self, *, included_only: bool = False) -> list[str]:
         """Return sorted channel IDs across recordings.

--- a/torch_brain/dataset/mixins.py
+++ b/torch_brain/dataset/mixins.py
@@ -89,20 +89,23 @@ class CalciumImagingDatasetMixin:
         return np.sort(np.concatenate(ans)).tolist()
 
 
-class SEEGDatasetMixin:
+class MultiChannelDatasetMixin:
     """
-    Mixin class for :class:`torch_brain.dataset.Dataset` subclasses containing sEEG data.
+    Mixin class for :class:`torch_brain.dataset.Dataset` subclasses containing
+    multi-channel recordings (e.g., sEEG).
 
     Provides:
         - ``get_channel_ids()`` for retrieving sorted channel IDs from
           recording views returned by ``get_recording(...)``.
+        - Default channel-ID uniquification with ``subject.id`` only
+          (``seeg_dataset_mixin_uniquify_channel_ids_with_subject=True``,
+          ``seeg_dataset_mixin_uniquify_channel_ids_with_session=False``).
     """
 
-    # Channel-ID components used for hook-based uniquification.
-    # Supported values are "subject_id" and "session_id".
-    # Example: {"subject_id"} for subject-only prefixes.
-    seeg_dataset_mixin_uniquify_channel_ids: set[str] | frozenset[str] = frozenset()
-    _SEEG_CHANNEL_ID_COMPONENT_ORDER: tuple[str, str] = ("subject_id", "session_id")
+    # Channel-ID uniquification toggles used by get_recording_hook.
+    # Prefix order is always subject/session when enabled.
+    seeg_dataset_mixin_uniquify_channel_ids_with_subject: bool = True
+    seeg_dataset_mixin_uniquify_channel_ids_with_session: bool = False
 
     def get_recording_hook(self, data: Data):
         prefix = self._build_seeg_channel_id_prefix(data)
@@ -111,39 +114,36 @@ class SEEGDatasetMixin:
         super().get_recording_hook(data)
 
     def _normalize_channel_uniquify_components(self) -> tuple[str, ...]:
-        config = self.seeg_dataset_mixin_uniquify_channel_ids
-        valid_components = set(self._SEEG_CHANNEL_ID_COMPONENT_ORDER)
-
-        if not isinstance(config, (set, frozenset)):
+        with_subject = self.seeg_dataset_mixin_uniquify_channel_ids_with_subject
+        with_session = self.seeg_dataset_mixin_uniquify_channel_ids_with_session
+        if not isinstance(with_subject, bool):
             raise TypeError(
-                "'seeg_dataset_mixin_uniquify_channel_ids' must be a set or "
-                f"frozenset; got {type(config).__name__}."
+                "'seeg_dataset_mixin_uniquify_channel_ids_with_subject' must be "
+                f"bool; got {type(with_subject).__name__}."
+            )
+        if not isinstance(with_session, bool):
+            raise TypeError(
+                "'seeg_dataset_mixin_uniquify_channel_ids_with_session' must be "
+                f"bool; got {type(with_session).__name__}."
             )
 
-        normalized = set(config)
-        invalid = [item for item in normalized if item not in valid_components]
-        if invalid:
-            invalid_str = ", ".join(sorted(repr(item) for item in invalid))
-            raise ValueError(
-                "Invalid channel uniquify components: "
-                f"{invalid_str}. Expected subset of "
-                f"{sorted(valid_components)}."
-            )
-        return tuple(
-            component
-            for component in self._SEEG_CHANNEL_ID_COMPONENT_ORDER
-            if component in normalized
-        )
+        components = []
+        if with_subject:
+            components.append("subject_id")
+        if with_session:
+            components.append("session_id")
+        return tuple(components)
 
     def _build_seeg_channel_id_prefix(self, data: Data) -> str:
         components = self._normalize_channel_uniquify_components()
         if not components:
             return ""
 
-        component_values = {
-            "subject_id": getattr(getattr(data, "subject", None), "id", None),
-            "session_id": getattr(getattr(data, "session", None), "id", None),
-        }
+        component_values = {}
+        if "subject_id" in components:
+            component_values["subject_id"] = data.get_nested_attribute("subject.id")
+        if "session_id" in components:
+            component_values["session_id"] = data.get_nested_attribute("session.id")
         prefix_parts = [
             str(component_values[component])
             for component in components
@@ -158,16 +158,16 @@ class SEEGDatasetMixin:
 
         ``get_channel_ids`` aggregates ``rec.channels.id`` from ``get_recording(...)``.
         Any subject/session uniquification is applied there according to
-        ``seeg_dataset_mixin_uniquify_channel_ids``. ``included_only=True`` filters
-        by ``rec.channels.included`` before IDs are collected.
+        ``seeg_dataset_mixin_uniquify_channel_ids_with_subject`` and
+        ``seeg_dataset_mixin_uniquify_channel_ids_with_session``.
+        ``included_only=True`` filters by ``rec.channels.included`` before IDs are collected.
         """
         all_ids = []
         for rid in self.recording_ids:
             rec = self.get_recording(rid)
             ids = np.asarray(rec.channels.id).astype(str)
             if included_only:
-                included_mask = np.asarray(
-                    getattr(rec.channels, "included", np.ones(len(ids), dtype=bool)),
+                included_mask = np.asarray(rec.channels.included,
                     dtype=bool,
                 )
                 ids = ids[included_mask]
@@ -175,3 +175,7 @@ class SEEGDatasetMixin:
         if not all_ids:
             return []
         return np.sort(np.concatenate(all_ids).astype(str)).tolist()
+
+
+# Backwards-compatibility alias.
+SEEGDatasetMixin = MultiChannelDatasetMixin

--- a/torch_brain/dataset/mixins.py
+++ b/torch_brain/dataset/mixins.py
@@ -87,3 +87,15 @@ class CalciumImagingDatasetMixin:
         """Return a sorted list of all ROI IDs across all recordings in the dataset."""
         ans = [self.get_recording(rid).rois.id for rid in self.recording_ids]
         return np.sort(np.concatenate(ans)).tolist()
+
+
+class SEEGDatasetMixin:
+    """
+    Mixin class for :class:`torch_brain.dataset.Dataset` subclasses containing sEEG data.
+
+    Provides:
+        - ``get_recording_hook()`` passthrough for mixin hook chaining.
+    """
+
+    def get_recording_hook(self, data: Data):
+        super().get_recording_hook(data)

--- a/torch_brain/dataset/mixins.py
+++ b/torch_brain/dataset/mixins.py
@@ -116,9 +116,13 @@ class SEEGDatasetMixin:
     # Dataset classes should set this with all available recording-domain intervals.
     seeg_dataset_mixin_domain_intervals: dict[str, Interval] | None = None
     # Dataset classes should set this with full channel views for each recording.
-    seeg_dataset_mixin_channel_views: dict[str, "SEEGDatasetMixin.ChannelView"] | None = None
+    seeg_dataset_mixin_channel_views: (
+        dict[str, "SEEGDatasetMixin.ChannelView"] | None
+    ) = None
     # Dataset classes should set this with compact recording metadata.
-    seeg_dataset_mixin_recording_infos: dict[str, "SEEGDatasetMixin.RecordingInfo"] | None = None
+    seeg_dataset_mixin_recording_infos: (
+        dict[str, "SEEGDatasetMixin.RecordingInfo"] | None
+    ) = None
 
     @dataclass(frozen=True)
     class ChannelView:
@@ -161,7 +165,9 @@ class SEEGDatasetMixin:
                 "SEEG datasets must define 'seeg_dataset_mixin_domain_intervals'."
             )
         ids = self.recording_ids if recording_ids is None else recording_ids
-        missing = [rid for rid in ids if rid not in self.seeg_dataset_mixin_domain_intervals]
+        missing = [
+            rid for rid in ids if rid not in self.seeg_dataset_mixin_domain_intervals
+        ]
         if missing:
             raise KeyError(f"Missing domain intervals for recording_ids: {missing}")
         return {rid: self.seeg_dataset_mixin_domain_intervals[rid] for rid in ids}

--- a/torch_brain/dataset/mixins.py
+++ b/torch_brain/dataset/mixins.py
@@ -123,6 +123,9 @@ class SEEGDatasetMixin:
     seeg_dataset_mixin_recording_infos: (
         dict[str, "SEEGDatasetMixin.RecordingInfo"] | None
     ) = None
+    # If enabled, channel IDs are made unique in the returned recording view
+    # using subject/session context, matching the hook-based style of the other mixins.
+    seeg_dataset_mixin_uniquify_channel_ids: bool = False
 
     @dataclass(frozen=True)
     class ChannelView:
@@ -145,6 +148,20 @@ class SEEGDatasetMixin:
         domain: Interval
         n_channels: int
         n_included_channels: int
+
+    def get_recording_hook(self, data: Data):
+        if self.seeg_dataset_mixin_uniquify_channel_ids:
+            subject_id = getattr(getattr(data, "subject", None), "id", None)
+            session_id = getattr(getattr(data, "session", None), "id", None)
+            if subject_id is not None and session_id is not None:
+                prefix = f"{subject_id}/{session_id}/"
+            elif session_id is not None:
+                prefix = f"{session_id}/"
+            else:
+                prefix = ""
+            if prefix:
+                data.channels.id = np_string_prefix(prefix, data.channels.id.astype(str))
+        super().get_recording_hook(data)
 
     def get_sampling_rate(self, recording_id: str | None = None) -> float:
         """Return recording sampling rate in Hz."""
@@ -204,13 +221,29 @@ class SEEGDatasetMixin:
         return included_view
 
     def get_channel_ids(self, *, included_only: bool = False) -> list[str]:
-        """Return sorted ``<channel_id>/<recording_id>`` IDs across recordings."""
+        """Return sorted channel IDs across recordings.
+
+        When channel-ID uniquification is enabled, this reuses ``get_recording(...)``
+        so the returned IDs exactly match the hook-mutated recording view. Otherwise
+        it falls back to ``<channel_id>/<recording_id>`` disambiguation.
+        """
         all_ids = []
         for rid in self.recording_ids:
-            ids = self.get_channel_view(rid, included_only=included_only).ids
-            ids = np.asarray(ids).astype(str)
-            # Postfix recording ID to avoid cross-recording collisions.
-            all_ids.append(np.char.add(np.char.add(ids, "/"), rid))
+            if self.seeg_dataset_mixin_uniquify_channel_ids:
+                rec = self.get_recording(rid)
+                ids = np.asarray(rec.channels.id).astype(str)
+                if included_only:
+                    included_mask = np.asarray(
+                        getattr(rec.channels, "included", np.ones(len(ids), dtype=bool)),
+                        dtype=bool,
+                    )
+                    ids = ids[included_mask]
+                all_ids.append(ids)
+            else:
+                ids = self.get_channel_view(rid, included_only=included_only).ids
+                ids = np.asarray(ids).astype(str)
+                # Postfix recording ID to avoid cross-recording collisions.
+                all_ids.append(np.char.add(np.char.add(ids, "/"), rid))
         if not all_ids:
             return []
         return np.sort(np.concatenate(all_ids).astype(str)).tolist()

--- a/torch_brain/dataset/mixins.py
+++ b/torch_brain/dataset/mixins.py
@@ -1,6 +1,7 @@
+from dataclasses import dataclass
 import numpy as np
 import pandas as pd
-from temporaldata import Data
+from temporaldata import Data, Interval
 
 from torch_brain.utils import np_string_prefix
 
@@ -94,8 +95,148 @@ class SEEGDatasetMixin:
     Mixin class for :class:`torch_brain.dataset.Dataset` subclasses containing sEEG data.
 
     Provides:
-        - ``get_recording_hook()`` passthrough for mixin hook chaining.
+        - ``get_sampling_rate()`` for retrieving signal sampling rate (Hz).
+          Requires dataset classes to define
+          ``seeg_dataset_mixin_sampling_rate_hz``.
+        - ``get_domain_intervals()`` for retrieving full-domain intervals.
+          Requires dataset classes to define
+          ``seeg_dataset_mixin_domain_intervals``.
+        - ``get_channel_view()`` for normalized channel metadata access.
+          Requires dataset classes to define
+          ``seeg_dataset_mixin_channel_views`` with full channel views.
+        - ``get_channel_ids()`` for retrieving recording-disambiguated
+          channel IDs in ``<channel_id>/<recording_id>`` format.
+        - ``get_recording_info()`` for compact per-recording metadata.
+          Requires dataset classes to define
+          ``seeg_dataset_mixin_recording_infos``.
     """
 
-    def get_recording_hook(self, data: Data):
-        super().get_recording_hook(data)
+    # Dataset classes should set this to expose a stable sampling-rate contract.
+    seeg_dataset_mixin_sampling_rate_hz: float | None = None
+    # Dataset classes should set this with all available recording-domain intervals.
+    seeg_dataset_mixin_domain_intervals: dict[str, Interval] | None = None
+    # Dataset classes should set this with full channel views for each recording.
+    seeg_dataset_mixin_channel_views: dict[str, "SEEGDatasetMixin.ChannelView"] | None = None
+    # Dataset classes should set this with compact recording metadata.
+    seeg_dataset_mixin_recording_infos: dict[str, "SEEGDatasetMixin.RecordingInfo"] | None = None
+
+    @dataclass(frozen=True)
+    class ChannelView:
+        """Channel metadata view for one recording."""
+
+        ids: np.ndarray
+        names: np.ndarray
+        included_mask: np.ndarray
+        # Channel coordinates ordered as (L, I, P), or ``None`` when unavailable.
+        lip: np.ndarray | None
+
+    @dataclass(frozen=True)
+    class RecordingInfo:
+        """Compact metadata summary for one recording."""
+
+        recording_id: str
+        subject_id: str | int | None
+        session_id: str | int | None
+        sampling_rate_hz: float
+        domain: Interval
+        n_channels: int
+        n_included_channels: int
+
+    def get_sampling_rate(self, recording_id: str | None = None) -> float:
+        """Return recording sampling rate in Hz."""
+        _ = recording_id  # keep signature compatible with per-recording datasets
+        if self.seeg_dataset_mixin_sampling_rate_hz is None:
+            raise NotImplementedError(
+                "SEEG datasets must define 'seeg_dataset_mixin_sampling_rate_hz'."
+            )
+        return float(self.seeg_dataset_mixin_sampling_rate_hz)
+
+    def get_domain_intervals(
+        self, recording_ids: list[str] | None = None
+    ) -> dict[str, Interval]:
+        """Return full-domain intervals for the provided recordings."""
+        # Domain intervals are dataset-specific and should be precomputed at init.
+        if self.seeg_dataset_mixin_domain_intervals is None:
+            raise NotImplementedError(
+                "SEEG datasets must define 'seeg_dataset_mixin_domain_intervals'."
+            )
+        ids = self.recording_ids if recording_ids is None else recording_ids
+        missing = [rid for rid in ids if rid not in self.seeg_dataset_mixin_domain_intervals]
+        if missing:
+            raise KeyError(f"Missing domain intervals for recording_ids: {missing}")
+        return {rid: self.seeg_dataset_mixin_domain_intervals[rid] for rid in ids}
+
+    def get_channel_view(
+        self, recording_id: str, *, included_only: bool = False
+    ) -> "SEEGDatasetMixin.ChannelView":
+        """Return normalized channel metadata and optional LIP coordinates."""
+        # Full channel views come from dataset-managed cache so schema conversion stays local.
+        if self.seeg_dataset_mixin_channel_views is None:
+            raise NotImplementedError(
+                "SEEG datasets must define 'seeg_dataset_mixin_channel_views'."
+            )
+
+        if recording_id not in self.seeg_dataset_mixin_channel_views:
+            raise KeyError(f"Missing channel view for recording_id '{recording_id}'.")
+
+        full_view = self.seeg_dataset_mixin_channel_views[recording_id]
+        if not included_only:
+            return full_view
+
+        # Included-only views are frequently requested by samplers/evaluators.
+        # Cache the derived filtered view to avoid repeated mask application.
+        included_cache = self._get_seeg_included_channel_view_cache()
+        if recording_id in included_cache:
+            # Keep the source full-view identity so we can invalidate stale derived
+            # views if datasets replace full channel views after initialization.
+            source_view_id, included_view = included_cache[recording_id]
+            if source_view_id == id(full_view):
+                return included_view
+
+        included_view = self._filter_included_channels(full_view)
+        included_cache[recording_id] = (id(full_view), included_view)
+        return included_view
+
+    def get_channel_ids(self, *, included_only: bool = False) -> list[str]:
+        """Return sorted ``<channel_id>/<recording_id>`` IDs across recordings."""
+        all_ids = []
+        for rid in self.recording_ids:
+            ids = self.get_channel_view(rid, included_only=included_only).ids
+            ids = np.asarray(ids).astype(str)
+            # Postfix recording ID to avoid cross-recording collisions.
+            all_ids.append(np.char.add(np.char.add(ids, "/"), rid))
+        if not all_ids:
+            return []
+        return np.sort(np.concatenate(all_ids).astype(str)).tolist()
+
+    def get_recording_info(self, recording_id: str) -> "SEEGDatasetMixin.RecordingInfo":
+        """Return compact metadata for one recording."""
+        # RecordingInfo is also dataset-managed to avoid mixin-side schema assumptions.
+        if self.seeg_dataset_mixin_recording_infos is None:
+            raise NotImplementedError(
+                "SEEG datasets must define 'seeg_dataset_mixin_recording_infos'."
+            )
+        if recording_id not in self.seeg_dataset_mixin_recording_infos:
+            raise KeyError(f"Missing recording info for recording_id '{recording_id}'.")
+        return self.seeg_dataset_mixin_recording_infos[recording_id]
+
+    def _filter_included_channels(
+        self, view: "SEEGDatasetMixin.ChannelView"
+    ) -> "SEEGDatasetMixin.ChannelView":
+        mask = view.included_mask
+        lip = None if view.lip is None else view.lip[mask]
+        return self.ChannelView(
+            ids=view.ids[mask],
+            names=view.names[mask],
+            included_mask=np.ones(int(np.sum(mask)), dtype=bool),
+            lip=lip,
+        )
+
+    def _get_seeg_included_channel_view_cache(
+        self,
+    ) -> dict[str, tuple[int, "SEEGDatasetMixin.ChannelView"]]:
+        cache = getattr(self, "_seeg_included_channel_view_cache", None)
+        if cache is None:
+            cache = {}
+            setattr(self, "_seeg_included_channel_view_cache", cache)
+        return cache


### PR DESCRIPTION
Simple MultiChannelDatasetMixin for Neuroprobe 2025 being implemented here: https://github.com/neuro-galaxy/brainsets/pull/79 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added sEEG dataset mixin with channel-ID retrieval and optional channel-ID uniquification across recordings.
* **Behavior**
  * Channel-ID handling supports configurable uniquification and validation; non-uniquified IDs remain disambiguated by recording.
* **Documentation**
  * API docs updated to include the new sEEG mixin.
* **Tests**
  * New tests covering sEEG scenarios, ID disambiguation, uniquification behavior, and error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->