### PR TITLE
chore: change pyproject author name

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,10 +7,7 @@ name = "torch_brain"
 dynamic = ["version"]
 description = "A package for deep learning models for neuroscience"
 readme = "README.md"
-authors = [
-    { name = "Mehdi Azabou", email = "mehdiazabou@gmail.com" },
-    { name = "Vinam Arora", email = "vinam@seas.upenn.edu" },
-]
+authors = [{ name = "TorchBrain Team", email = "torch-brain-team@googlegroups.com" }]
 license = { text = "Apache-2.0" }
 classifiers = [
     "Programming Language :: Python :: 3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "torch_brain"
 dynamic = ["version"]
 description = "A package for deep learning models for neuroscience"
 readme = "README.md"
-authors = [{ name = "TorchBrain Team", email = "torch-brain-team@googlegroups.com" }]
+authors = [{ name = "TorchBrain Team", email = "contact@torchbrain.org" }]
 license = { text = "Apache-2.0" }
 classifiers = [
     "Programming Language :: Python :: 3",


### PR DESCRIPTION
- Renaming "author" field in pyproject.toml to "TorchBrain Team" (e.g. [PyTorch does this](https://github.com/pytorch/pytorch/blob/main/pyproject.toml)).
- The email is set to a forwarding address on torchbrain.org. Any emails sent to that would be received by @AlexandreAndr, @milosobral, and myself in its current configuration