### PR TITLE
chore: remove hydra-core from core dependencies

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Install dependencies
       run: |
         source venv/bin/activate
-        uv pip install --upgrade pip 
+        uv pip install --upgrade pip
         uv pip install -e ".[dev]"
         uv pip install lightning
     - name: Install plugin
@@ -58,7 +58,7 @@ jobs:
     - name: Train a POYO model
       run: |
         source venv/bin/activate
-        uv pip install torch-optimizer==0.3.0
+        uv pip install torch-optimizer==0.3.0 hydra-core
         python examples/poyo/train.py --config-name train_mc_maze_small.yaml data_root=data/processed wandb.enable=false epochs=2 eval_epochs=2 optim.lr_decay_start=0.
     - name: Train a POYO+ model
       run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Replaced `torch_brain.data.dataset.DatasetIndex` with `torch_brain.dataset.DatasetIndex` ([#186](https://github.com/neuro-galaxy/torch_brain/pull/186))
 - `bin_spikes` output shape changed from `(N, T)` to `(T, N)` and default `dtype` changed from `np.float32` to `np.int32` ([#170](https://github.com/neuro-galaxy/torch_brain/pull/170))
 - Renamed `torch_brain.models.CaPOYO` to `torch_brain.models.CalciumPOYOPlus` ([#198](https://github.com/neuro-galaxy/torch_brain/pull/198))
+- Removed `hydra-core` as a core dependency ([#211](https://github.com/neuro-galaxy/torch_brain/pull/211))
 
 ### Fixed
 - Fixed `MultiTaskDecodingStitchEvaluator` caching predictions under the wrong sequence index when batch samples have non-overlapping readout types. ([#175](https://github.com/neuro-galaxy/torch_brain/pull/175))

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,3 @@
 global-exclude *.pyc
 global-exclude __pycache__
 recursive-include torch_brain/ *.yaml
-recursive-include hydra_plugins/* *.yaml py.typed

--- a/examples/poyo/README.md
+++ b/examples/poyo/README.md
@@ -6,7 +6,7 @@ Official codebase for POYO published at NeurIPS 2023
 ### Installation
 
 ```bash
-pip install pytorch_brain lightning wandb brainsets
+pip install torch_brain lightning wandb brainsets hydra-core
 ```
 
 ### Training POYO-MP

--- a/examples/poyo_plus/README.md
+++ b/examples/poyo_plus/README.md
@@ -1,6 +1,6 @@
 # POYO+ 🧠
 
-Official codebase for POYO+ from [ICLR 2025].  
+Official codebase for POYO+ from [ICLR 2025].
 [[Paper Link]](https://proceedings.iclr.cc/paper_files/paper/2025/file/953390c834451505703c9da45de634d8-Paper-Conference.pdf)
 
 ---
@@ -13,13 +13,13 @@ This is an example training script for the model in [Azabou and Pan et al. 2025]
 
 **Installing necessary packages**
 ```bash
-pip install torch_brain "lightning>=2.6.0" wandb brainsets
+pip install torch_brain "lightning>=2.6.0" wandb brainsets hydra-core
 ```
 
 > Note: `lightning>=2.6.0` is required because `train.py` passes the
 > `weights_only=False` argument to `Trainer.fit`, which was added in 2.6.0.
 
-**Data Preparation**  
+**Data Preparation**
 There are 1304 sessions in the full Calcium POYO+ model and 30 holdout drifting gratings sessions.
 The raw data for all sessions is ~360GB and processed data uses ~58GB.
 To prepare the data, run:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dev = [
     "pytest<9",
     "black==24.2.0",
     "pre-commit>=3.5.0",
-    "omegaconf",
+    "omegaconf",  # TODO: only needed for old Dataset, remove after cleanup
     "flake8",
     "boto3",
     "tqdm",
@@ -53,6 +53,7 @@ docs = [
     "sphinx-design",
     "sphinx-copybutton",
     "sphinxcontrib-sass",
+    "omegaconf",  # TODO: only needed for old Dataset, remove after cleanup
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,6 @@ dependencies = [
     "numpy",
     "torch~=2.0",
     "einops~=0.6.0",
-    "hydra-core~=1.3.2",
     "torchtyping~=0.1",
     "torchmetrics>=1.6.0",
     "pydantic~=2.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dev = [
     "pytest<9",
     "black==24.2.0",
     "pre-commit>=3.5.0",
+    "omegaconf",
     "flake8",
     "boto3",
     "tqdm",

--- a/torch_brain/data/dataset.py
+++ b/torch_brain/data/dataset.py
@@ -112,7 +112,7 @@ class Dataset(torch.utils.data.Dataset):
         except:
             raise ImportError(
                 "Could not find `omegaconf` which is needed for the old Dataset."
-                " Please install using `pip intall omegaconf`."
+                " Please install using `pip install omegaconf`."
                 " Alternately, it is recommended to switch to torch_brain.dataset.Dataset."
             )
 

--- a/torch_brain/data/dataset.py
+++ b/torch_brain/data/dataset.py
@@ -109,7 +109,7 @@ class Dataset(torch.utils.data.Dataset):
 
         try:
             import omegaconf
-        except:
+        except ImportError:
             raise ImportError(
                 "Could not find `omegaconf` which is needed for the old Dataset."
                 " Please install using `pip install omegaconf`."

--- a/torch_brain/data/dataset.py
+++ b/torch_brain/data/dataset.py
@@ -8,7 +8,6 @@ from typing import Any, Callable, Dict, List, Optional, Tuple
 
 import h5py
 import numpy as np
-import omegaconf
 import torch
 from temporaldata import Data, Interval
 from torch_brain.dataset import DatasetIndex
@@ -107,6 +106,15 @@ class Dataset(torch.utils.data.Dataset):
         self.session_id_prefix_fn = session_id_prefix_fn
         self.subject_id_prefix_fn = subject_id_prefix_fn
         self.keep_files_open = keep_files_open
+
+        try:
+            import omegaconf
+        except:
+            raise ImportError(
+                "Could not find `omegaconf` which is needed for the old Dataset.
+                "Please install using `pip intall omegaconf`."
+                "Alternately, it is recommended to switch to torch_brfain.dataset.Dataset."
+            )
 
         if config is not None:
             assert (

--- a/torch_brain/data/dataset.py
+++ b/torch_brain/data/dataset.py
@@ -111,9 +111,9 @@ class Dataset(torch.utils.data.Dataset):
             import omegaconf
         except:
             raise ImportError(
-                "Could not find `omegaconf` which is needed for the old Dataset.
-                "Please install using `pip intall omegaconf`."
-                "Alternately, it is recommended to switch to torch_brfain.dataset.Dataset."
+                "Could not find `omegaconf` which is needed for the old Dataset."
+                " Please install using `pip intall omegaconf`."
+                " Alternately, it is recommended to switch to torch_brfain.dataset.Dataset."
             )
 
         if config is not None:
@@ -166,7 +166,7 @@ class Dataset(torch.utils.data.Dataset):
     def __del__(self):
         self._close_open_files()
 
-    def _look_for_files(self, config: omegaconf.DictConfig) -> Dict[str, Dict]:
+    def _look_for_files(self, config) -> Dict[str, Dict]:
         recording_dict = {}
 
         for i, selection_list in enumerate(config):

--- a/torch_brain/data/dataset.py
+++ b/torch_brain/data/dataset.py
@@ -113,7 +113,7 @@ class Dataset(torch.utils.data.Dataset):
             raise ImportError(
                 "Could not find `omegaconf` which is needed for the old Dataset."
                 " Please install using `pip intall omegaconf`."
-                " Alternately, it is recommended to switch to torch_brfain.dataset.Dataset."
+                " Alternately, it is recommended to switch to torch_brain.dataset.Dataset."
             )
 
         if config is not None:


### PR DESCRIPTION
`hydra-core` has only needed been for examples, and so can be removed from our core dependencies.

Additionally, `omegaconf` was needed for only the deprecated `torch_brain.data.Dataset`, and so I am adding it to the dev dependencies. Plus, an error to guide users if they are still using old `Dataset` and do not have `omegaconf` installed.

OmegaConf is also used in one of our docs page. That docs page needs to be updated. `omegaconf` in docs dependencies will handle it for now.

Closes #210 