### PR TITLE
MultitaskReadout: only iterate over tasks in batch

### DIFF
--- a/torch_brain/nn/multitask_readout.py
+++ b/torch_brain/nn/multitask_readout.py
@@ -31,8 +31,10 @@ class MultitaskReadout(nn.Module):
 
         # Create a bunch of projection layers. One for each readout
         self.projections = nn.ModuleDict({})
-        for readout_id, spec in self.readout_specs.items():
-            self.projections[readout_id] = nn.Linear(dim, spec.dim)
+        self._readout_id_to_name = {}
+        for readout_name, readout_spec in self.readout_specs.items():
+            self.projections[readout_name] = nn.Linear(dim, readout_spec.dim)
+            self._readout_id_to_name[readout_spec.id] = readout_name
 
     def forward(
         self,
@@ -63,13 +65,16 @@ class MultitaskReadout(nn.Module):
         else:
             outputs = {}
 
-        for readout_name, readout_spec in self.readout_specs.items():
-            # get the mask of tokens that belong to this task
-            mask = output_readout_index == readout_spec.id
+        for readout_id in output_readout_index.unique().tolist():
+            readout_name = self._readout_id_to_name.get(readout_id, None)
 
-            if not torch.any(mask):
-                # there is not a single token in the batch for this task, so we skip
+            # if the readout_id is not found in the registry, skip it
+            # this deals with padding and potentially tasks to be ignored during training
+            if readout_name is None:
                 continue
+
+            # get the mask of tokens that belong to this task
+            mask = output_readout_index == readout_id
 
             # apply the appropriate projection for all tokens in the batch that belong to this task
             task_output = self.projections[readout_name](output_embs[mask])
@@ -127,13 +132,16 @@ class MultitaskReadout(nn.Module):
         else:
             outputs = {}
 
-        for readout_name, readout_spec in self.readout_specs.items():
-            # get the mask of tokens that belong to this task
-            mask = output_readout_index == readout_spec.id
+        for readout_id in output_readout_index.unique().tolist():
+            readout_name = self._readout_id_to_name.get(readout_id, None)
 
-            if not torch.any(mask):
-                # there is not a single token in the batch for this task, so we skip
+            # if the readout_id is not found in the registry, skip it
+            # this deals with padding and potentially tasks to be ignored during training
+            if readout_name is None:
                 continue
+
+            # get the mask of tokens that belong to this task
+            mask = output_readout_index == readout_id
 
             # apply the projection
             task_output = self.projections[readout_name](output_embs[mask])


### PR DESCRIPTION
The current `MultitaskReadout.forward` and `forward_varlen` loop over every entry in `self.readout_specs`, testing each with `torch.any(mask)` to skip absent modalities. This scales the forward cost with the total size of the readout registry even though each batch only touches at most batch_size * n_out distinct modalities.                                
                                                                         
At large modality counts (e.g. per-session readouts over thousands of sessions, or large brainset pools), the empty-mask `==` + `torch.any`operations slow down the forward pass quite a bit.

This PR makes `MultitaskReadout` iterate over modalities or tasks present within the batch, skipping IDs that are for whatever reason non-existent in readout_specs for the MultitaskReadout (e.g., padding or deliberately removed tasks that still exist in the collated batch -- just for safety). The mapping between readout IDs and names is cached upon initial creation, along with storing the projection matrices in the dictionary.

Benchmarking:
| `readout_specs` | no-fix fwd | patched fwd | **fwd speedup** | no-fix total | patched total | **total speedup** |
|---:|---:|---:|---:|---:|---:|---:|
|   ~21 | 15.0 |   —   |   —   |  49.9 |   —   |   —   |
|   ~30 | 16.1 | 15.6 | 1.03× |  53.6 |  53.1 | 1.01× |
|  ~120 | 28.0 | 25.5 | 1.10× |  85.5 |  82.9 | 1.03× |
| ~1020 | 53.0 | 31.6 | **1.68×** | 122.8 | 101.7 | **1.21×** |

At 10k datasets/readouts, I expect this to yield even up to 4x speedups.

Hoping to land this soon as we need it for a project, would appreciate reviews!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized multitask readout layer to process only active tasks present in the current batch, reducing unnecessary computation and improving performance for models with variable task configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->