### PR TITLE
Remove `einops`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Removed
 - Removed `torch_brain.utils.prepare_for_readout` (unused) ([#218](https://github.com/neuro-galaxy/torch_brain/pull/218))
+- Removed `einops` as a dependency; replaced all `rearrange`/`repeat` calls with native PyTorch and NumPy equivalents. ([#216](https://github.com/neuro-galaxy/torch_brain/pull/216))
 - Removed `torch_brain.nn.FeedForwad` (too inflexible) ([#204](https://github.com/neuro-galaxy/torch_brain/pull/204))
 - Removed `torch_brain.optim` / `SparseLamb` from the public package API ([#203](https://github.com/neuro-galaxy/torch_brain/pull/203))
 - Remove `utils/gradient_rescale.py` (legacy) ([#201](https://github.com/neuro-galaxy/torch_brain/pull/201))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,6 @@ dependencies = [
     "temporaldata>=0.1.4",
     "numpy",
     "torch~=2.0",
-    "einops~=0.6.0",
     "torchtyping~=0.1",
     "torchmetrics>=1.6.0",
     "pydantic~=2.0",

--- a/torch_brain/models/calcium_poyo_plus.py
+++ b/torch_brain/models/calcium_poyo_plus.py
@@ -261,10 +261,8 @@ class CalciumPOYOPlus(nn.Module):
 
         ### prepare calcium values
         T, N = calcium_traces.df_over_f.shape
-        # (T,) -> (T*N,)
-        input_timestamps = calcium_traces.timestamps.repeat_interleave(N)
-        # (T, N) -> (T*N,) -> (T*N, 1)
-        input_values = calcium_traces.df_over_f.flatten().unsqueeze(-1)
+        input_timestamps = np.repeat(calcium_traces.timestamps, N)  # (T,) -> (T*N,)
+        input_values = calcium_traces.df_over_f.flatten()[:, None]  # (T, N) -> (T*N, 1)
 
         # input unit indices
         local_to_global_map = np.array(self.unit_emb.tokenizer(unit_ids))

--- a/torch_brain/models/calcium_poyo_plus.py
+++ b/torch_brain/models/calcium_poyo_plus.py
@@ -3,7 +3,6 @@ import logging
 
 import numpy as np
 from torch import cat, tensor, int64
-from einops import rearrange, repeat
 import torch.nn as nn
 from torchtyping import TensorType
 from temporaldata import Data
@@ -260,18 +259,18 @@ class CalciumPOYOPlus(nn.Module):
         calcium_traces = data.calcium_traces
         unit_ids = data.units.id
 
-        T, N = calcium_traces.df_over_f.shape
-        input_timestamps = repeat(calcium_traces.timestamps, "T -> (T N)", T=T, N=N)
-
         ### prepare calcium values
         T, N = calcium_traces.df_over_f.shape
-        input_values = rearrange(calcium_traces.df_over_f, "T N -> (T N) 1", T=T, N=N)
+        # (T,) -> (T*N,)
+        input_timestamps = calcium_traces.timestamps.repeat_interleave(N)
+        # (T, N) -> (T*N,) -> (T*N, 1)
+        input_values = calcium_traces.df_over_f.flatten().unsqueeze(-1)
 
         # input unit indices
         local_to_global_map = np.array(self.unit_emb.tokenizer(unit_ids))
         input_unit_index = [local_to_global_map[i] for i in range(len(unit_ids))]
         input_unit_index = tensor(input_unit_index, dtype=int64)
-        input_unit_index = repeat(input_unit_index, "N -> (T N)", T=T, N=N)
+        input_unit_index = input_unit_index.repeat(T)  # (N,) -> (T*N,)
 
         ### prepare latents
         latent_index, latent_timestamps = create_linspace_latent_tokens(

--- a/torch_brain/nn/position_embeddings.py
+++ b/torch_brain/nn/position_embeddings.py
@@ -1,4 +1,3 @@
-from typing import Union
 import torch
 from torch import nn, Tensor
 
@@ -11,10 +10,10 @@ class SinusoidalTimeEmbedding(nn.Module):
     (both inclusive).
 
     Args:
-        dim (int): The dimension of the embedding needed (must be a multiple of 2)
-        t_min (float): Minimum period of the sinusoids. Set this to the smallest
+        dim: The dimension of the embedding needed (must be a multiple of 2)
+        t_min: Minimum period of the sinusoids. Set this to the smallest
             timescale you care about.
-        t_max (float): Maximum period of the sinusoids. Set this to the largest
+        t_max: Maximum period of the sinusoids. Set this to the largest
             timescale you care about.
     """
 
@@ -25,9 +24,10 @@ class SinusoidalTimeEmbedding(nn.Module):
         if dim % 2 != 0:
             raise ValueError("`dim` must be a multiple of 2")
 
-        periods = generate_logspace_timeperiods(dim // 2, t_min, t_max)
+        F = dim // 2
+        periods = generate_logspace_timeperiods(F, t_min, t_max)  # (F,)
         omega = 2 * torch.pi / periods
-        self.register_buffer("omega", omega)
+        self.register_buffer("omega", omega)  # (F,)
 
     @torch.no_grad
     @torch.autocast(device_type="cuda", enabled=False)
@@ -37,8 +37,8 @@ class SinusoidalTimeEmbedding(nn.Module):
         Args:
             timestamps (torch.Tensor): timestamps tensor
         """
-        angles = timestamps[..., None] * self.omega
-        return torch.cat((angles.sin(), angles.cos()), dim=-1)
+        angles = timestamps[..., None] * self.omega  # (...,) x (F,)-> (..., F)
+        return torch.cat((angles.sin(), angles.cos()), dim=-1)  # (..., D)
 
 
 class RotaryTimeEmbedding(nn.Module):
@@ -50,14 +50,14 @@ class RotaryTimeEmbedding(nn.Module):
     The timeperiods are computed using :func:`generate_logspace_timeperiods`.
 
     Args:
-        head_dim (int): Dimension of the attention head.
-        rotate_dim (int): Number of dimensions to rotate. You can choose to rotate only a
+        head_dim: Dimension of the attention head.
+        rotate_dim: Number of dimensions to rotate. You can choose to rotate only a
             small portion of the head dimension using this parameter.
             E.g. `PerceiverIO <https://arxiv.org/abs/2107.14795>`_ found rotating only half
             dimensions to be effective.
-        t_min (float): Minimum period of the sinusoids. Set this to the smallest
+        t_min: Minimum period of the sinusoids. Set this to the smallest
             timescale the attention layer should care about.
-        t_max (float): Maximum period of the sinusoids. Set this to the largest
+        t_max: Maximum period of the sinusoids. Set this to the largest
             timescale the attention layer should care about.
     """
 
@@ -72,10 +72,12 @@ class RotaryTimeEmbedding(nn.Module):
         if not head_dim >= rotate_dim:
             raise ValueError("head_dim must be equal to or larger than rotate_dim")
 
-        periods = generate_logspace_timeperiods(rotate_dim // 2, t_min, t_max)
-        omega = torch.zeros(head_dim // 2)
-        omega[: rotate_dim // 2] = 2 * torch.pi / periods
-        self.register_buffer("omega", omega)
+        F = rotate_dim // 2
+        D = head_dim // 2
+        periods = generate_logspace_timeperiods(F, t_min, t_max)  # (F,)
+        omega = torch.zeros(D)
+        omega[:F] = 2 * torch.pi / periods
+        self.register_buffer("omega", omega)  # (D,)
 
     @torch.no_grad
     @torch.autocast(device_type="cuda", enabled=False)
@@ -84,19 +86,20 @@ class RotaryTimeEmbedding(nn.Module):
         which can then be used by :meth:`RotaryTimeEmbedding.rotate`.
 
         Args:
-            timestamps (torch.Tensor): timestamps tensor.
+            timestamps: timestamps tensor.
         """
-        angles = torch.einsum("..., f -> ... f", timestamps, self.omega)
-        angles = angles.repeat_interleave(2, dim=-1)  # (..., F) -> (..., F*2)
-        rotary_emb = torch.cat((angles.cos(), angles.sin()), dim=-1)
+
+        angles = timestamps[..., None] * self.omega  # (...,) x (D,)-> (..., D)
+        angles = angles.repeat_interleave(2, dim=-1)  # (..., D) -> (..., H)
+        rotary_emb = torch.cat((angles.cos(), angles.sin()), dim=-1)  # (..., H*2)
         return rotary_emb
 
     @staticmethod
     def _rotate_half(x: Tensor) -> Tensor:
-        x = x.unflatten(-1, sizes=(-1, 2))  # (..., D*R) -> (..., D, R) R=2
-        x1, x2 = x.unbind(dim=-1)
-        x = torch.stack((-x2, x1), dim=-1)
-        return x.flatten(start_dim=-2)  # (..., D, R) -> (..., D*R)
+        x = x.unflatten(-1, sizes=(-1, 2))  # (..., H) -> (..., D, 2)
+        x1, x2 = x.unbind(dim=-1)  # (..., D, 2) -> (..., D), (..., D)
+        x = torch.stack((-x2, x1), dim=-1)  # (..., D, 2)
+        return x.flatten(start_dim=-2)  # (..., D, 2) -> (..., H)
 
     @staticmethod
     def rotate(
@@ -107,17 +110,18 @@ class RotaryTimeEmbedding(nn.Module):
         r"""Apply the rotary positional embedding to the input data.
 
         Args:
-            x (torch.Tensor): Input data.
-            rotary_emb (torch.Tensor): The rotary embedding produced by a forward
+            x: Input data.
+            rotary_emb: The rotary embedding produced by a forward
                 call of :class:`RotaryTimeEmbedding`.
-            unsqueeze_dim (int, optional): Dimension where heads are located in the input tensor.
+            unsqueeze_dim: Dimension where heads are located in the input tensor.
                 E.g. For input shape (batch, heads, seq_len, dim) use 1.
                 For input shape (batch, seq_len, heads, dim) use 2.
                 Defaults to 2.
         """
-        rotary_emb = rotary_emb.unsqueeze(unsqueeze_dim).to(x.dtype)
-        cos, sin = rotary_emb.chunk(chunks=2, dim=-1)
-        return (x * cos) + (RotaryTimeEmbedding._rotate_half(x) * sin)
+        rotary_emb = rotary_emb.unsqueeze(unsqueeze_dim)  # (..., H*2) -> (..., 1, H*2)
+        rotary_emb = rotary_emb.to(x.dtype)
+        cos, sin = rotary_emb.chunk(chunks=2, dim=-1)  # (..., 1, H), (..., 1, H)
+        return (x * cos) + (RotaryTimeEmbedding._rotate_half(x) * sin)  # (..., H)
 
     @staticmethod
     def invert(rotary_emb: Tensor) -> Tensor:
@@ -125,25 +129,25 @@ class RotaryTimeEmbedding(nn.Module):
         :math:`t`, then the output embeddings correspond to time :math:`-t`.
 
         Args:
-            rotary_emb (torch.Tensor): Embeddings produced by a forward call of
+            rotary_emb: Embeddings produced by a forward call of
                 :class:`RotaryTimeEmbedding`.
         """
-        cos, sin = rotary_emb.chunk(chunks=2, dim=-1)
-        return torch.cat((cos, -sin), dim=-1)
+        cos, sin = rotary_emb.chunk(chunks=2, dim=-1)  # (..., H), (..., H)
+        return torch.cat((cos, -sin), dim=-1)  # (..., H*2)
 
 
 def generate_logspace_timeperiods(
     num: int,
-    t_min: Union[float, Tensor],
-    t_max: Union[float, Tensor],
+    t_min: float | Tensor,
+    t_max: float | Tensor,
 ) -> Tensor:
     r"""Generates ``num`` timeperiods that are logarithmically spaced between
     ``t_min`` and ``t_max`` (both inclusive).
 
     Args:
-        num (int): number of timestamps needed
-        t_min (float): smallest timeperiod
-        t_max (float): largest timeperiod
+        num: number of timestamps needed
+        t_min: smallest timeperiod
+        t_max: largest timeperiod
     """
     if not 0 < t_min < t_max:
         raise ValueError(

--- a/torch_brain/nn/position_embeddings.py
+++ b/torch_brain/nn/position_embeddings.py
@@ -1,7 +1,6 @@
 from typing import Union
 import torch
 from torch import nn, Tensor
-from einops import repeat, rearrange
 
 
 class SinusoidalTimeEmbedding(nn.Module):
@@ -88,16 +87,16 @@ class RotaryTimeEmbedding(nn.Module):
             timestamps (torch.Tensor): timestamps tensor.
         """
         angles = torch.einsum("..., f -> ... f", timestamps, self.omega)
-        angles = repeat(angles, "... n -> ... (n r)", r=2)
+        angles = angles.repeat_interleave(2, dim=-1)  # (..., F) -> (..., F*2)
         rotary_emb = torch.cat((angles.cos(), angles.sin()), dim=-1)
         return rotary_emb
 
     @staticmethod
     def _rotate_half(x: Tensor) -> Tensor:
-        x = rearrange(x, "... (d r) -> ... d r", r=2)
+        x = x.unflatten(-1, sizes=(-1, 2))  # (..., D*R) -> (..., D, R) R=2
         x1, x2 = x.unbind(dim=-1)
         x = torch.stack((-x2, x1), dim=-1)
-        return rearrange(x, "... d r -> ... (d r)")
+        return x.flatten(start_dim=-2)  # (..., D, R) -> (..., D*R)
 
     @staticmethod
     def rotate(

--- a/torch_brain/nn/rotary_attention.py
+++ b/torch_brain/nn/rotary_attention.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 import torch
 import torch.nn.functional as F
 import torch.nn as nn
@@ -11,8 +9,6 @@ except ImportError:
 
 
 from torch_brain.nn import RotaryTimeEmbedding
-
-# TODO unformize the notation in the shapes with Pytorch convention (Maj)
 
 
 class RotaryCrossAttention(nn.Module):
@@ -33,20 +29,20 @@ class RotaryCrossAttention(nn.Module):
       padding, but requires the sequences to be concatenated rather than stacked.
 
     Args:
-        dim (int): Dimension of input query embeddings
-        context_dim (Optional[int]): Dimension of input context embeddings. If None, uses same as dim
-        heads (int): Number of attention heads
-        dim_head (int): Dimension of each attention head
-        dropout (float): Dropout probability
-        rotate_value (bool): Whether to apply rotary embeddings to values as well as queries/keys
-        use_xformers (bool): Whether to use xformers for attention. Defaults to True.
+        dim: Dimension of input query embeddings
+        context_dim: Dimension of input context embeddings. If None, uses same as dim
+        heads: Number of attention heads
+        dim_head: Dimension of each attention head
+        dropout: Dropout probability
+        rotate_value: Whether to apply rotary embeddings to values as well as queries/keys
+        use_xformers: Whether to use xformers for attention. Defaults to True.
     """
 
     def __init__(
         self,
         *,
         dim: int,
-        context_dim: Optional[int] = None,
+        context_dim: int | None = None,
         heads: int = 8,
         dim_head: int = 64,
         dropout: float = 0.0,
@@ -71,11 +67,11 @@ class RotaryCrossAttention(nn.Module):
 
     def forward(
         self,
-        x_query,
-        x_context,
-        query_pos_emb,
-        context_pos_emb,
-        context_mask=None,
+        x_query: torch.Tensor,
+        x_context: torch.Tensor,
+        query_pos_emb: torch.Tensor,
+        context_pos_emb: torch.Tensor,
+        context_mask: torch.Tensor | None = None,
     ):
         """Forward pass for regular or padded sequences.
 
@@ -131,12 +127,12 @@ class RotaryCrossAttention(nn.Module):
 
     def forward_varlen(
         self,
-        x_query,
-        x_context,
-        query_pos_emb,
-        context_pos_emb,
-        query_seqlen,
-        context_seqlen,
+        x_query: torch.Tensor,
+        x_context: torch.Tensor,
+        query_pos_emb: torch.Tensor,
+        context_pos_emb: torch.Tensor,
+        query_seqlen: torch.Tensor,
+        context_seqlen: torch.Tensor,
     ):
         """Forward pass for variable length sequences.
 
@@ -214,12 +210,12 @@ class RotarySelfAttention(nn.Module):
       padding, but requires the sequences to be concatenated rather than stacked.
 
     Args:
-        dim (int): Dimension of input embeddings
-        heads (int): Number of attention heads
-        dim_head (int): Dimension of each attention head
-        dropout (float): Dropout probability
-        rotate_value (bool): Whether to apply rotary embeddings to values as well as queries/keys
-        use_xformers (bool): Whether to use xformers for attention. Defaults to True.
+        dim: Dimension of input embeddings
+        heads: Number of attention heads
+        dim_head: Dimension of each attention head
+        dropout: Dropout probability
+        rotate_value: Whether to apply rotary embeddings to values as well as queries/keys
+        use_xformers: Whether to use xformers for attention. Defaults to True.
     """
 
     def __init__(
@@ -247,9 +243,9 @@ class RotarySelfAttention(nn.Module):
 
     def forward(
         self,
-        x,
-        rotary_time_emb,
-        x_mask=None,
+        x: torch.Tensor,
+        rotary_time_emb: torch.Tensor,
+        x_mask: torch.Tensor | None = None,
     ):
         """Forward pass for fixed-length sequences.
 
@@ -293,9 +289,9 @@ class RotarySelfAttention(nn.Module):
 
     def forward_varlen(
         self,
-        x,
-        rotary_time_emb,
-        x_seqlen,
+        x: torch.Tensor,
+        rotary_time_emb: torch.Tensor,
+        x_seqlen: torch.Tensor,
     ):
         """Forward pass for variable-length sequences.
 
@@ -346,12 +342,12 @@ class RotarySelfAttention(nn.Module):
 
 def rotary_attn_pytorch_func(
     *,
-    query,
-    key,
-    value,
-    q_pos_emb,
-    kv_pos_emb,
-    attn_mask=None,
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    q_pos_emb: torch.Tensor,
+    kv_pos_emb: torch.Tensor,
+    attn_mask: torch.Tensor | None = None,
     num_heads: int,
     dropout_p: float,
     rotate_value: bool,
@@ -364,22 +360,22 @@ def rotary_attn_pytorch_func(
     r"""Wraps the default attention implementation with rotary embedding application.
 
     Args:
-        query: The query tensor, with shape (b, n_q, (h d))
-        key: The key tensor, with shape (b, n_kv, (h d))
-        value: The value tensor, with shape (b, n_kv, (h d))
-        q_pos_emb: The query rotary position embedding, with shape (b, n_q, d)
-        kv_pos_emb: The key rotary position embedding, with shape (b, n_kv, d)
+        query: The query tensor, with shape (B, N_q, (H D))
+        key: The key tensor, with shape (B, N_kv, (H D))
+        value: The value tensor, with shape (B, N_kv, (H D))
+        q_pos_emb: The query rotary position embedding, with shape (B, N_q, D)
+        kv_pos_emb: The key rotary position embedding, with shape (B, N_kv, D)
         num_heads: The number of attention heads
         dropout_p: The dropout probability
         rotate_value: Whether to rotate the value in addition to the query and key
-        attn_mask: The attention mask, with shape (b, n_kv)
+        attn_mask: The attention mask, with shape (B, N_kv)
 
     Returns:
-        The output tensor, with shape (b, n_q, (h d))
+        The output tensor, with shape (B, N_q, (H D))
     """
 
-    # default attention expects shape b h n d
-    # (b, n, h*d) -> (b, n, h, d) -> (b, h, n, d)
+    # default attention expects shape B H N D
+    # (B, N, H*D) -> (B, N, H, D) -> (B, H, N, D)
     query = query.unflatten(-1, (num_heads, -1)).permute(0, 2, 1, 3)
     key = key.unflatten(-1, (num_heads, -1)).permute(0, 2, 1, 3)
     value = value.unflatten(-1, (num_heads, -1)).permute(0, 2, 1, 3)
@@ -394,7 +390,7 @@ def rotary_attn_pytorch_func(
 
     # attention mask
     if attn_mask is not None:
-        attn_mask = attn_mask[:, None, None, :]  # (b, n) -> (b, 1, 1, n)
+        attn_mask = attn_mask[:, None, None, :]  # (B, N) -> (B, 1, 1, N)
 
     # perform attention, by default will use the optimal attention implementation
     out = F.scaled_dot_product_attention(
@@ -412,19 +408,19 @@ def rotary_attn_pytorch_func(
             unsqueeze_dim=1,
         )
 
-    # (b, h, n, d) -> (b, n, h, d) -> (b, n, h*d)
+    # (B, H, N, D) -> (B, N, H, D) -> (B, N, H*D)
     out = out.permute(0, 2, 1, 3).flatten(-2)
     return out
 
 
 def rotary_attn_xformers_func(
     *,
-    query,
-    key,
-    value,
-    q_pos_emb,
-    kv_pos_emb,
-    attn_mask=None,
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    q_pos_emb: torch.Tensor,
+    kv_pos_emb: torch.Tensor,
+    attn_mask: torch.Tensor | None = None,
     num_heads: int,
     dropout_p: float,
     rotate_value: bool,
@@ -433,22 +429,22 @@ def rotary_attn_xformers_func(
     application.
 
     Args:
-        query: The query tensor, with shape (b n (h d))
-        key: The key tensor, with shape (b n (h d))
-        value: The value tensor, with shape (b n (h d))
-        q_pos_emb: The query rotary position embedding, with shape (b n d)
-        kv_pos_emb: The key rotary position embedding, with shape (b n d)
-        attn_mask: The attention mask, with shape (b, n_kv). A value of True indicates
+        query: The query tensor, with shape (B N (H D))
+        key: The key tensor, with shape (B N (H D))
+        value: The value tensor, with shape (B N (H D))
+        q_pos_emb: The query rotary position embedding, with shape (B N D)
+        kv_pos_emb: The key rotary position embedding, with shape (B N D)
+        attn_mask: The attention mask, with shape B, N_kv). A value of True indicates
             that the element should take part in attention.
         num_heads: The number of attention heads
         dropout_p: The dropout probability
         rotate_value: Whether to rotate the value in addition to the query and key
 
     Returns:
-        The output tensor, with shape (b n (h d))
+        The output tensor, with shape (B N (H D))
     """
-    # xformers attention expects shape (b, n, h, d)
-    query = query.unflatten(-1, (num_heads, -1))  # (b, n, h*d) -> (b, n, h, d)
+    # xformers attention expects shape (B, N, H, D)
+    query = query.unflatten(-1, (num_heads, -1))  # (B, N, H*D) -> (B, N, H, D)
     key = key.unflatten(-1, (num_heads, -1))
     value = value.unflatten(-1, (num_heads, -1))
 
@@ -465,7 +461,7 @@ def rotary_attn_xformers_func(
     attn_mask = (
         attn_mask[:, None, None, :].expand(
             -1, num_heads, query.size(1), -1
-        )  # (b, m) -> (b, h, n, m)
+        )  # (B, M) -> (B, H, N, M)
         if attn_mask is not None
         else None
     )
@@ -490,19 +486,19 @@ def rotary_attn_xformers_func(
             unsqueeze_dim=2,
         )
 
-    out = out.flatten(-2)  # (b, n, h, d) -> (b, n, h*d)
+    out = out.flatten(-2)  # (B, N, H, D) -> (B, N, H*D)
     return out
 
 
 def rotary_attn_xformers_varlen_func(
     *,
-    query,
-    key,
-    value,
-    q_pos_emb,
-    kv_pos_emb,
-    q_seqlen,
-    kv_seqlen,
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    q_pos_emb: torch.Tensor,
+    kv_pos_emb: torch.Tensor,
+    q_seqlen: torch.Tensor,
+    kv_seqlen: torch.Tensor | None,
     num_heads: int,
     dropout_p: float,
     rotate_value: bool,
@@ -511,11 +507,11 @@ def rotary_attn_xformers_varlen_func(
     application.
 
     Args:
-        query: The query tensor, with shape (n, (h d))
-        key: The key tensor, with shape (n, (h d))
-        value: The value tensor, with shape (n, (h d))
-        query_pos_emb: The query rotary position embedding, with shape (n, d)
-        key_pos_emb: The key rotary position embedding, with shape (n, d)
+        query: The query tensor, with shape (N, (H D))
+        key: The key tensor, with shape (N, (H D))
+        value: The value tensor, with shape (N, (H D))
+        query_pos_emb: The query rotary position embedding, with shape (N, D)
+        key_pos_emb: The key rotary position embedding, with shape (N, D)
         num_heads: The number of attention heads
         dropout_p: The dropout probability
         rotate_value: Whether to rotate the value in addition to the query and key
@@ -523,10 +519,10 @@ def rotary_attn_xformers_varlen_func(
         kv_seqlen: The sequence length of the key and value tensors
 
     Returns:
-        The output tensor, with shape (n, (h d))
+        The output tensor, with shape (N, (H D))
     """
-    # xformers attention expects shape (1, n, h, d)
-    # (n, h*d) -> (1, n, h, d)
+    # xformers attention expects shape (1, N, H, D)
+    # (N, H*D) -> (1, N, H, D)
     query = query.unflatten(-1, (num_heads, -1)).unsqueeze(0)
     key = key.unflatten(-1, (num_heads, -1)).unsqueeze(0)
     value = value.unflatten(-1, (num_heads, -1)).unsqueeze(0)
@@ -564,5 +560,5 @@ def rotary_attn_xformers_varlen_func(
             rotary_emb=RotaryTimeEmbedding.invert(q_pos_emb).unsqueeze(0),
         )
 
-    out = out.squeeze(0).flatten(-2)  # (1, n, h, d) -> (n, h*d)
+    out = out.squeeze(0).flatten(-2)  # (1, N, H, D) -> (N, H*D)
     return out

--- a/torch_brain/nn/rotary_attention.py
+++ b/torch_brain/nn/rotary_attention.py
@@ -3,7 +3,6 @@ from typing import Optional
 import torch
 import torch.nn.functional as F
 import torch.nn as nn
-from einops import rearrange, repeat
 
 try:
     import xformers.ops as xops
@@ -378,9 +377,10 @@ def rotary_attn_pytorch_func(
     """
 
     # default attention expects shape b h n d
-    query = rearrange(query, "b n (h d) -> b h n d", h=num_heads)
-    key = rearrange(key, "b n (h d) -> b h n d", h=num_heads)
-    value = rearrange(value, "b n (h d) -> b h n d", h=num_heads)
+    # (b, n, h*d) -> (b, n, h, d) -> (b, h, n, d)
+    query = query.unflatten(-1, (num_heads, -1)).permute(0, 2, 1, 3)
+    key = key.unflatten(-1, (num_heads, -1)).permute(0, 2, 1, 3)
+    value = value.unflatten(-1, (num_heads, -1)).permute(0, 2, 1, 3)
 
     # apply rotary embeddings
     query = RotaryTimeEmbedding.rotate(x=query, rotary_emb=q_pos_emb, unsqueeze_dim=1)
@@ -392,7 +392,7 @@ def rotary_attn_pytorch_func(
 
     # attention mask
     if attn_mask is not None:
-        attn_mask = rearrange(attn_mask, "b n -> b () () n")
+        attn_mask = attn_mask[:, None, None, :]  # (b, n) -> (b, 1, 1, n)
 
     # perform attention, by default will use the optimal attention implementation
     out = F.scaled_dot_product_attention(
@@ -410,8 +410,8 @@ def rotary_attn_pytorch_func(
             unsqueeze_dim=1,
         )
 
-    # return (b, n, (h d), )
-    out = rearrange(out, "b h n d -> b n (h d)")
+    # (b, h, n, d) -> (b, n, h, d) -> (b, n, h*d)
+    out = out.permute(0, 2, 1, 3).flatten(-2)
     return out
 
 
@@ -445,10 +445,10 @@ def rotary_attn_xformers_func(
     Returns:
         The output tensor, with shape (b n (h d))
     """
-    # xformers attention expects shape (1, n, h, d)
-    query = rearrange(query, "b n (h d) -> b n h d", h=num_heads)
-    key = rearrange(key, "b n (h d) -> b n h d", h=num_heads)
-    value = rearrange(value, "b n (h d) -> b n h d", h=num_heads)
+    # xformers attention expects shape (b, n, h, d)
+    query = query.unflatten(-1, (num_heads, -1))  # (b, n, h*d) -> (b, n, h, d)
+    key = key.unflatten(-1, (num_heads, -1))
+    value = value.unflatten(-1, (num_heads, -1))
 
     query = RotaryTimeEmbedding.rotate(x=query, rotary_emb=q_pos_emb, unsqueeze_dim=2)
     key = RotaryTimeEmbedding.rotate(x=key, rotary_emb=kv_pos_emb, unsqueeze_dim=2)
@@ -461,7 +461,9 @@ def rotary_attn_xformers_func(
     # WARNING: this is very slow, avoid using attn_mask if possible, refer to xformers
     # documentation
     attn_mask = (
-        repeat(attn_mask, "b m -> b h n m", h=num_heads, n=query.size(1))
+        attn_mask[:, None, None, :].expand(
+            -1, num_heads, query.size(1), -1
+        )  # (b, m) -> (b, h, n, m)
         if attn_mask is not None
         else None
     )
@@ -486,7 +488,7 @@ def rotary_attn_xformers_func(
             unsqueeze_dim=2,
         )
 
-    out = rearrange(out, "b n h d -> b n (h d)")
+    out = out.flatten(-2)  # (b, n, h, d) -> (b, n, h*d)
     return out
 
 
@@ -522,9 +524,11 @@ def rotary_attn_xformers_varlen_func(
         The output tensor, with shape (n, (h d))
     """
     # xformers attention expects shape (1, n, h, d)
-    query = rearrange(query, "n (h d) -> () n h d", h=num_heads)
-    key = rearrange(key, "n (h d) -> () n h d", h=num_heads)
-    value = rearrange(value, "n (h d) -> () n h d", h=num_heads)
+    query = query.unflatten(-1, (num_heads, -1)).unsqueeze(
+        0
+    )  # (n, h*d) -> (1, n, h, d)
+    key = key.unflatten(-1, (num_heads, -1)).unsqueeze(0)
+    value = value.unflatten(-1, (num_heads, -1)).unsqueeze(0)
 
     # TODO check rotation works
     query = RotaryTimeEmbedding.rotate(x=query, rotary_emb=q_pos_emb.unsqueeze(0))
@@ -559,5 +563,5 @@ def rotary_attn_xformers_varlen_func(
             rotary_emb=RotaryTimeEmbedding.invert(q_pos_emb).unsqueeze(0),
         )
 
-    out = rearrange(out, "() n h d -> n (h d)")
+    out = out.squeeze(0).flatten(-2)  # (1, n, h, d) -> (n, h*d)
     return out

--- a/torch_brain/nn/rotary_attention.py
+++ b/torch_brain/nn/rotary_attention.py
@@ -434,7 +434,7 @@ def rotary_attn_xformers_func(
         value: The value tensor, with shape (B N (H D))
         q_pos_emb: The query rotary position embedding, with shape (B N D)
         kv_pos_emb: The key rotary position embedding, with shape (B N D)
-        attn_mask: The attention mask, with shape B, N_kv). A value of True indicates
+        attn_mask: The attention mask, with shape (B, N_kv). A value of True indicates
             that the element should take part in attention.
         num_heads: The number of attention heads
         dropout_p: The dropout probability

--- a/torch_brain/nn/rotary_attention.py
+++ b/torch_brain/nn/rotary_attention.py
@@ -12,6 +12,8 @@ except ImportError:
 
 from torch_brain.nn import RotaryTimeEmbedding
 
+# TODO unformize the notation in the shapes with Pytorch convention (Maj)
+
 
 class RotaryCrossAttention(nn.Module):
     """Cross-attention layer with rotary positional embeddings.
@@ -524,9 +526,8 @@ def rotary_attn_xformers_varlen_func(
         The output tensor, with shape (n, (h d))
     """
     # xformers attention expects shape (1, n, h, d)
-    query = query.unflatten(-1, (num_heads, -1)).unsqueeze(
-        0
-    )  # (n, h*d) -> (1, n, h, d)
+    # (n, h*d) -> (1, n, h, d)
+    query = query.unflatten(-1, (num_heads, -1)).unsqueeze(0)
     key = key.unflatten(-1, (num_heads, -1)).unsqueeze(0)
     value = value.unflatten(-1, (num_heads, -1)).unsqueeze(0)
 

--- a/torch_brain/utils/tokenizers.py
+++ b/torch_brain/utils/tokenizers.py
@@ -23,13 +23,13 @@ def create_start_end_unit_tokens(unit_ids: np.ndarray, start: float, end: float)
         [TokenType.START_OF_SEQUENCE.value, TokenType.END_OF_SEQUENCE.value],
         dtype=np.int64,
     )
-    token_type_index = np.tile(token_type_index, U)  # (2,) -> (2*U,)
+    token_type_index = np.tile(token_type_index, U)  # (2,) -> (U*2,)
 
     unit_index = np.arange(U)
     unit_index = np.repeat(unit_index, 2)  # (U,) -> (U*2,)
 
     timestamps = np.array([start, end], dtype=np.float64)
-    timestamps = np.tile(timestamps, U)  # (U,) -> (2*U,)
+    timestamps = np.tile(timestamps, U)  # (2,) -> (U*2,)
     return token_type_index, unit_index, timestamps
 
 

--- a/torch_brain/utils/tokenizers.py
+++ b/torch_brain/utils/tokenizers.py
@@ -1,5 +1,4 @@
 import numpy as np
-from einops import repeat
 from enum import Enum
 
 
@@ -22,13 +21,13 @@ def create_start_end_unit_tokens(unit_ids, start, end):
         [TokenType.START_OF_SEQUENCE.value, TokenType.END_OF_SEQUENCE.value],
         dtype=np.int64,
     )
-    token_type_index = repeat(token_type_index, "u -> (t u)", t=len(unit_ids))
+    token_type_index = np.tile(token_type_index, len(unit_ids))  # (u,) -> (t*u,)
 
     unit_index = np.arange(len(unit_ids))
-    unit_index = repeat(unit_index, "u -> (u t)", t=2)
+    unit_index = np.repeat(unit_index, 2)  # (u,) -> (u*t,)
 
     timestamps = np.array([start, end], dtype=np.float64)
-    timestamps = repeat(timestamps, "u -> (t u)", t=len(unit_ids))
+    timestamps = np.tile(timestamps, len(unit_ids))  # (u,) -> (t*u,)
     return token_type_index, unit_index, timestamps
 
 
@@ -49,7 +48,9 @@ def create_linspace_latent_tokens(start, end, step, num_latents_per_step):
     latent_index = np.arange(num_latents_per_step, dtype=np.int64)
 
     num_timestamps = len(latent_timestamps)
-    latent_timestamps = repeat(latent_timestamps, "t -> (t u)", u=len(latent_index))
+    latent_timestamps = np.repeat(
+        latent_timestamps, len(latent_index)
+    )  # (t,) -> (t*u,)
 
-    latent_index = repeat(latent_index, "u -> (t u)", t=num_timestamps)
+    latent_index = np.tile(latent_index, num_timestamps)  # (u,) -> (t*u,)
     return latent_index, latent_timestamps

--- a/torch_brain/utils/tokenizers.py
+++ b/torch_brain/utils/tokenizers.py
@@ -8,49 +8,52 @@ class TokenType(Enum):
     END_OF_SEQUENCE = 2
 
 
-def create_start_end_unit_tokens(unit_ids, start, end):
+def create_start_end_unit_tokens(unit_ids: np.ndarray, start: float, end: float):
     r"""Creates for each unit a start and end token. Each token is defined by the
     unit index, the token type index and the timestamps.
 
     Args:
-        unit_ids (np.ndarray): List of unit identifiers.
-        start (float): The start time of the sequence.
-        end (float): The end time of the sequence.
+        unit_ids: List of unit identifiers.
+        start: The start time of the sequence.
+        end: The end time of the sequence.
     """
+    U = len(unit_ids)
+
     token_type_index = np.array(
         [TokenType.START_OF_SEQUENCE.value, TokenType.END_OF_SEQUENCE.value],
         dtype=np.int64,
     )
-    token_type_index = np.tile(token_type_index, len(unit_ids))  # (u,) -> (t*u,)
+    token_type_index = np.tile(token_type_index, U)  # (2,) -> (2*U,)
 
-    unit_index = np.arange(len(unit_ids))
-    unit_index = np.repeat(unit_index, 2)  # (u,) -> (u*t,)
+    unit_index = np.arange(U)
+    unit_index = np.repeat(unit_index, 2)  # (U,) -> (U*2,)
 
     timestamps = np.array([start, end], dtype=np.float64)
-    timestamps = np.tile(timestamps, len(unit_ids))  # (u,) -> (t*u,)
+    timestamps = np.tile(timestamps, U)  # (U,) -> (2*U,)
     return token_type_index, unit_index, timestamps
 
 
-def create_linspace_latent_tokens(start, end, step, num_latents_per_step):
+def create_linspace_latent_tokens(
+    start: float, end: float, step: float, num_latents_per_step: int
+):
     r"""Creates a sequence of latent tokens. Each token is defined by the
     latent index and the timestamps. The sequence is defined by the start and end
     time and the step size. The group of `num_latents_per_step` latents is repeated
     for each step.
 
     Args:
-        start (float): The start time of the sequence.
-        end (float): The end time of the sequence.
-        step (float): The step size.
-        num_latents_per_step (int): The number of latents per step.
+        start: The start time of the sequence.
+        end: The end time of the sequence.
+        step: The step size.
+        num_latents_per_step: The number of latents per step.
     """
     sequence_len = end - start
     latent_timestamps = np.arange(0, sequence_len, step) + step / 2 + start
     latent_index = np.arange(num_latents_per_step, dtype=np.int64)
 
-    num_timestamps = len(latent_timestamps)
-    latent_timestamps = np.repeat(
-        latent_timestamps, len(latent_index)
-    )  # (t,) -> (t*u,)
+    T = len(latent_timestamps)
+    U = len(latent_index)
 
-    latent_index = np.tile(latent_index, num_timestamps)  # (u,) -> (t*u,)
+    latent_timestamps = np.repeat(latent_timestamps, U)  # (T,) -> (T*U,)
+    latent_index = np.tile(latent_index, T)  # (U,) -> (T*U,)
     return latent_index, latent_timestamps


### PR DESCRIPTION
## Summary

Removes `einops` as a core dependency of `torch_brain`. All usages have been
replaced with equivalent native PyTorch / NumPy operations.

**Files changed:**
- `pyproject.toml` — drop `einops~=0.6.0` from dependencies
- `torch_brain/nn/position_embeddings.py` — replace `repeat`/`rearrange` in
  `RotaryTimeEmbedding.forward` and `_rotate_half`
- `torch_brain/nn/rotary_attention.py` — replace `rearrange`/`repeat` in
  `rotary_attn_pytorch_func`, `rotary_attn_xformers_func`, and
  `rotary_attn_xformers_varlen_func`
- `torch_brain/utils/tokenizers.py` — replace `repeat` with `np.tile`/`np.repeat`
  in `create_start_end_unit_tokens` and `create_linspace_latent_tokens`
- `torch_brain/models/calcium_poyo_plus.py` — replace `rearrange`/`repeat` in
  `CalciumPOYOPlus.forward`
