### PR TITLE
docs: update pygments style

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -63,6 +63,8 @@ html_theme_options = {
     "navbar_start": ["navbar-logo"],
     "navbar_center": ["navbar-nav"],
     "navbar_end": ["theme-switcher", "navbar-icon-links"],
+    "pygments_light_style": "default",
+    "pygments_dark_style": "lightbulb",
 }
 
 html_static_path = ["_static", "generated/css", "js"]
@@ -91,8 +93,6 @@ myst_enable_extensions = [
 ]
 
 nb_execution_mode = "off"
-
-pygments_style = "default"
 
 bokeh_plot_pyfile_include_dirs = [
     "concepts/examples",


### PR DESCRIPTION
Currently, commented and un-commented code in the docs are not easily distinguishable.
Plus, the way pygments style (code colortheme) are set is incorrect for pydata-sphinx-theme
This PR changes the code colortheme for both light- and dark-mode.
