### PR TITLE
cleanup!: rm seed_everything

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Added `torch_brain.samplers` module with dedicated sampler classes moved out of `torch_brain.data.sampler`: `RandomFixedWindowSampler`,`SequentialFixedWindowSampler`, `TrialSampler`, `DistributedEvaluationSamplerWrapper`, and  `DistributedStitchingFixedWindowSampler` ([#217](https://github.com/neuro-galaxy/torch_brain/pull/217))
 
 ### Removed
+- Removed `torch_brain.utils.seed_everything`; a reference implementation can still be found in `examples/poyo/utils.py` ([#227](https://github.com/neuro-galaxy/torch_brain/pull/227))
 - Removed `torch_brain.utils.prepare_for_readout` (unused) ([#218](https://github.com/neuro-galaxy/torch_brain/pull/218))
 - Removed `einops` as a dependency; replaced all `rearrange`/`repeat` calls with native PyTorch and NumPy equivalents. ([#216](https://github.com/neuro-galaxy/torch_brain/pull/216))
 - Removed `torch_brain.nn.FeedForwad` (too inflexible) ([#204](https://github.com/neuro-galaxy/torch_brain/pull/204))

--- a/examples/poyo_plus/finetune.py
+++ b/examples/poyo_plus/finetune.py
@@ -14,11 +14,11 @@ from omegaconf import DictConfig
 
 from torch_brain.registry import MODALITY_REGISTRY
 from torch_brain.utils import callbacks as tbrain_callbacks
-from torch_brain.utils import seed_everything
 from torch_brain.utils.datamodules import DataModule
 from torch_brain.utils.stitcher import StitchEvaluator
 
 from train import POYOTrainWrapper
+from utils import seed_everything
 
 from torch_brain.models import POYOPlus, CalciumPOYOPlus
 

--- a/examples/poyo_plus/train.py
+++ b/examples/poyo_plus/train.py
@@ -25,13 +25,13 @@ from torch_brain.models import POYOPlus
 from torch_brain.registry import MODALITY_REGISTRY
 from torch_brain.transforms import Compose
 from torch_brain.utils import callbacks as tbrain_callbacks
-from torch_brain.utils import seed_everything
 from torch_brain.utils.callbacks import (
     MultiTaskDecodingStitchEvaluator,
     DataForMultiTaskDecodingStitchEvaluator,
 )
 
 from optim import SparseLamb
+from utils import seed_everything
 
 # higher speed on machines with tensor cores
 torch.set_float32_matmul_precision("medium")

--- a/examples/poyo_plus/utils.py
+++ b/examples/poyo_plus/utils.py
@@ -1,21 +1,15 @@
 import os
-import random
 import logging
-
-import torch
+import random
 import numpy as np
-
+import torch
 
 log = logging.getLogger(__name__)
 
 
 def seed_everything(seed: int) -> None:
-    """Sets random seed for reproducibility.
-    Args:
-        seed (int): Random seed.
-    """
     if seed is not None:
-        log.info("Global seed set to {}.".format(seed))
+        log.info(f"Global seed: {seed}")
 
         torch.manual_seed(seed)
         torch.cuda.manual_seed_all(seed)

--- a/torch_brain/utils/__init__.py
+++ b/torch_brain/utils/__init__.py
@@ -4,6 +4,14 @@ from .misc import np_string_prefix
 from .binning import bin_spikes
 from .stitcher import stitch
 
+
+def seed_everything(*args, **kwargs):
+    raise ImportError(
+        "`seed_everything` has been removed from `torch_brain.utils`. "
+        "You can find a reference implementation in `examples/poyo/utils.py`"
+    )
+
+
 __all__ = [
     "stitch",
     "create_linspace_latent_tokens",

--- a/torch_brain/utils/__init__.py
+++ b/torch_brain/utils/__init__.py
@@ -1,4 +1,3 @@
-from .seed_everything import seed_everything
 from .tokenizers import create_linspace_latent_tokens, create_start_end_unit_tokens
 from .weights import resolve_weights_based_on_interval_membership, isin_interval
 from .misc import np_string_prefix
@@ -7,7 +6,6 @@ from .stitcher import stitch
 
 __all__ = [
     "stitch",
-    "seed_everything",
     "create_linspace_latent_tokens",
     "create_start_end_unit_tokens",
     "resolve_weights_based_on_interval_membership",


### PR DESCRIPTION
`torch_brain.utils.seed_everything` moved out of the public API; a reference implementation is still available in `examples/poyo/utils.py` and `examples/poyo_plus/utils.py`. 
Calling it now raises an `ImportError` pointing to the POYO example.
