### PR TITLE
cleanup!: Remove torchtyping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Removed `torch_brain.nn.MultitaskReadout` and `torch_brain.nn.prepare_for_multitask_readout` ([#230](https://github.com/neuro-galaxy/torch_brain/pull/230))
 - Removed `DecodingStitchEvaluator` and `MultiTaskDecodingStitchEvaluator` from `torch_brain.utils.callbacks` ([#230](https://github.com/neuro-galaxy/torch_brain/pull/230))
 - Removed `torch_brain.utils.prepare_for_readout` (unused) ([#218](https://github.com/neuro-galaxy/torch_brain/pull/218))
+- Removed `torchtyping` as a dependency; replaced all `TensorType` annotations in `POYO` with plain `torch.Tensor` ([#231](https://github.com/neuro-galaxy/torch_brain/pull/231))
 - Removed `einops` as a dependency; replaced all `rearrange`/`repeat` calls with native PyTorch and NumPy equivalents. ([#216](https://github.com/neuro-galaxy/torch_brain/pull/216))
 - Removed `torch_brain.nn.FeedForwad` (too inflexible) ([#204](https://github.com/neuro-galaxy/torch_brain/pull/204))
 - Removed `torch_brain.optim` / `SparseLamb` from the public package API ([#203](https://github.com/neuro-galaxy/torch_brain/pull/203))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,6 @@ dependencies = [
     "temporaldata>=0.1.4",
     "numpy",
     "torch~=2.0",
-    "torchtyping~=0.1",
     "pydantic~=2.0",
     "rich",
 ]

--- a/torch_brain/models/poyo.py
+++ b/torch_brain/models/poyo.py
@@ -1,16 +1,16 @@
 import inspect
-from typing import Dict, List
 import logging
-
 from pathlib import Path
+from typing import Dict, List
+
 import numpy as np
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
 from temporaldata import Data
 
-from torch_brain.dataset import Dataset
 from torch_brain.data import pad8, track_mask8
+from torch_brain.dataset import Dataset
 from torch_brain.nn import (
     Embedding,
     InfiniteVocabEmbedding,
@@ -18,7 +18,6 @@ from torch_brain.nn import (
     RotarySelfAttention,
     RotaryTimeEmbedding,
 )
-
 from torch_brain.utils import (
     create_linspace_latent_tokens,
     create_start_end_unit_tokens,
@@ -193,13 +192,13 @@ class POYO(nn.Module):
             output_mask: Boolean mask of shape :math:`(B, N_{out})`.
                 Required when ``unpack_output=True``.
             unpack_output: If ``False``, returns a padded tensor of shape
-                :math:`(B, N_{out}, d_{out})`; use ``output_mask`` to index valid entries.
+                :math:`(B, N_{out}, D_{out})`; use ``output_mask`` to index valid entries.
                 If ``True``, returns a list of :math:`B` tensors each of shape
-                :math:`(N_{out,i}, d_{out})` containing only the valid outputs.
+                :math:`(N_{out,i}, D_{out})` containing only the valid outputs.
 
         Returns:
-            Shape :math:`(B, N_{out}, d_{out})` when ``unpack_output=False``,
-            or a list of :math:`B` tensors of shape :math:`(N_{out,i}, d_{out})`
+            Shape :math:`(B, N_{out}, D_{out})` when ``unpack_output=False``,
+            or a list of :math:`B` tensors of shape :math:`(N_{out,i}, D_{out})`
             when ``unpack_output=True``.
         """
 

--- a/torch_brain/models/poyo.py
+++ b/torch_brain/models/poyo.py
@@ -1,5 +1,5 @@
 import inspect
-from typing import Dict, List, Optional, Union
+from typing import Dict, List
 import logging
 
 from pathlib import Path
@@ -7,7 +7,6 @@ import numpy as np
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-from torchtyping import TensorType
 from temporaldata import Data
 
 from torch_brain.dataset import Dataset
@@ -163,50 +162,45 @@ class POYO(nn.Module):
         self,
         *,
         # input sequence
-        input_unit_index: TensorType["batch", "n_in", int],
-        input_timestamps: TensorType["batch", "n_in", float],
-        input_token_type: TensorType["batch", "n_in", int],
-        input_mask: Optional[TensorType["batch", "n_in", bool]] = None,
+        input_unit_index: torch.Tensor,
+        input_timestamps: torch.Tensor,
+        input_token_type: torch.Tensor,
+        input_mask: torch.Tensor | None = None,
         # latent sequence
-        latent_index: TensorType["batch", "n_latent", int],
-        latent_timestamps: TensorType["batch", "n_latent", float],
+        latent_index: torch.Tensor,
+        latent_timestamps: torch.Tensor,
         # Metadata for queries
-        session_index: TensorType["batch", int],
+        session_index: torch.Tensor,
         # output sequence
-        output_timestamps: TensorType["batch", "n_out", float],
-        output_mask: Optional[TensorType["batch", "n_out", bool]] = None,
+        output_timestamps: torch.Tensor,
+        output_mask: torch.Tensor | None = None,
         unpack_output: bool = False,
-    ) -> Union[
-        TensorType["batch", "n_out", "dim_out", float],
-        List[TensorType[..., "dim_out", float]],
-    ]:
+    ) -> torch.Tensor | List[torch.Tensor]:
         """Forward pass of the POYO model.
 
         The model processes input spike sequences through its encoder-processor-decoder
         architecture to generate task-specific predictions.
 
         Args:
-            input_unit_index: Indices of input units
-            input_timestamps: Timestamps of input spikes
-            input_token_type: Type of input tokens
-            input_mask: Mask for input sequence
-            latent_index: Indices for latent tokens
-            latent_timestamps: Timestamps for latent tokens
-            session_index: Index of the recording session
-            output_timestamps: Timestamps for output predictions
-            output_mask: A mask of the same size as output_timestamps. True implies
-                that particular timestamp is a valid query for POYO. This is required
-                iff `unpack_output` is set to True.
-            unpack_output: If False, this function will return a padded tensor of
-                shape (batch size, num of max output queries in batch, `dim_out`).
-                In this case you have to use `output_mask` externally to only look
-                at valid outputs. If True, this will return a list of Tensors:
-                the length of the list is equal to batch size, the shape of
-                i^th Tensor is (num of valid output queries for i^th sample, `d_out`).
+            input_unit_index: Unit indices of shape ``(B, N_in)``.
+            input_timestamps: Spike timestamps of shape ``(B, N_in)``.
+            input_token_type: Token type indices of shape ``(B, N_in)``.
+            input_mask: Boolean mask of shape ``(B, N_in)``.
+            latent_index: Latent token indices of shape ``(B, N_lat)``.
+            latent_timestamps: Latent token timestamps of shape ``(B, N_lat)``.
+            session_index: Session indices of shape ``(B,)``.
+            output_timestamps: Output query timestamps of shape ``(B, N_out)``.
+            output_mask: Boolean mask of shape ``(B, N_out)``.
+                Required when ``unpack_output=True``.
+            unpack_output: If ``False``, returns a padded tensor of shape
+                ``(B, N_out, dim_out)``; use ``output_mask`` to index valid entries.
+                If ``True``, returns a list of ``B`` tensors each of shape
+                ``(N_out_i, dim_out)`` containing only the valid outputs.
 
         Returns:
-            A :class:`torch.Tensor` of shape `(batch, n_out, dim_out)`
-            containing the predicted outputs corresponding to `output_timestamps`.
+            Shape ``(B, N_out, dim_out)`` when ``unpack_output=False``,
+            or a list of ``B`` tensors of shape ``(N_out_i, dim_out)``
+            when ``unpack_output=True``.
         """
 
         if self.unit_emb.is_lazy():
@@ -407,12 +401,12 @@ class FeedForward(nn.Module):
     """A feed-forward network with GEGLU activation.
 
     Args:
-        dim (int): Input and output dimension
-        mult (int, optional): Multiplier for hidden dimension. Defaults to 4
-        dropout (float, optional): Dropout probability. Defaults to 0.2
+        dim: Input and output dimension
+        mult: Multiplier for hidden dimension. Defaults to 4
+        dropout: Dropout probability. Defaults to 0.2
     """
 
-    def __init__(self, dim, mult=4, dropout=0.2):
+    def __init__(self, dim: int, mult: int = 4, dropout: float = 0.2):
         super().__init__()
         self.net = nn.Sequential(
             nn.Linear(dim, dim * mult * 2),

--- a/torch_brain/models/poyo.py
+++ b/torch_brain/models/poyo.py
@@ -182,24 +182,24 @@ class POYO(nn.Module):
         architecture to generate task-specific predictions.
 
         Args:
-            input_unit_index: Unit indices of shape ``(B, N_in)``.
-            input_timestamps: Spike timestamps of shape ``(B, N_in)``.
-            input_token_type: Token type indices of shape ``(B, N_in)``.
-            input_mask: Boolean mask of shape ``(B, N_in)``.
-            latent_index: Latent token indices of shape ``(B, N_lat)``.
-            latent_timestamps: Latent token timestamps of shape ``(B, N_lat)``.
-            session_index: Session indices of shape ``(B,)``.
-            output_timestamps: Output query timestamps of shape ``(B, N_out)``.
-            output_mask: Boolean mask of shape ``(B, N_out)``.
+            input_unit_index: Unit indices of shape :math:`(B, N_{in})`.
+            input_timestamps: Spike timestamps of shape :math:`(B, N_{in})`.
+            input_token_type: Token type indices of shape :math:`(B, N_{in})`.
+            input_mask: Boolean mask of shape :math:`(B, N_{in})`.
+            latent_index: Latent token indices of shape :math:`(B, N_{lat})`.
+            latent_timestamps: Latent token timestamps of shape :math:`(B, N_{lat})`.
+            session_index: Session indices of shape :math:`(B,)`.
+            output_timestamps: Output query timestamps of shape :math:`(B, N_{out})`.
+            output_mask: Boolean mask of shape :math:`(B, N_{out})`.
                 Required when ``unpack_output=True``.
             unpack_output: If ``False``, returns a padded tensor of shape
-                ``(B, N_out, dim_out)``; use ``output_mask`` to index valid entries.
-                If ``True``, returns a list of ``B`` tensors each of shape
-                ``(N_out_i, dim_out)`` containing only the valid outputs.
+                :math:`(B, N_{out}, d_{out})`; use ``output_mask`` to index valid entries.
+                If ``True``, returns a list of :math:`B` tensors each of shape
+                :math:`(N_{out,i}, d_{out})` containing only the valid outputs.
 
         Returns:
-            Shape ``(B, N_out, dim_out)`` when ``unpack_output=False``,
-            or a list of ``B`` tensors of shape ``(N_out_i, dim_out)``
+            Shape :math:`(B, N_{out}, d_{out})` when ``unpack_output=False``,
+            or a list of :math:`B` tensors of shape :math:`(N_{out,i}, d_{out})`
             when ``unpack_output=True``.
         """
 

--- a/torch_brain/models/poyo.py
+++ b/torch_brain/models/poyo.py
@@ -253,6 +253,9 @@ class POYO(nn.Module):
         output_latents = output_queries + self.dec_ffn(output_queries)
         output = self.readout(output_latents)
 
+        if unpack_output and output_mask is None:
+            raise ValueError("output_mask is required when unpack_output=True")
+
         if unpack_output:
             output = [output[b][output_mask[b]] for b in range(output.size(0))]
 


### PR DESCRIPTION
## Summary

Removes `torchtyping` as a required dependency. The library's runtime
tensor-shape assertions were not being used (no `@typechecked` decorator),
so the annotations provided no functional benefit over plain `torch.Tensor`.

- Remove `torchtyping~=0.1` from `pyproject.toml` dependencies
- Replace all `TensorType[...]` annotations in `POYO.forward` with
  `torch.Tensor` / `torch.Tensor | None` using modern union syntax
- Clean up docstrings to use concise `(B, N)` shape notation
- Add explicit type hints to `FeedForward.__init__` parameters
- Drop now-unused `Optional` and `Union` imports
