### PR TITLE
chore: Update minimum temporaldata version to v0.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Removed `utils.get_sinusoidal_encoding` (legacy) ([#200](https://github.com/neuro-galaxy/torch_brain/pull/200))
 
 ### Changed
+- Changed minimum `temporaldata` version to `v0.1.4` ([#209](https://github.com/neuro-galaxy/torch_brain/pull/209))
 - Moved `DecodingStitchEvaluator` and `MultiTaskDecodingStitchEvaluator` to `utils/callbacks.py` ([#183](https://github.com/neuro-galaxy/torch_brain/pull/183))
 - Replaced `torch_brain.data.dataset.DatasetIndex` with `torch_brain.dataset.DatasetIndex` ([#186](https://github.com/neuro-galaxy/torch_brain/pull/186))
 - `bin_spikes` output shape changed from `(N, T)` to `(T, N)` and default `dtype` changed from `np.float32` to `np.int32` ([#170](https://github.com/neuro-galaxy/torch_brain/pull/170))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
 ]
 requires-python = ">=3.10"
 dependencies = [
-    "temporaldata>=0.1.3",
+    "temporaldata>=0.1.4",
     "numpy",
     "torch~=2.0",
     "einops~=0.6.0",

--- a/tests/test_random_time_scaling.py
+++ b/tests/test_random_time_scaling.py
@@ -68,4 +68,4 @@ def test_regular_scaling():
     data_prime = rts(data)
 
     assert data_prime.lfps.domain.start == 0
-    assert data_prime.lfps.domain.end == 19.8
+    assert data_prime.lfps.domain.end == 20.0


### PR DESCRIPTION
- Change minimum `temporaldata` version to v0.1.4 following its release
- Fix #208 : FAILURE in `test_random_time_scaling`
