### PR TITLE
cleanup!: remove `optim.py`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Added per-task average metric logging in `MultiTaskDecodingStitchEvaluator` ([#198](https://github.com/neuro-galaxy/torch_brain/pull/198))
 
 ### Removed
-- Removed `optim.py` ([#203](https://github.com/neuro-galaxy/torch_brain/pull/203))
+- Removed `torch_brain.optim` / `SparseLamb` from the public package API ([#203](https://github.com/neuro-galaxy/torch_brain/pull/203))
 - Remove `utils/gradient_rescale.py` (legacy) ([#201](https://github.com/neuro-galaxy/torch_brain/pull/201))
 - Removed `utils.get_sinusoidal_encoding` (legacy) ([#200](https://github.com/neuro-galaxy/torch_brain/pull/200))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Added per-task average metric logging in `MultiTaskDecodingStitchEvaluator` ([#198](https://github.com/neuro-galaxy/torch_brain/pull/198))
 
 ### Removed
+- Removed `optim.py` ([#203](https://github.com/neuro-galaxy/torch_brain/pull/203))
 - Remove `utils/gradient_rescale.py` (legacy) ([#201](https://github.com/neuro-galaxy/torch_brain/pull/201))
 - Removed `utils.get_sinusoidal_encoding` (legacy) ([#200](https://github.com/neuro-galaxy/torch_brain/pull/200))
 

--- a/examples/poyo/optim.py
+++ b/examples/poyo/optim.py
@@ -1,0 +1,177 @@
+import math
+
+import torch
+from torch.optim.optimizer import Optimizer
+
+
+class SparseLamb(Optimizer):
+    r"""Implements the sparse variant of the Lamb algorithm.
+
+    SparseLamb is a variant of the Lamb optimizer that only updates the parameters
+    for which the gradient is non-zero. This is useful for models that do not always
+    use all parameters during a single forward pass.
+
+    By default, SparseLamb is equivalent to Lamb. To activate the sparse variant,
+    set the `sparse` argument to `True`.
+
+    Arguments:
+        params: iterable of parameters to optimize or dicts defining
+            parameter groups
+        lr: learning rate (default: 1e-3)
+        betas: coefficients used for computing
+            running averages of gradient and its square (default: (0.9, 0.999))
+        eps: term added to the denominator to improve
+            numerical stability (default: 1e-8)
+        weight_decay: weight decay (L2 penalty) (default: 0)
+        clamp_value: clamp weight_norm in (0,clamp_value) (default: 10)
+            set to a high value to avoid it (e.g 10e3)
+        adam: always use trust ratio = 1, which turns this
+            into Adam. Useful for comparison purposes. (default: False)
+        debias: debias adam by (1 - beta**step) (default: False)
+        sparse: only update the parameters that have non-zero gradients (default: False)
+
+    __ https://arxiv.org/abs/1904.00962
+
+    Note:
+        Reference code: https://github.com/cybertronai/pytorch-lamb
+    """
+
+    def __init__(
+        self,
+        params,
+        lr: float = 1e-3,
+        betas=(0.9, 0.999),
+        eps: float = 1e-6,
+        weight_decay: float = 0,
+        clamp_value: float = 10,
+        adam: bool = False,
+        debias: bool = False,
+        sparse: bool = False,
+    ) -> None:
+        if lr <= 0.0:
+            raise ValueError("Invalid learning rate: {}".format(lr))
+        if eps < 0.0:
+            raise ValueError("Invalid epsilon value: {}".format(eps))
+        if not 0.0 <= betas[0] < 1.0:
+            raise ValueError("Invalid beta parameter at index 0: {}".format(betas[0]))
+        if not 0.0 <= betas[1] < 1.0:
+            raise ValueError("Invalid beta parameter at index 1: {}".format(betas[1]))
+        if weight_decay < 0:
+            raise ValueError("Invalid weight_decay value: {}".format(weight_decay))
+        if clamp_value < 0.0:
+            raise ValueError("Invalid clamp value: {}".format(clamp_value))
+
+        defaults = dict(
+            lr=lr, betas=betas, eps=eps, weight_decay=weight_decay, sparse=sparse
+        )
+        self.clamp_value = clamp_value
+        self.adam = adam
+        self.debias = debias
+
+        super(SparseLamb, self).__init__(params, defaults)
+
+    def step(self, closure=None):
+        r"""Performs a single optimization step.
+
+        Arguments:
+            closure: A closure that reevaluates the model and returns the loss.
+        """
+        loss = None
+        if closure is not None:
+            loss = closure()
+
+        for group in self.param_groups:
+            for p in group["params"]:
+                if p.grad is None:
+                    continue
+
+                grad = p.grad.data
+
+                if grad.is_sparse:
+                    msg = (
+                        "Lamb does not support sparse gradients, "
+                        "please consider SparseAdam instead"
+                    )
+                    raise RuntimeError(msg)
+
+                state = self.state[p]
+
+                # State initialization
+                if len(state) == 0:
+                    state["step"] = 0
+                    # Exponential moving average of gradient values
+                    state["exp_avg"] = torch.zeros_like(p)
+                    # Exponential moving average of squared gradient values
+                    state["exp_avg_sq"] = torch.zeros_like(p)
+
+                exp_avg, exp_avg_sq = state["exp_avg"], state["exp_avg_sq"]
+                beta1, beta2 = group["betas"]
+
+                state["step"] += 1
+                is_sparse = group["sparse"]
+                if is_sparse:
+                    # only update the values that are non-zero
+                    mask = grad.abs().sum(dim=-1) > 0.0
+                    is_sparse = not mask.all()
+
+                if is_sparse:
+                    mask_idx = mask.nonzero()
+                    mask_idx = mask_idx.repeat((1, p.size(1)))
+
+                    beta1_vec = torch.full_like(p, beta1)
+                    beta1_vec[~mask] = 0
+                    beta2_vec = torch.full_like(p, beta2)
+                    beta2_vec[~mask] = 0
+
+                    # Decay the first and second moment running average coefficient
+                    # m_t
+                    exp_avg.mul_(beta1_vec).scatter_add_(
+                        0, mask_idx, grad[mask].mul_(1 - beta1)
+                    )
+                    # v_t
+                    exp_avg_sq.mul_(beta2_vec).scatter_add_(
+                        0, mask_idx, grad[mask].mul_(grad[mask]).mul_(1 - beta2)
+                    )
+                else:
+                    # Decay the first and second moment running average coefficient
+                    # m_t
+                    exp_avg.mul_(beta1).add_(grad, alpha=1 - beta1)
+                    # v_t
+                    exp_avg_sq.mul_(beta2).addcmul_(grad, grad, value=1 - beta2)
+
+                # Paper v3 does not use debiasing.
+                if self.debias:
+                    raise NotImplementedError
+                    bias_correction = math.sqrt(1 - beta2 ** state["step"])
+                    bias_correction /= 1 - beta1 ** state["step"]
+                else:
+                    bias_correction = 1
+
+                # Apply bias to lr to avoid broadcast.
+                step_size = group["lr"] * bias_correction
+
+                weight_norm = torch.norm(p.data).clamp(0, self.clamp_value)
+
+                adam_step = exp_avg / exp_avg_sq.sqrt().add(group["eps"])
+                if group["weight_decay"] != 0:
+                    adam_step.add_(p.data, alpha=group["weight_decay"])
+
+                adam_norm = torch.norm(adam_step)
+                if weight_norm == 0 or adam_norm == 0:
+                    trust_ratio = 1
+                else:
+                    trust_ratio = weight_norm / adam_norm
+                state["weight_norm"] = weight_norm
+                state["adam_norm"] = adam_norm
+                state["trust_ratio"] = trust_ratio
+                if self.adam:
+                    trust_ratio = 1
+                if is_sparse:
+                    # alpha_vec = torch.full((p.size(0),), -step_size * trust_ratio)
+                    p.data.scatter_add_(
+                        0, mask_idx, adam_step[mask].mul_(-step_size * trust_ratio)
+                    )
+                else:
+                    p.data.add_(adam_step, alpha=-step_size * trust_ratio)
+
+        return loss

--- a/examples/poyo/optim.py
+++ b/examples/poyo/optim.py
@@ -21,7 +21,7 @@ class SparseLamb(Optimizer):
         betas: coefficients used for computing
             running averages of gradient and its square (default: (0.9, 0.999))
         eps: term added to the denominator to improve
-            numerical stability (default: 1e-8)
+            numerical stability (default: 1e-6)
         weight_decay: weight decay (L2 penalty) (default: 0)
         clamp_value: clamp weight_norm in (0,clamp_value) (default: 10)
             set to a high value to avoid it (e.g 10e3)

--- a/examples/poyo/train.py
+++ b/examples/poyo/train.py
@@ -14,7 +14,6 @@ from omegaconf import DictConfig, OmegaConf
 from temporaldata import Data
 
 from torch_brain.registry import MODALITY_REGISTRY, ModalitySpec
-from torch_brain.optim import SparseLamb
 from torch_brain.models.poyo import POYO
 from torch_brain.utils import callbacks as tbrain_callbacks
 from torch_brain.utils import seed_everything
@@ -28,6 +27,8 @@ from torch_brain.data.sampler import (
     RandomFixedWindowSampler,
 )
 from torch_brain.transforms import Compose
+
+from .optim import SparseLamb
 
 # higher speed on machines with tensor cores
 torch.set_float32_matmul_precision("medium")

--- a/examples/poyo/train.py
+++ b/examples/poyo/train.py
@@ -28,7 +28,7 @@ from torch_brain.data.sampler import (
 )
 from torch_brain.transforms import Compose
 
-from .optim import SparseLamb
+from optim import SparseLamb
 
 # higher speed on machines with tensor cores
 torch.set_float32_matmul_precision("medium")

--- a/examples/poyo_plus/optim.py
+++ b/examples/poyo_plus/optim.py
@@ -3,10 +3,6 @@ import math
 import torch
 from torch.optim.optimizer import Optimizer
 
-__all__ = [
-    "SparseLamb",
-]
-
 
 class SparseLamb(Optimizer):
     r"""Implements the sparse variant of the Lamb algorithm.

--- a/examples/poyo_plus/optim.py
+++ b/examples/poyo_plus/optim.py
@@ -21,7 +21,7 @@ class SparseLamb(Optimizer):
         betas: coefficients used for computing
             running averages of gradient and its square (default: (0.9, 0.999))
         eps: term added to the denominator to improve
-            numerical stability (default: 1e-8)
+            numerical stability (default: 1e-6)
         weight_decay: weight decay (L2 penalty) (default: 0)
         clamp_value: clamp weight_norm in (0,clamp_value) (default: 10)
             set to a high value to avoid it (e.g 10e3)

--- a/examples/poyo_plus/train.py
+++ b/examples/poyo_plus/train.py
@@ -21,7 +21,6 @@ from torch_brain.data.sampler import (
     DistributedStitchingFixedWindowSampler,
     RandomFixedWindowSampler,
 )
-from torch_brain.optim import SparseLamb
 from torch_brain.models import POYOPlus
 from torch_brain.registry import MODALITY_REGISTRY
 from torch_brain.transforms import Compose
@@ -31,6 +30,8 @@ from torch_brain.utils.callbacks import (
     MultiTaskDecodingStitchEvaluator,
     DataForMultiTaskDecodingStitchEvaluator,
 )
+
+from optim import SparseLamb
 
 # higher speed on machines with tensor cores
 torch.set_float32_matmul_precision("medium")

--- a/torch_brain/__init__.py
+++ b/torch_brain/__init__.py
@@ -2,13 +2,11 @@ from importlib.metadata import version, PackageNotFoundError
 from . import data
 from . import nn
 from . import models
-from . import optim
 from . import utils
 from . import transforms
 from . import registry
 
 from .registry import register_modality, get_modality_by_id, MODALITY_REGISTRY
-
 
 try:
     __version__ = version("torch_brain")


### PR DESCRIPTION
Since we have agreed to not serve custom optimizers with `torch_brain`, this PR removes `SparseLamb` and the `optim.py` module.