### PR TITLE
merge: Modernize typing and replace black with ruff

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -19,5 +19,9 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: '3.10'
-    - run: pip install black==24.2.0
-    - run: black --check .
+    - uses: astral-sh/ruff-action@v3
+      with:
+        args: "check"
+    - uses: astral-sh/ruff-action@v3
+      with:
+        args: "format --check"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,4 +3,5 @@ repos:
     rev: v0.15.15
     hooks:
     - id: ruff
+      args: [--fix]
     - id: ruff-format

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
-  - repo: https://github.com/psf/black
-    rev: 24.3.0
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.15.15
     hooks:
-    - id: black
-      language_version: python3
+    - id: ruff
+    - id: ruff-format

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -132,14 +132,15 @@ To ensure **Neuro-Galaxy** remains maintainable and accessible, we adhere to the
 
 ### Formatting
 
-- All code must be formatted using [Black](https://github.com/psf/black).
-- Run black in your project root:
+- All code must be formatted and linted using [Ruff](https://github.com/astral-sh/ruff).
+- Run ruff in your project root:
 
 ```bash
-black .
+ruff format .
+ruff check --fix .
 ```
 
-- We recommend enabling “Format on Save” in your code editor. You can also set up a hook so the formatter runs automatically before every commit:
+- We recommend enabling “Format on Save” in your code editor. You can also set up a hook so the formatter and linter run automatically before every commit:
 
 ```bash
 pre-commit install

--- a/brainsets_pipelines/allen_visual_coding_ophys_2016/pipeline.py
+++ b/brainsets_pipelines/allen_visual_coding_ophys_2016/pipeline.py
@@ -8,12 +8,10 @@
 # ///
 
 
-import argparse
 import logging
 import os
-from argparse import ArgumentParser, Namespace
+from argparse import ArgumentParser
 from pathlib import Path
-from typing import Optional
 
 import h5py
 import numpy as np
@@ -248,7 +246,7 @@ def extract_calcium_traces(nwbfile):
     period = np.mean(timestamps_diff)
     if not np.allclose(timestamps_diff, period, rtol=1e-03, atol=1e-02):
         raise ValueError(
-            f"Timestamps are not uniformly spaced, found a deviation of {timestamps_diff.max()-timestamps_diff.min()}."
+            f"Timestamps are not uniformly spaced, found a deviation of {timestamps_diff.max() - timestamps_diff.min()}."
         )
     sampling_rate = 1.0 / period
 
@@ -521,7 +519,7 @@ def extract_pupil_info(nwbfile):
     try:
         timestamps, pupil_location = nwbfile.get_pupil_location()
         _, pupil_size = nwbfile.get_pupil_size()
-    except NoEyeTrackingException as e:
+    except NoEyeTrackingException:
         return None
 
     # Check for NaNs

--- a/brainsets_pipelines/churchland_shenoy_neural_2012/pipeline.py
+++ b/brainsets_pipelines/churchland_shenoy_neural_2012/pipeline.py
@@ -7,10 +7,8 @@
 # ///
 
 import datetime
-import os
 from argparse import ArgumentParser, Namespace
 from pathlib import Path
-from typing import Optional
 
 import h5py
 import numpy as np
@@ -20,11 +18,11 @@ from scipy.ndimage import binary_dilation
 
 from torch_brain.data import (
     ArrayDict,
+    BrainsetDescription,
     Data,
+    DeviceDescription,
     Interval,
     IrregularTimeSeries,
-    BrainsetDescription,
-    DeviceDescription,
     SessionDescription,
     serialize_fn_map,
 )
@@ -49,7 +47,7 @@ class Pipeline(BrainsetPipeline):
     def get_manifest(
         cls,
         raw_dir: Path,
-        args: Optional[Namespace],
+        args: Namespace | None,
     ) -> pd.DataFrame:
         asset_list = get_nwb_asset_list(cls.dandiset_id)
         manifest_list = [{"path": x.path, "url": x.download_url} for x in asset_list]
@@ -542,12 +540,12 @@ def extract_spikes(nwbfile, trials, artifact_dict):
             spikes_times = np.concatenate(spikes_times_blocks)
 
             obs_intervals = nwbfile.units[i].obs_intervals[i]
-            assert np.allclose(
-                obs_intervals[:, 0], trial_table["start_time"]
-            ), f"Unit {i}"
-            assert np.allclose(
-                obs_intervals[:, 1], trial_table["stop_time"]
-            ), f"Unit {i}"
+            assert np.allclose(obs_intervals[:, 0], trial_table["start_time"]), (
+                f"Unit {i}"
+            )
+            assert np.allclose(obs_intervals[:, 1], trial_table["stop_time"]), (
+                f"Unit {i}"
+            )
 
         else:
             if len(artifact_index) != 0:

--- a/brainsets_pipelines/flint_slutzky_accurate_2012/pipeline.py
+++ b/brainsets_pipelines/flint_slutzky_accurate_2012/pipeline.py
@@ -4,9 +4,8 @@
 # ///
 
 from argparse import ArgumentParser, Namespace
-from pathlib import Path
-from typing import Optional
 from datetime import datetime
+from pathlib import Path
 
 import h5py
 import numpy as np
@@ -16,11 +15,11 @@ from scipy.io import loadmat
 
 from torch_brain.data import (
     ArrayDict,
+    BrainsetDescription,
     Data,
+    DeviceDescription,
     Interval,
     IrregularTimeSeries,
-    BrainsetDescription,
-    DeviceDescription,
     SessionDescription,
     SubjectDescription,
     serialize_fn_map,
@@ -65,7 +64,7 @@ class Pipeline(BrainsetPipeline):
     def get_manifest(
         cls,
         raw_dir: Path,
-        args: Optional[Namespace],
+        args: Namespace | None,
     ) -> pd.DataFrame:
         manifest_list = [
             {"session_id": x.split(".")[0].lower(), "fname": x} for x in MANIFEST_LIST

--- a/brainsets_pipelines/kemp_sleep_edf_2013/pipeline.py
+++ b/brainsets_pipelines/kemp_sleep_edf_2013/pipeline.py
@@ -10,7 +10,6 @@
 import logging
 from argparse import ArgumentParser
 from pathlib import Path
-from typing import Optional, Tuple
 
 import h5py
 import mne
@@ -78,7 +77,7 @@ class Pipeline(BrainsetPipeline):
         if args.study_type in ["st", "both"]:
             prefixes.append(f"{cls.prefix}/sleep-telemetry/")
 
-        def find_hypnogram_key(s3, psg_key: str) -> Optional[str]:
+        def find_hypnogram_key(s3, psg_key: str) -> str | None:
             """Find the hypnogram file corresponding to a PSG file."""
             psg_path = Path(psg_key)
             base_name = psg_path.stem
@@ -132,7 +131,7 @@ class Pipeline(BrainsetPipeline):
         manifest = pd.DataFrame(manifest_rows).set_index("session_id")
         return manifest
 
-    def download(self, manifest_item) -> Tuple[Path, Path]:
+    def download(self, manifest_item) -> tuple[Path, Path]:
         self.update_status("DOWNLOADING")
         s3 = get_cached_s3_client()
 
@@ -162,7 +161,7 @@ class Pipeline(BrainsetPipeline):
 
         return psg_local, hypnogram_local
 
-    def process(self, download_output: Tuple[Path, Path]) -> None:
+    def process(self, download_output: tuple[Path, Path]) -> None:
         psg_path, hypnogram_path = download_output
 
         self.update_status("PROCESSING")

--- a/brainsets_pipelines/neuroprobe_2025/pipeline.py
+++ b/brainsets_pipelines/neuroprobe_2025/pipeline.py
@@ -6,33 +6,34 @@
 # ]
 # ///
 
-from itertools import product
-import os
-import time
-import h5py
 import logging
+import os
 import shutil
+import time
 import urllib.request
 import zipfile
-import torch
-from torch.utils.data import Subset
+from argparse import ArgumentParser, Namespace
+from itertools import product
+from pathlib import Path
+from typing import Literal, NamedTuple, get_args
+
+import h5py
 import numpy as np
 import pandas as pd
-from pathlib import Path
-from argparse import ArgumentParser, Namespace
-from typing import Dict, List, Literal, Tuple, Optional, NamedTuple, get_args
+import torch
+from torch.utils.data import Subset
 from tqdm import tqdm
 
-from torch_brain.pipeline import BrainsetPipeline
 from torch_brain.data import (
     ArrayDict,
+    BrainsetDescription,
     Data,
     Interval,
     RegularTimeSeries,
-    BrainsetDescription,
     SubjectDescription,
     serialize_fn_map,
 )
+from torch_brain.pipeline import BrainsetPipeline
 
 logging.basicConfig(level=logging.INFO)
 
@@ -54,15 +55,23 @@ COMMON_ASSETS = [
     "data/corrupted_elec.json",
 ]
 
-FILENAME_MAP = lambda sub_id, trial_id: f"sub_{sub_id}_trial{trial_id:03d}"
-ASSET_PATH_MAP = (
-    lambda sub_id, trial_id: f"data/subject_data/sub_{sub_id}/trial{trial_id:03d}/{FILENAME_MAP(sub_id, trial_id)}.h5.zip"
-)
 
-SUBSET_TIER_KEY_MAP = lambda lite, nano: (
-    "lite" if lite else ("nano" if nano else "full")
-)
-LABEL_MODE_KEY_MAP = lambda binary_tasks: "binary" if binary_tasks else "multiclass"
+def FILENAME_MAP(sub_id, trial_id):
+    return f"sub_{sub_id}_trial{trial_id:03d}"
+
+
+def ASSET_PATH_MAP(sub_id, trial_id):
+    return f"data/subject_data/sub_{sub_id}/trial{trial_id:03d}/{FILENAME_MAP(sub_id, trial_id)}.h5.zip"
+
+
+def SUBSET_TIER_KEY_MAP(lite, nano):
+    return "lite" if lite else ("nano" if nano else "full")
+
+
+def LABEL_MODE_KEY_MAP(binary_tasks):
+    return "binary" if binary_tasks else "multiclass"
+
+
 EvalSettingOption = Literal["within_session", "cross_x"]
 ALL_EVAL_SETTINGS = {
     "lite": [True, False],
@@ -113,7 +122,7 @@ class Pipeline(BrainsetPipeline):
     def get_manifest(
         cls,
         raw_dir: Path,
-        args: Optional[Namespace],
+        args: Namespace | None,
     ) -> pd.DataFrame:
         _prepare_neuroprobe_lib(raw_dir)
 
@@ -241,7 +250,7 @@ class Pipeline(BrainsetPipeline):
 
     def iterate_extract_splits(
         self, subject_id: int, trial_id: int
-    ) -> Tuple[Dict[str, Interval], Dict[str, np.ndarray]]:
+    ) -> tuple[dict[str, Interval], dict[str, np.ndarray]]:
         _prepare_neuroprobe_lib(self.raw_dir)
         if not hasattr(self, "all_subjects"):
             # load all subjects and channels once
@@ -265,8 +274,8 @@ class Pipeline(BrainsetPipeline):
             }
 
         all_combinations = product(*ALL_EVAL_SETTINGS.values())
-        split_indices: Dict[str, Interval] = {}
-        split_channel_masks: Dict[str, np.ndarray] = {}
+        split_indices: dict[str, Interval] = {}
+        split_channel_masks: dict[str, np.ndarray] = {}
         for setting_combination in all_combinations:
             lite, nano, binary_tasks, eval_setting = setting_combination
             if lite and nano:  # lite and nano cannot be True at the same time
@@ -389,21 +398,21 @@ def _extract_channel_data(subject) -> ArrayDict:
 
 
 def _extract_and_structure_splits(
-    all_subjects: Dict[int, object],
-    all_channels: Dict[int, ArrayDict],
+    all_subjects: dict[int, object],
+    all_channels: dict[int, ArrayDict],
     subject_id: int,
     trial_id: int,
     lite: bool,
     nano: bool,
     binary_tasks: bool,
     eval_setting: EvalSettingOption,
-) -> Tuple[Dict[str, Interval], Dict[str, np.ndarray]]:
-    split_indices: Dict[str, Interval] = {}
-    split_channel_masks: Dict[str, np.ndarray] = {}
+) -> tuple[dict[str, Interval], dict[str, np.ndarray]]:
+    split_indices: dict[str, Interval] = {}
+    split_channel_masks: dict[str, np.ndarray] = {}
 
-    assert (
-        len(neuroprobe_config.NEUROPROBE_TASKS_MAPPING) > 0
-    ), "No tasks to extract splits for"
+    assert len(neuroprobe_config.NEUROPROBE_TASKS_MAPPING) > 0, (
+        "No tasks to extract splits for"
+    )
     for eval_name in neuroprobe_config.NEUROPROBE_TASKS_MAPPING:
         # load splits via neuroprobe API
         folds = _extract_splits(
@@ -447,7 +456,7 @@ def _extract_and_structure_splits(
 
 
 def _extract_splits(
-    all_subjects: Dict[int, object],
+    all_subjects: dict[int, object],
     subject_id: int,
     trial_id: int,
     lite: bool,
@@ -507,8 +516,8 @@ def _extract_local_role_splits(
     output_dict: bool,
     start_neural_data_before_word_onset: int,
     end_neural_data_after_word_onset: int,
-    max_samples: Optional[int],
-) -> List[Dict[str, object]]:
+    max_samples: int | None,
+) -> list[dict[str, object]]:
     local_dataset = neuroprobe.BrainTreebankSubjectTrialBenchmarkDataset(
         subject=subject,
         trial_id=trial_id,
@@ -659,7 +668,7 @@ def _get_electrode_labels(dataset) -> np.ndarray:
     )
 
 
-def _unpack_dataset_item(item) -> Tuple[np.ndarray, np.ndarray]:
+def _unpack_dataset_item(item) -> tuple[np.ndarray, np.ndarray]:
     if isinstance(item, dict):
         return item["data"], item["label"]
     return item[0], item[1]

--- a/brainsets_pipelines/odoherty_sabes_nonhuman_2017/pipeline.py
+++ b/brainsets_pipelines/odoherty_sabes_nonhuman_2017/pipeline.py
@@ -3,11 +3,10 @@
 # dependencies = ["zenodo_get==2.0.0"]
 # ///
 
-import os
 import datetime
 import hashlib
 import logging
-import subprocess
+import os
 from argparse import ArgumentParser
 from pathlib import Path
 
@@ -17,17 +16,16 @@ import pandas as pd
 
 from torch_brain.data import (
     ArrayDict,
+    BrainsetDescription,
     Data,
+    DeviceDescription,
     Interval,
     IrregularTimeSeries,
     RegularTimeSeries,
-    serialize_fn_map,
-    BrainsetDescription,
-    DeviceDescription,
     SessionDescription,
     SubjectDescription,
+    serialize_fn_map,
 )
-
 from torch_brain.pipeline import BrainsetPipeline
 from torch_brain.utils import calculate_sampling_rate
 
@@ -45,7 +43,7 @@ class Pipeline(BrainsetPipeline):
     @classmethod
     def get_manifest(cls, raw_dir, args) -> pd.DataFrame:
         # list files to download
-        r_fd = os.popen(f"zenodo_get -w - 3854034")
+        r_fd = os.popen("zenodo_get -w - 3854034")
         manifest_out = r_fd.read()
         exit_code = r_fd.close()
         if exit_code is not None and exit_code != 0:
@@ -57,7 +55,7 @@ class Pipeline(BrainsetPipeline):
             raise RuntimeError("zenodo_get (md5) failed")
 
         # parse md5sums
-        with open(raw_dir / "md5sums.txt", "r") as f:
+        with open(raw_dir / "md5sums.txt") as f:
             md5sums = {}
             for line in f:
                 line = line.strip()
@@ -225,7 +223,7 @@ def extract_behavior(h5file):
 
     cursor_pos = h5file["cursor_pos"][:].T
     finger_pos = h5file["finger_pos"][:].T
-    target_pos = h5file["target_pos"][:].T
+    h5file["target_pos"][:].T  # noqa: B018
     timestamps = h5file["t"][:][0]
 
     expected_period = 0.004

--- a/brainsets_pipelines/pei_pandarinath_nlb_2021/pipeline.py
+++ b/brainsets_pipelines/pei_pandarinath_nlb_2021/pipeline.py
@@ -3,31 +3,30 @@
 # dependencies = ["dandi==0.74.0"]
 # ///
 
-from argparse import ArgumentParser
 import datetime
+from argparse import ArgumentParser
 
-import numpy as np
 import h5py
-from pynwb import NWBHDF5IO
+import numpy as np
 import pandas as pd
+from pynwb import NWBHDF5IO
 
 from torch_brain.data import (
+    BrainsetDescription,
     Data,
-    IrregularTimeSeries,
+    DeviceDescription,
     Interval,
     RegularTimeSeries,
-    BrainsetDescription,
     SessionDescription,
-    DeviceDescription,
     serialize_fn_map,
 )
+from torch_brain.pipeline import BrainsetPipeline
 from torch_brain.utils.dandi import (
+    download_file,
     extract_spikes_from_nwbfile,
     extract_subject_from_nwb,
     get_nwb_asset_list,
-    download_file,
 )
-from torch_brain.pipeline import BrainsetPipeline
 
 parser = ArgumentParser()
 parser.add_argument("--redownload", action="store_true")
@@ -139,7 +138,7 @@ class Pipeline(BrainsetPipeline):
             domain="auto",
         )
 
-        if not "test" in str(fpath):
+        if "test" not in str(fpath):
             self.update_status("Creating Splits")
             # extract behavior
             data.hand, data.eye = extract_behavior(nwbfile, trials)

--- a/brainsets_pipelines/perich_miller_population_2018/pipeline.py
+++ b/brainsets_pipelines/perich_miller_population_2018/pipeline.py
@@ -6,36 +6,32 @@
 # ]
 # ///
 
-from argparse import ArgumentParser
-from typing import NamedTuple
-from pynwb import NWBHDF5IO
-
 import datetime
-import h5py
+from argparse import ArgumentParser
 
+import h5py
 import numpy as np
+import pandas as pd
 from pynwb import NWBHDF5IO
 from scipy.ndimage import binary_dilation, binary_erosion
 from sklearn.model_selection import train_test_split
-import pandas as pd
 
 from torch_brain.data import (
-    Data,
-    IrregularTimeSeries,
-    Interval,
     BrainsetDescription,
-    SessionDescription,
+    Data,
     DeviceDescription,
+    Interval,
+    IrregularTimeSeries,
+    SessionDescription,
     serialize_fn_map,
 )
+from torch_brain.pipeline import BrainsetPipeline
 from torch_brain.utils.dandi import (
+    download_file,
     extract_spikes_from_nwbfile,
     extract_subject_from_nwb,
-    download_file,
     get_nwb_asset_list,
 )
-
-from torch_brain.pipeline import BrainsetPipeline
 
 parser = ArgumentParser()
 parser.add_argument("--redownload", action="store_true")

--- a/brainsets_pipelines/vollan_moser_alternating_2025/pipeline.py
+++ b/brainsets_pipelines/vollan_moser_alternating_2025/pipeline.py
@@ -6,7 +6,6 @@
 import logging
 from argparse import ArgumentParser, Namespace
 from pathlib import Path
-from typing import Optional
 
 import h5py
 import numpy as np
@@ -129,7 +128,7 @@ class Pipeline(BrainsetPipeline):
     def get_manifest(
         cls,
         raw_dir: Path,
-        args: Optional[Namespace],
+        args: Namespace | None,
     ) -> pd.DataFrame:
         manifest_list = []
         for fname in MANIFEST_FILES:

--- a/docs/source/api_reference.py
+++ b/docs/source/api_reference.py
@@ -76,7 +76,6 @@ API_REFERENCE = {m: import_module(m).__api_ref__ for m in API_MODS}
 
 
 def build_api_rst():
-    import importlib
     import pathlib
 
     generated = pathlib.Path(__file__).parent / "generated"
@@ -104,7 +103,7 @@ def build_api_rst():
 
     for template in rst_templates:
         # Read the corresponding template file into jinja2
-        with open(template["template_path"], "r") as f:
+        with open(template["template_path"]) as f:
             t = jinja2.Template(f.read())
 
         # Render the template and write to the target

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -110,8 +110,8 @@ sass_targets = {
 Path("generated/css/").mkdir(exist_ok=True, parents=True)
 
 
-import notebooks.nlb_maze_minimal_example.modify
-from api_reference import build_api_rst
+import notebooks.nlb_maze_minimal_example.modify  # noqa: E402
+from api_reference import build_api_rst  # noqa: E402
 
 build_api_rst()
 notebooks.nlb_maze_minimal_example.modify.main()

--- a/docs/source/guides/sampling/_utils.py
+++ b/docs/source/guides/sampling/_utils.py
@@ -1,9 +1,9 @@
 import os
+
 import requests
-from typing import Optional
 
 
-def download_file_from_s3(file_path: str, target_path: Optional[str] = None) -> None:
+def download_file_from_s3(file_path: str, target_path: str | None = None) -> None:
     """Downloads a file from the torch-brain S3 bucket.
 
     Args:

--- a/docs/source/notebooks/nlb_maze_minimal_example/modify.py
+++ b/docs/source/notebooks/nlb_maze_minimal_example/modify.py
@@ -1,5 +1,6 @@
-from pathlib import Path
 import json
+from pathlib import Path
+
 import nbformat
 
 

--- a/docs/source/notebooks/nlb_maze_minimal_example/nlb_maze_minimal_example.ipynb
+++ b/docs/source/notebooks/nlb_maze_minimal_example/nlb_maze_minimal_example.ipynb
@@ -327,11 +327,11 @@
    },
    "outputs": [],
    "source": [
+    "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",
     "import torch\n",
-    "from torch import nn, Tensor\n",
-    "from tqdm.auto import tqdm\n",
-    "import matplotlib.pyplot as plt"
+    "from torch import Tensor, nn\n",
+    "from tqdm.auto import tqdm"
    ]
   },
   {
@@ -366,7 +366,7 @@
    ],
    "source": [
     "# Hyperparameters (feel free to play with these)\n",
-    "BIN_SIZE = 0.01 # seconds\n",
+    "BIN_SIZE = 0.01  # seconds\n",
     "BATCH_SIZE = 8\n",
     "EPOCHS = 100\n",
     "LR = 1e-3\n",
@@ -401,10 +401,13 @@
    "outputs": [],
    "source": [
     "from typing import Literal\n",
-    "from temporaldata import Interval\n",
-    "from torch_brain.utils import bin_spikes\n",
-    "from torch_brain.dataset import DatasetIndex\n",
+    "\n",
     "from brainsets.datasets import PeiPandarinathNLB2021\n",
+    "\n",
+    "from temporaldata import Interval\n",
+    "from torch_brain.dataset import DatasetIndex\n",
+    "from torch_brain.utils import bin_spikes\n",
+    "\n",
     "\n",
     "class SimpleNLBMazeDataset(PeiPandarinathNLB2021):\n",
     "    sample_length = 0.7\n",
@@ -529,8 +532,9 @@
     }
    ],
    "source": [
-    "from torch_brain.samplers import TrialSampler\n",
     "from torch.utils.data import DataLoader  # standard PyTorch loader\n",
+    "\n",
+    "from torch_brain.samplers import TrialSampler\n",
     "\n",
     "DATA_ROOT = \"data/processed\"  # This is where we stored the processed dataset\n",
     "\n",
@@ -554,9 +558,15 @@
     "\n",
     "print(f\"Number of units:    {train_ds.num_units}\")\n",
     "print(f\"Bins per sample:    {train_ds.num_bins}  (bin size = {BIN_SIZE}s)\")\n",
-    "print(f\"Target samples:     {train_ds.out_samples}  (at {train_ds.out_sampling_rate} Hz)\")\n",
-    "print(f\"Train trials:       {len(train_ds.get_sampling_intervals()[train_ds.recording_ids[0]])}\")\n",
-    "print(f\"Val trials:         {len(val_ds.get_sampling_intervals()[val_ds.recording_ids[0]])}\")"
+    "print(\n",
+    "    f\"Target samples:     {train_ds.out_samples}  (at {train_ds.out_sampling_rate} Hz)\"\n",
+    ")\n",
+    "print(\n",
+    "    f\"Train trials:       {len(train_ds.get_sampling_intervals()[train_ds.recording_ids[0]])}\"\n",
+    ")\n",
+    "print(\n",
+    "    f\"Val trials:         {len(val_ds.get_sampling_intervals()[val_ds.recording_ids[0]])}\"\n",
+    ")"
    ]
   },
   {
@@ -631,7 +641,9 @@
     "\n",
     "fig, axes = plt.subplots(2, 1, figsize=(5, 5))\n",
     "\n",
-    "axes[0].imshow(X.T.numpy(), aspect=\"auto\", cmap=\"Greys\", origin=\"lower\", interpolation=\"nearest\")\n",
+    "axes[0].imshow(\n",
+    "    X.T.numpy(), aspect=\"auto\", cmap=\"Greys\", origin=\"lower\", interpolation=\"nearest\"\n",
+    ")\n",
     "axes[0].set_title(\"Binned spikes (input)\")\n",
     "axes[0].set_xlabel(\"Time bin\")\n",
     "axes[0].set_ylabel(\"Unit\")\n",
@@ -968,7 +980,7 @@
     "\n",
     "val_r2_history = []\n",
     "\n",
-    "for epoch in (epoch_pbar := tqdm(range(EPOCHS))):\n",
+    "for _epoch in (epoch_pbar := tqdm(range(EPOCHS))):\n",
     "    model.train()\n",
     "    for X, Y in train_loader:\n",
     "        X, Y = X.to(device), Y.to(device)\n",

--- a/examples/nlb_maze_minimal/models.py
+++ b/examples/nlb_maze_minimal/models.py
@@ -1,4 +1,4 @@
-from torch import nn, Tensor
+from torch import Tensor, nn
 
 
 class Linear(nn.Module):

--- a/examples/nlb_maze_minimal/train.py
+++ b/examples/nlb_maze_minimal/train.py
@@ -135,7 +135,7 @@ print(f"Number of parameters {num_parameters:,}")
 optim = torch.optim.AdamW(model.parameters(), lr=args.lr)
 
 # Train Loop
-for epoch in (epoch_pbar := tqdm(range(args.epochs))):
+for _epoch in (epoch_pbar := tqdm(range(args.epochs))):
     # Train epoch
     model.train()
     for X, Y in (step_pbar := tqdm(train_loader, leave=False)):

--- a/examples/poyo/datasets/poyo_1.py
+++ b/examples/poyo/datasets/poyo_1.py
@@ -1,8 +1,7 @@
-from typing import Callable
+from collections.abc import Callable
 
 from datasets.poyo_mp import PoyoMPDataset
 from datasets.wrapper import PoyoReadoutConfig
-
 from torch_brain.data import Data
 from torch_brain.datasets import (
     ChurchlandShenoyNeural2012,

--- a/examples/poyo/datasets/wrapper.py
+++ b/examples/poyo/datasets/wrapper.py
@@ -1,5 +1,5 @@
+from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Callable
 
 import numpy as np
 import torch

--- a/examples/poyo/optim.py
+++ b/examples/poyo/optim.py
@@ -49,17 +49,17 @@ class SparseLamb(Optimizer):
         sparse: bool = False,
     ) -> None:
         if lr <= 0.0:
-            raise ValueError("Invalid learning rate: {}".format(lr))
+            raise ValueError(f"Invalid learning rate: {lr}")
         if eps < 0.0:
-            raise ValueError("Invalid epsilon value: {}".format(eps))
+            raise ValueError(f"Invalid epsilon value: {eps}")
         if not 0.0 <= betas[0] < 1.0:
-            raise ValueError("Invalid beta parameter at index 0: {}".format(betas[0]))
+            raise ValueError(f"Invalid beta parameter at index 0: {betas[0]}")
         if not 0.0 <= betas[1] < 1.0:
-            raise ValueError("Invalid beta parameter at index 1: {}".format(betas[1]))
+            raise ValueError(f"Invalid beta parameter at index 1: {betas[1]}")
         if weight_decay < 0:
-            raise ValueError("Invalid weight_decay value: {}".format(weight_decay))
+            raise ValueError(f"Invalid weight_decay value: {weight_decay}")
         if clamp_value < 0.0:
-            raise ValueError("Invalid clamp value: {}".format(clamp_value))
+            raise ValueError(f"Invalid clamp value: {clamp_value}")
 
         defaults = dict(
             lr=lr, betas=betas, eps=eps, weight_decay=weight_decay, sparse=sparse
@@ -68,7 +68,7 @@ class SparseLamb(Optimizer):
         self.adam = adam
         self.debias = debias
 
-        super(SparseLamb, self).__init__(params, defaults)
+        super().__init__(params, defaults)
 
     def step(self, closure=None):
         r"""Performs a single optimization step.

--- a/examples/poyo/train_simple.py
+++ b/examples/poyo/train_simple.py
@@ -1,14 +1,22 @@
 import logging
-from tqdm import tqdm
-from omegaconf import DictConfig
-import hydra
-from hydra.utils import instantiate
 
-import pandas as pd
+import hydra
 import numpy as np
+import pandas as pd
 import torch
 import torchmetrics
 import wandb
+from datasets.wrapper import PoyoDatasetWrapper
+from hydra.utils import instantiate
+from omegaconf import DictConfig
+from tqdm import tqdm
+from utils import (
+    BehaviorStitcher,
+    create_optim,
+    move_to_device,
+    seed_everything,
+    weighted_mse_loss_fn,
+)
 
 from torch_brain.batching import collate
 from torch_brain.models import POYO
@@ -16,15 +24,6 @@ from torch_brain.samplers import (
     RandomFixedWindowSampler,
     SequentialFixedWindowSampler,
 )
-
-from utils import (
-    seed_everything,
-    move_to_device,
-    BehaviorStitcher,
-    create_optim,
-    weighted_mse_loss_fn,
-)
-from datasets.wrapper import PoyoDatasetWrapper
 
 
 @hydra.main(version_base="1.3", config_path="./configs")
@@ -90,7 +89,6 @@ def main(cfg: DictConfig):
     # Train loop
     step = 0
     for epoch in tqdm(range(cfg.epochs), desc="Epoch"):
-
         # Train epoch
         model.train()
         loader_pbar = tqdm(train_loader, leave=False)

--- a/examples/poyo/utils.py
+++ b/examples/poyo/utils.py
@@ -1,14 +1,15 @@
-import os
 import logging
+import os
 import random
-from omegaconf import DictConfig
+
 import numpy as np
 import torch
+from omegaconf import DictConfig
+from optim import SparseLamb
 from torch import Tensor
 
-from torch_brain.utils.stitcher import stitch
 from torch_brain.models import POYO
-from optim import SparseLamb
+from torch_brain.utils.stitcher import stitch
 
 log = logging.getLogger(__name__)
 
@@ -97,7 +98,7 @@ def create_optim(model: POYO, steps_per_epoch: int, cfg: DictConfig):
     log.info(
         f"Optim: max_lr={max_lr}, "
         f"# Embedding params={sum(p.numel() for p in emb_params):,}, "
-        f"# Non-Embedding params={sum(p.numel()for p in nonemb_params):,}"
+        f"# Non-Embedding params={sum(p.numel() for p in nonemb_params):,}"
     )
     return optim, scheduler
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,6 @@ dev = [
     "torch~=2.0",
     "scipy>=1.10.1",
     "pytest<9",
-    "black==24.2.0",
     "pre-commit>=3.5.0",
     "omegaconf",  # TODO: only needed for old Dataset, remove after cleanup
     "flake8",
@@ -48,6 +47,7 @@ dev = [
     "mne-bids",
     "dandi",
     "ty",
+    "ruff",
 ]
 docs = [
     "sphinx",
@@ -75,6 +75,12 @@ include = ["torch_brain*"]
 
 [project.scripts]
 brainsets = "torch_brain.pipeline._cli:cli"
+
+[tool.ruff]
+target-version = "py310"
+
+[tool.ruff.lint]
+select = ["I"]
 
 [tool.ty.environment]
 python-version = "3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,7 +78,7 @@ brainsets = "torch_brain.pipeline._cli:cli"
 
 [tool.ruff]
 target-version = "py310"
-exclude = ["brainsets", "temporaldata"]
+exclude = ["brainsets", "temporaldata"] # TODO: remove after cleanup
 
 [tool.ruff.lint]
 select = ["I", "F", "UP", "B", "E"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,9 +78,11 @@ brainsets = "torch_brain.pipeline._cli:cli"
 
 [tool.ruff]
 target-version = "py310"
+exclude = ["brainsets", "temporaldata"]
 
 [tool.ruff.lint]
-select = ["I"]
+select = ["I", "F", "UP", "B", "E"]
+ignore = ["E501", "B905"]
 
 [tool.ty.environment]
 python-version = "3.10"

--- a/scripts/data_benchmarks/benchmark.py
+++ b/scripts/data_benchmarks/benchmark.py
@@ -29,10 +29,10 @@ _source = os.environ.get(
 )
 sys.path.insert(0, _source)
 
-import h5py
-import numpy as np
+import h5py  # noqa: E402
+import numpy as np  # noqa: E402
 
-from torch_brain.data import (
+from torch_brain.data import (  # noqa: E402
     ArrayDict,
     Data,
     Interval,

--- a/scripts/data_benchmarks/compare.py
+++ b/scripts/data_benchmarks/compare.py
@@ -54,8 +54,7 @@ def extract_source(commit: str) -> str:
     git_proc = subprocess.run(
         ["git", "archive", commit, "--", "temporaldata/"],
         cwd=REPO_ROOT,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
+        capture_output=True,
         check=False,
     )
     if git_proc.returncode != 0:
@@ -72,8 +71,7 @@ def extract_source(commit: str) -> str:
     tar_proc = subprocess.run(
         ["tar", "xf", "-", "-C", tmpdir],
         input=git_proc.stdout,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
+        capture_output=True,
         check=False,
     )
     if tar_proc.returncode != 0:

--- a/tests/_test_old_dataset_sim.py
+++ b/tests/_test_old_dataset_sim.py
@@ -219,7 +219,7 @@ def test_dataset_selection(dummy_data):
         assert len(ds.recording_dict) == 1
 
 
-def test_get_recording_data(dummy_data):
+def test_get_recording_data_lengths(dummy_data):
     ds = Dataset(
         dummy_data,
         split=None,
@@ -355,9 +355,9 @@ def test_disable_data_leakage_check(dummy_data):
         recording_id="allen_neuropixels_mock_1/20100102_1",
     )
 
-    assert ds._check_for_data_leakage_flag == True
+    assert ds._check_for_data_leakage_flag
     ds.disable_data_leakage_check()
-    assert ds._check_for_data_leakage_flag == False
+    assert not ds._check_for_data_leakage_flag
 
 
 def test_get_brainset_ids(dummy_data):

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -1,14 +1,14 @@
 """Tests for CLI commands in torch_brain.pipeline._cli module."""
 
+from unittest.mock import MagicMock, patch
+
 import pytest
-from pathlib import Path
-from unittest.mock import patch, MagicMock
 from click.testing import CliRunner
 
 from torch_brain.pipeline._cli.cli import cli
 from torch_brain.pipeline._cli.cli_completion import (
-    _detect_shell,
     SHELL_COMPLETION_FILENAMES,
+    _detect_shell,
 )
 from torch_brain.pipeline.config import CONFIG_FILE
 

--- a/tests/data/test_arraydict.py
+++ b/tests/data/test_arraydict.py
@@ -1,10 +1,10 @@
-import pytest
 import os
+import tempfile
 
 import h5py
 import numpy as np
 import pandas as pd
-import tempfile
+import pytest
 
 from torch_brain.data import ArrayDict, LazyArrayDict
 
@@ -123,7 +123,7 @@ def test_lazy_array_dict(test_filepath):
 
         assert data.__class__ == LazyArrayDict
 
-        data.waveform_mean
+        _ = data.waveform_mean
         # final attribute was accessed, the object should automatically convert to ArrayDict
         assert data.__class__ == ArrayDict
 

--- a/tests/data/test_concat.py
+++ b/tests/data/test_concat.py
@@ -1,5 +1,5 @@
-import pytest
 import numpy as np
+
 from torch_brain.data import IrregularTimeSeries, concat
 
 

--- a/tests/data/test_data.py
+++ b/tests/data/test_data.py
@@ -494,12 +494,12 @@ def test_data_has_nested_attribute_lazy(test_filepath):
         assert lazy_data.has_nested_attribute("nested_data.level2_primitive")
 
         # Check attributes remain lazy after has_nested_attribute calls
-        assert isinstance(
-            lazy_data.spikes.__dict__["unit_index"], h5py.Dataset
-        ), "spikes.unit_index was loaded"
-        assert isinstance(
-            lazy_data.units.__dict__["id"], h5py.Dataset
-        ), "units.id was loaded"
+        assert isinstance(lazy_data.spikes.__dict__["unit_index"], h5py.Dataset), (
+            "spikes.unit_index was loaded"
+        )
+        assert isinstance(lazy_data.units.__dict__["id"], h5py.Dataset), (
+            "units.id was loaded"
+        )
         assert isinstance(
             lazy_data.nested_data.level2_array_dict.__dict__["l2_field"], h5py.Dataset
         ), "nested_data.l2_array_dict.l2_field was loaded"

--- a/tests/data/test_descriptions.py
+++ b/tests/data/test_descriptions.py
@@ -12,7 +12,6 @@ from torch_brain.data import (
 
 
 class TestSubjectDescription:
-
     def test_basic_usage_with_all_parameters(self):
         result = SubjectDescription(
             id="subject_1",
@@ -98,7 +97,6 @@ class TestSubjectDescription:
 
 
 class TestBrainsetDescription:
-
     def test_basic_usage_with_all_parameters(self):
         result = BrainsetDescription(
             id="brainset_1",
@@ -193,7 +191,6 @@ class TestBrainsetDescription:
 
 
 class TestSessionDescription:
-
     def test_basic_usage_with_all_parameters(self):
         recording_date = datetime.datetime(2024, 1, 15, 10, 30, 0)
         result = SessionDescription(
@@ -235,7 +232,6 @@ class TestSessionDescription:
 
 
 class TestDeviceDescription:
-
     def test_basic_usage_with_all_parameters(self):
         result = DeviceDescription(
             id="device_1",

--- a/tests/data/test_file_handle.py
+++ b/tests/data/test_file_handle.py
@@ -1,13 +1,15 @@
-import pytest
 import os
+import tempfile
+
 import h5py
 import numpy as np
-import tempfile
+import pytest
+
 from torch_brain.data import (
+    Data,
+    Interval,
     IrregularTimeSeries,
     RegularTimeSeries,
-    Interval,
-    Data,
 )
 
 

--- a/tests/data/test_h5_io.py
+++ b/tests/data/test_h5_io.py
@@ -1,14 +1,16 @@
-import pytest
 import os
+import tempfile
+
 import h5py
 import numpy as np
-import tempfile
+import pytest
+
 from torch_brain.data import (
-    RegularTimeSeries,
-    IrregularTimeSeries,
-    Interval,
     Data,
+    Interval,
+    IrregularTimeSeries,
     LazyInterval,
+    RegularTimeSeries,
 )
 
 
@@ -187,72 +189,72 @@ class TestNestedDataLazyPropagation:
         """Test that lazy=True loads intervals as LazyInterval in nested Data."""
         with h5py.File(nested_data_filepath, "r") as f:
             loaded = Data.from_hdf5(f, lazy=True)
-            assert isinstance(
-                loaded.nested.interval, LazyInterval
-            ), "Level 1: interval should be LazyInterval when lazy=True"
-            assert isinstance(
-                loaded.nested.nested_level2.interval, LazyInterval
-            ), "Level 2: interval should be LazyInterval when lazy=True"
+            assert isinstance(loaded.nested.interval, LazyInterval), (
+                "Level 1: interval should be LazyInterval when lazy=True"
+            )
+            assert isinstance(loaded.nested.nested_level2.interval, LazyInterval), (
+                "Level 2: interval should be LazyInterval when lazy=True"
+            )
 
     def test_lazy_true_domain(self, nested_data_filepath):
         """Test that lazy=True loads domains as LazyInterval in nested Data."""
         with h5py.File(nested_data_filepath, "r") as f:
             loaded = Data.from_hdf5(f, lazy=True)
-            assert isinstance(
-                loaded.nested.domain, LazyInterval
-            ), "Level 1: domain should be LazyInterval when lazy=True"
-            assert isinstance(
-                loaded.nested.nested_level2.domain, LazyInterval
-            ), "Level 2: domain should be LazyInterval when lazy=True"
+            assert isinstance(loaded.nested.domain, LazyInterval), (
+                "Level 1: domain should be LazyInterval when lazy=True"
+            )
+            assert isinstance(loaded.nested.nested_level2.domain, LazyInterval), (
+                "Level 2: domain should be LazyInterval when lazy=True"
+            )
 
     def test_lazy_false_interval(self, nested_data_filepath):
         """Test that lazy=False loads intervals as regular Interval in nested Data."""
         with h5py.File(nested_data_filepath, "r") as f:
             loaded = Data.from_hdf5(f, lazy=False)
-            assert (
-                type(loaded.nested.interval) == Interval
-            ), f"Level 1: interval should be Interval when lazy=False, got {type(loaded.nested.interval)}"
-            assert not isinstance(
-                loaded.nested.interval, LazyInterval
-            ), "Level 1: interval should NOT be LazyInterval when lazy=False"
-            assert (
-                type(loaded.nested.nested_level2.interval) == Interval
-            ), f"Level 2: interval should be Interval when lazy=False, got {type(loaded.nested.nested_level2.interval)}"
-            assert not isinstance(
-                loaded.nested.nested_level2.interval, LazyInterval
-            ), "Level 2: interval should NOT be LazyInterval when lazy=False"
+            assert type(loaded.nested.interval) is Interval, (
+                f"Level 1: interval should be Interval when lazy=False, got {type(loaded.nested.interval)}"
+            )
+            assert not isinstance(loaded.nested.interval, LazyInterval), (
+                "Level 1: interval should NOT be LazyInterval when lazy=False"
+            )
+            assert type(loaded.nested.nested_level2.interval) is Interval, (
+                f"Level 2: interval should be Interval when lazy=False, got {type(loaded.nested.nested_level2.interval)}"
+            )
+            assert not isinstance(loaded.nested.nested_level2.interval, LazyInterval), (
+                "Level 2: interval should NOT be LazyInterval when lazy=False"
+            )
 
     def test_lazy_false_domain(self, nested_data_filepath):
         """Test that lazy=False loads domains as regular Interval in nested Data."""
         with h5py.File(nested_data_filepath, "r") as f:
             loaded = Data.from_hdf5(f, lazy=False)
-            assert (
-                type(loaded.nested.domain) == Interval
-            ), f"Level 1: domain should be Interval when lazy=False, got {type(loaded.nested.domain)}"
-            assert not isinstance(
-                loaded.nested.domain, LazyInterval
-            ), "Level 1: domain should NOT be LazyInterval when lazy=False"
-            assert (
-                type(loaded.nested.nested_level2.domain) == Interval
-            ), f"Level 2: domain should be Interval when lazy=False, got {type(loaded.nested.nested_level2.domain)}"
-            assert not isinstance(
-                loaded.nested.nested_level2.domain, LazyInterval
-            ), "Level 2: domain should NOT be LazyInterval when lazy=False"
+            assert type(loaded.nested.domain) is Interval, (
+                f"Level 1: domain should be Interval when lazy=False, got {type(loaded.nested.domain)}"
+            )
+            assert not isinstance(loaded.nested.domain, LazyInterval), (
+                "Level 1: domain should NOT be LazyInterval when lazy=False"
+            )
+            assert type(loaded.nested.nested_level2.domain) is Interval, (
+                f"Level 2: domain should be Interval when lazy=False, got {type(loaded.nested.nested_level2.domain)}"
+            )
+            assert not isinstance(loaded.nested.nested_level2.domain, LazyInterval), (
+                "Level 2: domain should NOT be LazyInterval when lazy=False"
+            )
 
     def test_materialize_converts_lazy(self, nested_data_filepath):
         """Test that materialize() converts LazyInterval to Interval in nested Data."""
         with h5py.File(nested_data_filepath, "r") as f:
             loaded = Data.from_hdf5(f, lazy=True)
             loaded.materialize()
-            assert (
-                type(loaded.nested.interval) == Interval
-            ), "Level 1: interval should be Interval after materialize()"
-            assert not isinstance(
-                loaded.nested.interval, LazyInterval
-            ), "Level 1: interval should NOT be LazyInterval after materialize()"
-            assert (
-                type(loaded.nested.domain) == Interval
-            ), "Level 1: domain should be Interval after materialize()"
-            assert not isinstance(
-                loaded.nested.domain, LazyInterval
-            ), "Level 1: domain should NOT be LazyInterval after materialize()"
+            assert type(loaded.nested.interval) is Interval, (
+                "Level 1: interval should be Interval after materialize()"
+            )
+            assert not isinstance(loaded.nested.interval, LazyInterval), (
+                "Level 1: interval should NOT be LazyInterval after materialize()"
+            )
+            assert type(loaded.nested.domain) is Interval, (
+                "Level 1: domain should be Interval after materialize()"
+            )
+            assert not isinstance(loaded.nested.domain, LazyInterval), (
+                "Level 1: domain should NOT be LazyInterval after materialize()"
+            )

--- a/tests/data/test_interval.py
+++ b/tests/data/test_interval.py
@@ -1,13 +1,15 @@
-import pytest
+import h5py
 import numpy as np
 import pandas as pd
-import h5py
+import pytest
+
 from torch_brain.data import Interval, LazyInterval
 
 
 @pytest.fixture
 def test_filepath(request):
-    import os, tempfile
+    import os
+    import tempfile
 
     tmpfile = tempfile.NamedTemporaryFile(suffix=".h5", delete=False)
     filepath = tmpfile.name
@@ -155,11 +157,11 @@ def test_lazy_interval(test_filepath):
 
         assert data.__class__ == LazyInterval
 
-        data.end
+        _ = data.end
         assert data.__class__ == LazyInterval
 
-        data.go_cue_time
-        data.drifting_gratings_dir
+        _ = data.go_cue_time
+        _ = data.drifting_gratings_dir
         # final attribute was accessed, the object should automatically convert to ArrayDict
         assert data.__class__ == Interval
 
@@ -405,7 +407,8 @@ def test_split():
 
 
 def test_and():
-    op = lambda x, y: x & y
+    def op(x, y):
+        return x & y
 
     I1 = Interval.from_list([(1.0, 2.3)])
     I2 = Interval.from_list([(1.7, 6.9)])
@@ -462,7 +465,8 @@ def test_and():
 
 
 def test_or():
-    op = lambda x, y: x | y
+    def op(x, y):
+        return x | y
 
     I1 = Interval.from_list([(1.0, 2.3)])
     I2 = Interval.from_list([(1.7, 6.9)])
@@ -525,7 +529,8 @@ def test_or():
 
 
 def test_difference():
-    op = lambda x, y: x.difference(y)
+    def op(x, y):
+        return x.difference(y)
 
     I1 = Interval.from_list([(1.0, 2.3)])
     I2 = Interval.from_list([(1.7, 6.9)])
@@ -620,7 +625,9 @@ def easy_symmetric_check(I1, I2, Iexp, op):
 
 
 def test_and_edge_cases():
-    op = lambda x, y: x & y
+    def op(x, y):
+        return x & y
+
     empty = Interval(np.array([]), np.array([]))
 
     # both empty
@@ -656,7 +663,9 @@ def test_and_edge_cases():
 
 
 def test_or_edge_cases():
-    op = lambda x, y: x | y
+    def op(x, y):
+        return x | y
+
     empty = Interval(np.array([]), np.array([]))
 
     # both empty
@@ -726,7 +735,9 @@ def test_overlapping_input_raises():
 
 
 def test_difference_edge_cases():
-    op = lambda x, y: x.difference(y)
+    def op(x, y):
+        return x.difference(y)
+
     empty = Interval(np.array([]), np.array([]))
 
     # both empty
@@ -789,52 +800,52 @@ def test_dilate():
 def test_is_dijoint_is_sorted():
     # Test sorted and disjoint interval
     sorted_disjoint = Interval(np.array([1.0, 3.0, 5.0]), np.array([2.0, 4.0, 6.0]))
-    assert sorted_disjoint.is_disjoint() == True
-    assert sorted_disjoint.is_sorted() == True
+    assert sorted_disjoint.is_disjoint()
+    assert sorted_disjoint.is_sorted()
 
     # Test not sorted but disjoint interval
     unsorted_disjoint = Interval(np.array([3.0, 1.0, 5.0]), np.array([4.0, 2.0, 6.0]))
-    assert unsorted_disjoint.is_disjoint() == True
-    assert unsorted_disjoint.is_sorted() == False
+    assert unsorted_disjoint.is_disjoint()
+    assert not unsorted_disjoint.is_sorted()
 
     # Test not sorted and not disjoint interval
     unsorted_overlapping = Interval(
         np.array([3.0, 1.0, 2.0]), np.array([5.0, 4.0, 6.0])
     )
-    assert unsorted_overlapping.is_disjoint() == False
-    assert unsorted_overlapping.is_sorted() == False
+    assert not unsorted_overlapping.is_disjoint()
+    assert not unsorted_overlapping.is_sorted()
 
     # Test sorted but not disjoint interval
     sorted_overlapping = Interval(np.array([1.0, 2.0, 3.0]), np.array([4.0, 5.0, 6.0]))
-    assert sorted_overlapping.is_disjoint() == False
-    assert sorted_overlapping.is_sorted() == True
+    assert not sorted_overlapping.is_disjoint()
+    assert sorted_overlapping.is_sorted()
 
     # Test edge case: interval of one point
     point_interval = Interval(np.array([1.0, 1.0, 3.0]), np.array([1.0, 3.0, 3.0]))
-    assert point_interval.is_disjoint() == True
-    assert point_interval.is_sorted() == True
+    assert point_interval.is_disjoint()
+    assert point_interval.is_sorted()
 
     # Test edge case: mixed point and non-point intervals
     mixed_interval = Interval(
         np.array([1.0, 2.0, 3.0, 4.0]), np.array([1.0, 2.5, 3.0, 5.0])
     )
-    assert mixed_interval.is_disjoint() == True
-    assert mixed_interval.is_sorted() == True
+    assert mixed_interval.is_disjoint()
+    assert mixed_interval.is_sorted()
 
     # Test edge case: adjacent intervals
     adjacent_interval = Interval(np.array([1.0, 2.0, 3.0]), np.array([2.0, 3.0, 4.0]))
-    assert adjacent_interval.is_disjoint() == True
-    assert adjacent_interval.is_sorted() == True
+    assert adjacent_interval.is_disjoint()
+    assert adjacent_interval.is_sorted()
 
     # Test interval object with one interval
     single_interval = Interval(np.array([1.0]), np.array([2.0]))
-    assert single_interval.is_disjoint() == True
-    assert single_interval.is_sorted() == True
+    assert single_interval.is_disjoint()
+    assert single_interval.is_sorted()
 
     # Test empty interval
     empty_interval = Interval(np.array([]), np.array([]))
-    assert empty_interval.is_disjoint() == True
-    assert empty_interval.is_sorted() == True
+    assert empty_interval.is_disjoint()
+    assert empty_interval.is_sorted()
 
 
 class TestIntervalCoalesce:

--- a/tests/data/test_irregular_ts.py
+++ b/tests/data/test_irregular_ts.py
@@ -1,10 +1,12 @@
-import pytest
 import os
+import tempfile
+
 import h5py
 import numpy as np
 import pandas as pd
-import tempfile
-from torch_brain.data import IrregularTimeSeries, LazyIrregularTimeSeries, Interval
+import pytest
+
+from torch_brain.data import Interval, IrregularTimeSeries, LazyIrregularTimeSeries
 
 
 @pytest.fixture
@@ -233,11 +235,11 @@ def test_lazy_irregular_timeseries(test_filepath):
 
         assert data.__class__ == LazyIrregularTimeSeries
 
-        data.timestamps
+        _ = data.timestamps
         assert data.__class__ == LazyIrregularTimeSeries
 
-        data.waveforms
-        data.values
+        _ = data.waveforms
+        _ = data.values
         # final attribute was accessed, the object should automatically convert to ArrayDict
         assert data.__class__ == IrregularTimeSeries
 

--- a/tests/data/test_materialize.py
+++ b/tests/data/test_materialize.py
@@ -1,15 +1,17 @@
-import pytest
 import os
+import tempfile
+
 import h5py
 import numpy as np
-import tempfile
+import pytest
+
 from torch_brain.data import (
     ArrayDict,
-    IrregularTimeSeries,
-    RegularTimeSeries,
-    Interval,
-    LazyInterval,
     Data,
+    Interval,
+    IrregularTimeSeries,
+    LazyInterval,
+    RegularTimeSeries,
 )
 
 
@@ -103,10 +105,10 @@ def test_materialize(test_filepath):
     for key in data.keys():
         obj = getattr(data, key)
         if isinstance(obj, (Data, RegularTimeSeries, IrregularTimeSeries, Interval)):
-            assert (
-                "Lazy" not in obj.__class__.__name__
-            ), f"{key} is still a Lazy object: {obj.__class__.__name__}"
+            assert "Lazy" not in obj.__class__.__name__, (
+                f"{key} is still a Lazy object: {obj.__class__.__name__}"
+            )
 
-    assert not isinstance(
-        data.domain, LazyInterval
-    ), f"data.domain is still a LazyInterval object"
+    assert not isinstance(data.domain, LazyInterval), (
+        "data.domain is still a LazyInterval object"
+    )

--- a/tests/data/test_regular_ts.py
+++ b/tests/data/test_regular_ts.py
@@ -173,7 +173,7 @@ def test_lazy_regular_timeseries(test_filepath):
 
         assert data.__class__ == LazyRegularTimeSeries
 
-        data.raw
+        _ = data.raw
         # final attribute was accessed, the object should automatically convert to ArrayDict
         assert data.__class__ == RegularTimeSeries
 
@@ -245,7 +245,7 @@ def test_lazy_regular_timeseries(test_filepath):
 
 
 def test_slice_numerical_instability():
-    ts = RegularTimeSeries(value=np.zeros((40)), sampling_rate=4)
+    ts = RegularTimeSeries(value=np.zeros(40), sampling_rate=4)
     # Expected timestamps: [0.0, 0.25, 0.5, 0.75, 1.0, 1.25, ...]
 
     eps = 1e-14
@@ -303,7 +303,7 @@ def test_slice_numerical_instability():
     assert sliced_ts.domain.start[0] == 0.25
     assert sliced_ts.domain.end[-1] == 1.0
 
-    ts = RegularTimeSeries(value=np.zeros((40)), sampling_rate=10)
+    ts = RegularTimeSeries(value=np.zeros(40), sampling_rate=10)
     # Expected timestamps: [0.0, 0.1, 0.2, ...]
 
     # Using math that natively generates known float anomalies.
@@ -317,7 +317,7 @@ def test_slice_numerical_instability():
 
 
 def test_slice_outside_domain(test_filepath):
-    ts = RegularTimeSeries(value=np.zeros((100)), sampling_rate=10, domain_start=10.0)
+    ts = RegularTimeSeries(value=np.zeros(100), sampling_rate=10, domain_start=10.0)
 
     def _assert_slice_outside_domain(ts):
         sliced_ts = ts.slice(0, 5, reset_origin=False)
@@ -736,7 +736,6 @@ class TestRegularTimeSeriesCoercion:
 
 
 class TestIndexMask:
-
     @pytest.fixture(params=["regular", "lazy"])
     def rts(self, request, test_filepath):
         rts = RegularTimeSeries(
@@ -818,7 +817,6 @@ class TestIndexMask:
 
 
 class TestIsGappy:
-
     @pytest.fixture(params=["regular", "lazy"])
     def rts(self, request, test_filepath):
         rts = RegularTimeSeries(
@@ -865,7 +863,6 @@ class TestIsGappy:
 
 
 class TestToIrregular:
-
     @pytest.fixture(params=["regular", "lazy"])
     def rts(self, request, test_filepath):
         rts = RegularTimeSeries(

--- a/tests/data/test_select_by_mask.py
+++ b/tests/data/test_select_by_mask.py
@@ -172,7 +172,6 @@ class TestLazyMaskIsCopied:
 
 
 class TestNewDomainIsNotShallowCopy:
-
     def test_irregular_ts(self):
         data = _make_irregular()
         masked = data.select_by_mask(np.array([True, False, True]))
@@ -182,7 +181,6 @@ class TestNewDomainIsNotShallowCopy:
 
 
 class TestPrivateAttribsAreDeepCopied:
-
     def test_array_dict(self):
         data = _make_array_dict()
         data._private = np.array([0, 1])
@@ -206,7 +204,6 @@ class TestPrivateAttribsAreDeepCopied:
 
 
 class TestRegularTimeSeriesNotImplemented:
-
     def test_raises_not_implemented(self):
         data = RegularTimeSeries(value=np.zeros(4), sampling_rate=1.0)
         with pytest.raises(NotImplementedError):
@@ -233,29 +230,29 @@ class TestCachedSorted:
             timestamps=np.array([0.0, 1.0, 0.5, 2.0]),
             domain="auto",
         )
-        assert data.is_sorted() == False
+        assert not data.is_sorted()
 
         # If original data is unsorted
         masked = data.select_by_mask(np.array([True, False, True, True]))
-        assert masked._sorted == None
-        assert masked.is_sorted() == True
+        assert masked._sorted is None
+        assert masked.is_sorted()
 
         # If original data is sorted
         masked2 = masked.select_by_mask(np.array([True, False, True]))
-        assert masked2._sorted == True
+        assert masked2._sorted
 
     def test_interval(self):
         data = Interval(
             start=np.array([0.0, 1.0, 0.5, 2.0]),
             end=np.array([0.1, 1.1, 0.6, 2.1]),
         )
-        assert data.is_sorted() == False
+        assert not data.is_sorted()
 
         # If original data is unsorted
         masked = data.select_by_mask(np.array([True, False, True, True]))
-        assert masked._sorted == None
-        assert masked.is_sorted() == True
+        assert masked._sorted is None
+        assert masked.is_sorted()
 
         # If original data is sorted
         masked2 = masked.select_by_mask(np.array([True, False, True]))
-        assert masked2._sorted == True
+        assert masked2._sorted

--- a/tests/data/test_serialize.py
+++ b/tests/data/test_serialize.py
@@ -1,9 +1,11 @@
-import pytest
 import os
-import h5py
 import tempfile
-from torch_brain.data import Data
 from enum import Enum
+
+import h5py
+import pytest
+
+from torch_brain.data import Data
 
 
 @pytest.fixture

--- a/tests/datasets/test_openneuro_dataset.py
+++ b/tests/datasets/test_openneuro_dataset.py
@@ -486,7 +486,7 @@ class TestHashAssignmentSensitivity:
             recording_ids=["rec-001"],
             seed=99,
         )
-        rec = _make_recording("rec-001", subject_id="sub-xyz")
+        _make_recording("rec-001", subject_id="sub-xyz")
 
         assignment_42 = _expected_hash_assignment(
             "sub-xyz", seed=42, split_ratios=ds_seed42.split_ratios

--- a/tests/pipeline/test_neuroprobe2025_pipeline.py
+++ b/tests/pipeline/test_neuroprobe2025_pipeline.py
@@ -4,13 +4,12 @@ from types import SimpleNamespace
 
 import h5py
 import numpy as np
+from _utils import add_pipelines_to_path
 
 from torch_brain.data import RegularTimeSeries
 
-from _utils import add_pipelines_to_path
-
 add_pipelines_to_path()
-from neuroprobe_2025 import (  # ty:ignore[unresolved-import]
+from neuroprobe_2025 import (  # noqa: E402  # ty:ignore[unresolved-import]
     pipeline as neuroprobe_pipeline,
 )
 

--- a/tests/pipeline/test_openneuro_pipeline.py
+++ b/tests/pipeline/test_openneuro_pipeline.py
@@ -1,14 +1,14 @@
 """Unit tests for OpenNeuro Pipeline classes."""
 
-import pytest
+import datetime
+from argparse import Namespace
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import mne
 import numpy as np
 import pandas as pd
-import mne
-import datetime
-
-from pathlib import Path
-from unittest.mock import MagicMock, patch, Mock, PropertyMock
-from argparse import Namespace
+import pytest
 
 from torch_brain.data import Data, Interval
 from torch_brain.pipeline.openneuro import OpenNeuroPipeline
@@ -856,7 +856,7 @@ class TestDownload:
             "torch_brain.pipeline.openneuro.download_recording"
         ) as mock_download:
             with patch("torch_brain.pipeline.openneuro.download_dataset_description"):
-                result = pipeline.download(manifest_row)
+                pipeline.download(manifest_row)
 
         mock_download.assert_called_once()
 

--- a/tests/pipeline/test_read_inline_metadata.py
+++ b/tests/pipeline/test_read_inline_metadata.py
@@ -1,8 +1,9 @@
 """Tests for _read_inline_metadata function in cli_prepare module."""
 
-import pytest
-from pathlib import Path
 import tempfile
+from pathlib import Path
+
+import pytest
 
 from torch_brain.pipeline._cli.cli_prepare import _read_inline_metadata
 

--- a/tests/pipeline/test_vollan_pipeline.py
+++ b/tests/pipeline/test_vollan_pipeline.py
@@ -1,20 +1,16 @@
-import sys
-from pathlib import Path
 import numpy as np
 import pytest
-from torch_brain.data import Interval
-
 from _utils import add_pipelines_to_path
 
 add_pipelines_to_path()
-from vollan_moser_alternating_2025.pipeline import (  # ty:ignore[unresolved-import]
+from vollan_moser_alternating_2025.pipeline import (  # noqa: E402  # ty:ignore[unresolved-import]
+    LMT_POPULATIONS,
+    LMT_VARIABLES,
     build_domain_from_timestamps,
     build_sleep_domain,
     extract_navigation_samples,
     extract_navigation_units_and_spikes,
     extract_theta_chunks,
-    LMT_POPULATIONS,
-    LMT_VARIABLES,
 )
 
 # ---------------------------------------------------------------------------

--- a/tests/test_binning.py
+++ b/tests/test_binning.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pytest
-from torch_brain.data import ArrayDict, Data, Interval, IrregularTimeSeries
 
+from torch_brain.data import ArrayDict, Data, Interval, IrregularTimeSeries
 from torch_brain.transforms.bin_spikes import BinSpikes
 from torch_brain.utils.binning import bin_spikes
 

--- a/tests/test_collate.py
+++ b/tests/test_collate.py
@@ -6,14 +6,14 @@ from torch_brain.batching import (
     chain,
     collate,
     pad,
-    pad8,
     pad2d,
     pad2d8,
+    pad8,
     track_batch,
     track_mask,
-    track_mask8,
     track_mask2d,
     track_mask2d8,
+    track_mask8,
 )
 
 

--- a/tests/test_infinite_vocab_embedding.py
+++ b/tests/test_infinite_vocab_embedding.py
@@ -1,4 +1,5 @@
 import copy
+
 import pytest
 import torch
 

--- a/tests/test_new_dataset.py
+++ b/tests/test_new_dataset.py
@@ -1,29 +1,27 @@
 import os
-import h5py
-import pytest
 from datetime import datetime
+
+import h5py
 import numpy as np
+import pytest
 
 from torch_brain.data import (
+    ArrayDict,
+    BrainsetDescription,
     Data,
     Interval,
     IrregularTimeSeries,
-    ArrayDict,
     RegularTimeSeries,
-)
-from torch_brain.data import serialize_fn_map
-from torch_brain.data import (
-    BrainsetDescription,
     SessionDescription,
     SubjectDescription,
+    serialize_fn_map,
 )
-
 from torch_brain.datasets import (
     Dataset,
     DatasetIndex,
+    MultiChannelDatasetMixin,
     NestedDataset,
     SpikingDatasetMixin,
-    MultiChannelDatasetMixin,
 )
 
 

--- a/tests/test_poyo.py
+++ b/tests/test_poyo.py
@@ -1,7 +1,8 @@
+from pathlib import Path
+
+import boto3
 import pytest
 import torch
-from pathlib import Path
-import boto3
 from botocore import UNSIGNED
 from botocore.config import Config
 from tqdm import tqdm

--- a/tests/test_random_time_scaling.py
+++ b/tests/test_random_time_scaling.py
@@ -1,14 +1,13 @@
 import numpy as np
 
 from torch_brain.data import (
-    Data,
     ArrayDict,
+    Data,
     Interval,
     IrregularTimeSeries,
     RegularTimeSeries,
 )
 from torch_brain.transforms.random_time_scaling import RandomTimeScaling
-from torch_brain.transforms.unit_dropout import TriangleDistribution, UnitDropout
 
 
 def test_irregular_scaling():

--- a/tests/test_rotary_attention.py
+++ b/tests/test_rotary_attention.py
@@ -1,5 +1,6 @@
 import pytest
 import torch
+
 from torch_brain.nn.rotary_attention import RotaryCrossAttention, RotarySelfAttention
 
 

--- a/tests/test_sampler.py
+++ b/tests/test_sampler.py
@@ -1,16 +1,14 @@
-import pytest
-
 import numpy as np
+import pytest
 import torch
 
 from torch_brain.data import Interval
-
+from torch_brain.datasets import DatasetIndex
 from torch_brain.samplers import (
-    SequentialFixedWindowSampler,
     RandomFixedWindowSampler,
+    SequentialFixedWindowSampler,
     TrialSampler,
 )
-from torch_brain.datasets import DatasetIndex
 
 
 # helper
@@ -116,7 +114,7 @@ def test_random_sampler():
     # sample and check that all indices are within the expected range
     samples = list(sampler)
     assert len(samples) == 9
-    assert samples_in_sampling_intervals(samples, sampling_intervals) == True
+    assert samples_in_sampling_intervals(samples, sampling_intervals)
 
     # sample again and check that the indices are different this time
     samples2 = list(sampler)
@@ -132,7 +130,7 @@ def test_random_sampler():
         generator=torch.Generator().manual_seed(42),
     )
     samples = list(sampler)
-    assert samples_in_sampling_intervals(samples, sampling_intervals) == True
+    assert samples_in_sampling_intervals(samples, sampling_intervals)
 
     # Having window_length bigger than any interval should raise an error
     with pytest.raises(ValueError):

--- a/tests/test_stitch.py
+++ b/tests/test_stitch.py
@@ -1,4 +1,5 @@
 import torch
+
 from torch_brain.utils.stitcher import stitch
 
 

--- a/tests/test_stitcher_sampler.py
+++ b/tests/test_stitcher_sampler.py
@@ -1,7 +1,6 @@
-import pytest
 import numpy as np
-from torch_brain.data import Interval
 
+from torch_brain.data import Interval
 from torch_brain.samplers import DistributedStitchingFixedWindowSampler
 
 

--- a/tests/test_unit_dropout.py
+++ b/tests/test_unit_dropout.py
@@ -1,11 +1,11 @@
 import numpy as np
 
-from torch_brain.data import Data, ArrayDict, IrregularTimeSeries
+from torch_brain.data import ArrayDict, Data, IrregularTimeSeries
 from torch_brain.transforms.unit_dropout import TriangleDistribution, UnitDropout
 
 
 def test_distro():
-    for i in range(100):
+    for _i in range(100):
         num_units = TriangleDistribution(
             min_units=100, mode_units=150, max_units=200
         ).sample(196)
@@ -20,7 +20,7 @@ def test_spikes():
     np.random.shuffle(unit_index)
     types = np.zeros(100)
 
-    for i in range(100):
+    for _i in range(100):
         data = Data(
             spikes=IrregularTimeSeries(
                 timestamps=timestamps,

--- a/tests/test_unit_dropout.py
+++ b/tests/test_unit_dropout.py
@@ -5,7 +5,7 @@ from torch_brain.transforms.unit_dropout import TriangleDistribution, UnitDropou
 
 
 def test_distro():
-    for _i in range(100):
+    for _ in range(100):
         num_units = TriangleDistribution(
             min_units=100, mode_units=150, max_units=200
         ).sample(196)
@@ -20,7 +20,7 @@ def test_spikes():
     np.random.shuffle(unit_index)
     types = np.zeros(100)
 
-    for _i in range(100):
+    for _ in range(100):
         data = Data(
             spikes=IrregularTimeSeries(
                 timestamps=timestamps,

--- a/tests/test_unit_filter.py
+++ b/tests/test_unit_filter.py
@@ -4,7 +4,7 @@ import numpy as np
 import pytest
 
 from torch_brain.data import ArrayDict, Data, IrregularTimeSeries
-from torch_brain.transforms.unit_filter import UnitFilter, UnitFilterById
+from torch_brain.transforms.unit_filter import UnitFilterById
 
 logger = logging.getLogger(__name__)
 

--- a/tests/test_weights.py
+++ b/tests/test_weights.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pytest
-from torch_brain.data import Data, Interval
 
+from torch_brain.data import Data, Interval
 from torch_brain.utils.weights import resolve_weights_based_on_interval_membership
 
 

--- a/tests/utils/test_bids.py
+++ b/tests/utils/test_bids.py
@@ -1,10 +1,10 @@
-from pathlib import Path
-from io import StringIO
 import shutil
+from io import StringIO
+from pathlib import Path
+from unittest.mock import MagicMock, patch
 
 import pandas as pd
 import pytest
-from unittest.mock import MagicMock, patch
 
 try:
     import mne_bids
@@ -19,16 +19,16 @@ try:
     from torch_brain.utils.bids import (
         EEG_EXTENSIONS,
         IEEG_EXTENSIONS,
-        fetch_eeg_recordings,
-        fetch_ieeg_recordings,
-        check_eeg_recording_files_exist,
-        build_bids_path,
-        load_json_sidecar,
-        get_subject_info,
-        group_recordings_by_entity,
-        load_participants_tsv,
         _fetch_recordings,
         _validate_modality,
+        build_bids_path,
+        check_eeg_recording_files_exist,
+        fetch_eeg_recordings,
+        fetch_ieeg_recordings,
+        get_subject_info,
+        group_recordings_by_entity,
+        load_json_sidecar,
+        load_participants_tsv,
     )
 except ImportError:
     EEG_EXTENSIONS = None
@@ -134,10 +134,7 @@ def bids_root_with_participants(bids_root):
     """
     participants_tsv = bids_root / "participants.tsv"
     participants_tsv.write_text(
-        "participant_id\tage\tsex\n"
-        "sub-01\t34\tF\n"
-        "sub-02\tn/a\tN/A\n"
-        "sub-03\t28\tM\n"
+        "participant_id\tage\tsex\nsub-01\t34\tF\nsub-02\tn/a\tN/A\nsub-03\t28\tM\n"
     )
     return bids_root
 
@@ -1024,20 +1021,20 @@ class TestGetSubjectInfo:
     def participants_df_with_age_sex(self):
         """Create a participants DataFrame with age and sex information."""
         return _make_participants_df(
-            "participant_id\tage\tsex\n" "sub-01\t34\tF\n" "sub-02\t28\tM\n"
+            "participant_id\tage\tsex\nsub-01\t34\tF\nsub-02\t28\tM\n"
         )
 
     @pytest.fixture
     def participants_df_with_na_values(self):
         """Create a participants DataFrame with NA/N/A values."""
         return _make_participants_df(
-            "participant_id\tage\tsex\n" "sub-01\tn/a\tN/A\n" "sub-02\t28\tM\n"
+            "participant_id\tage\tsex\nsub-01\tn/a\tN/A\nsub-02\t28\tM\n"
         )
 
     @pytest.fixture
     def participants_df_missing_age_sex(self):
         """Create a participants DataFrame without age and sex columns."""
-        return _make_participants_df("participant_id\thandedness\n" "sub-01\tright\n")
+        return _make_participants_df("participant_id\thandedness\nsub-01\tright\n")
 
     def test_returns_age_and_sex_when_available(self, participants_df_with_age_sex):
         """Test that age and sex are correctly returned when available in participants.tsv."""

--- a/tests/utils/test_misc.py
+++ b/tests/utils/test_misc.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pytest
+
 from torch_brain.utils.misc import calculate_sampling_rate
 
 

--- a/tests/utils/test_mne.py
+++ b/tests/utils/test_mne.py
@@ -1,7 +1,8 @@
 import datetime
+from unittest.mock import MagicMock, patch
+
 import numpy as np
 import pytest
-from unittest.mock import MagicMock, patch
 
 try:
     import mne
@@ -11,13 +12,13 @@ except ImportError:
     MNE_AVAILABLE = False
 
 try:
+    from torch_brain.data import ArrayDict
     from torch_brain.utils.mne import (
+        concatenate_recordings,
+        extract_channels,
         extract_measurement_date,
         extract_signal,
-        extract_channels,
-        concatenate_recordings,
     )
-    from torch_brain.data import ArrayDict
 except ImportError:
     extract_measurement_date = None
     extract_signal = None
@@ -843,7 +844,7 @@ class TestConcatenateRecordings:
                 UserWarning,
                 match="One or more recordings have missing measurement dates",
             ):
-                result = concatenate_recordings(
+                concatenate_recordings(
                     [mock_raw1, mock_raw2], on_missing_meas_date="warn"
                 )
             mock_concat.assert_called_once()
@@ -858,7 +859,7 @@ class TestConcatenateRecordings:
 
         with patch("torch_brain.utils.mne.mne.concatenate_raws") as mock_concat:
             mock_concat.return_value = MagicMock()
-            result = concatenate_recordings(
+            concatenate_recordings(
                 [mock_raw1, mock_raw2], on_missing_meas_date="ignore"
             )
             mock_concat.assert_called_once()
@@ -877,7 +878,7 @@ class TestConcatenateRecordings:
                 UserWarning,
                 match="One or more recordings have missing measurement dates",
             ):
-                result = concatenate_recordings([mock_raw1, mock_raw2])
+                concatenate_recordings([mock_raw1, mock_raw2])
             mock_concat.assert_called_once()
 
     # ----------- Timezone normalization/handling -----------
@@ -895,7 +896,7 @@ class TestConcatenateRecordings:
 
         with patch("torch_brain.utils.mne.mne.concatenate_raws") as mock_concat:
             mock_concat.return_value = MagicMock()
-            result = concatenate_recordings([mock_raw1, mock_raw2])
+            concatenate_recordings([mock_raw1, mock_raw2])
             mock_concat.assert_called_once()
 
     def test_mixed_naive_and_aware_datetimes_normalized(self):
@@ -912,7 +913,7 @@ class TestConcatenateRecordings:
 
         with patch("torch_brain.utils.mne.mne.concatenate_raws") as mock_concat:
             mock_concat.return_value = MagicMock()
-            result = concatenate_recordings([mock_raw1, mock_raw2])
+            concatenate_recordings([mock_raw1, mock_raw2])
             mock_concat.assert_called_once()
 
     # ----------- Handling different measurement days (mismatch policy) -----------
@@ -982,7 +983,7 @@ class TestConcatenateRecordings:
 
         with patch("torch_brain.utils.mne.mne.concatenate_raws") as mock_concat:
             mock_concat.return_value = MagicMock()
-            result = concatenate_recordings([mock_raw1, mock_raw2], on_gap="warn")
+            concatenate_recordings([mock_raw1, mock_raw2], on_gap="warn")
             mock_concat.assert_called_once()
 
     def test_gap_greater_than_max_gap_raise_with_raise_policy(self):

--- a/tests/utils/test_openneuro.py
+++ b/tests/utils/test_openneuro.py
@@ -1,10 +1,10 @@
 """Unit tests for OpenNeuro S3 utility functions."""
 
-import pytest
-from io import BytesIO
 from pathlib import Path
-from unittest.mock import MagicMock, patch, call
+from unittest.mock import MagicMock, patch
+
 import pandas as pd
+import pytest
 
 from torch_brain.utils.openneuro import BOTO_AVAILABLE
 
@@ -12,17 +12,17 @@ pytestmark = pytest.mark.skipif(
     not BOTO_AVAILABLE, reason="boto3/botocore not installed"
 )
 
-from torch_brain.utils.openneuro import (
-    ClientError,
-    fetch_latest_snapshot_tag,
-    fetch_species,
-    fetch_all_filenames,
-    fetch_participants_tsv,
-    construct_s3_url_from_path,
-    download_recording,
-    download_dataset_description,
-    _graphql_query_openneuro,
+from torch_brain.utils.openneuro import (  # noqa: E402
     OPENNEURO_S3_BUCKET,
+    ClientError,
+    _graphql_query_openneuro,
+    construct_s3_url_from_path,
+    download_dataset_description,
+    download_recording,
+    fetch_all_filenames,
+    fetch_latest_snapshot_tag,
+    fetch_participants_tsv,
+    fetch_species,
 )
 
 # ============================================================================

--- a/tests/utils/test_s3.py
+++ b/tests/utils/test_s3.py
@@ -1,25 +1,26 @@
 """Unit tests for S3 utility functions."""
 
-import pytest
 from unittest.mock import MagicMock, patch
+
+import pytest
+
 from torch_brain.utils.s3 import BOTO_AVAILABLE
 
 pytestmark = pytest.mark.skipif(
     not BOTO_AVAILABLE, reason="boto3/botocore not installed"
 )
 
-from torch_brain.utils.s3 import (
+from torch_brain.utils.s3 import (  # noqa: E402
     UNSIGNED,
     ClientError,
-    get_cached_s3_client,
-    get_object_list,
     download_prefix,
     download_prefix_from_url,
+    get_cached_s3_client,
+    get_object_list,
 )
 
 
 class TestGetCachedS3Client:
-
     def setup_method(self):
         get_cached_s3_client.cache_clear()
 
@@ -72,7 +73,6 @@ class TestGetCachedS3Client:
 
 
 class TestListObjects:
-
     def test_lists_objects_successfully(self):
         """Test listing objects returns keys without directories."""
         mock_client = MagicMock()
@@ -181,7 +181,6 @@ class TestListObjects:
 
 
 class TestDownloadPrefix:
-
     def test_downloads_files_successfully(self, tmp_path):
         mock_client = MagicMock()
         mock_paginator = MagicMock()
@@ -373,7 +372,6 @@ class TestDownloadPrefix:
 
 
 class TestDownloadPrefixFromUrl:
-
     @patch("torch_brain.utils.s3.download_prefix")
     def test_parses_s3_url_correctly(self, mock_download, tmp_path):
         mock_download.return_value = [tmp_path / "file.edf"]

--- a/tests/utils/test_signal.py
+++ b/tests/utils/test_signal.py
@@ -1,7 +1,8 @@
 import numpy as np
 import pytest
-from torch_brain.utils.signal import extract_bands, cube_to_long
+
 from torch_brain.utils.mne import MNE_AVAILABLE
+from torch_brain.utils.signal import cube_to_long, extract_bands
 
 
 @pytest.mark.skipif(not MNE_AVAILABLE, reason="mne not installed")

--- a/tests/utils/test_split.py
+++ b/tests/utils/test_split.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pytest
+
 from torch_brain.data import Data, Interval
 from torch_brain.utils.split import (
     generate_stratified_folds,
@@ -278,7 +279,7 @@ class TestGenerateStringKfoldAssignment:
 
         expected_per_fold = n_subjects / n_folds
         # Each fold should be test for roughly 1/n_folds of subjects (allow 20% deviation)
-        for k, count in fold_test_counts.items():
+        for _, count in fold_test_counts.items():
             assert abs(count - expected_per_fold) < expected_per_fold * 0.2
 
     def test_train_plus_valid_equals_non_test_count(self):
@@ -401,7 +402,7 @@ class TestGenerateStringKfoldAssignment:
         expected_train_ratio = (1 - 1 / n_folds) * (1 - val_ratio)
 
         # Verify test distribution (allow 15% deviation)
-        for k, count in test_fold_counts.items():
+        for _, count in test_fold_counts.items():
             assert abs(count - expected_test_per_fold) < expected_test_per_fold * 0.15
 
         # Verify valid/train ratios

--- a/torch_brain/__init__.py
+++ b/torch_brain/__init__.py
@@ -1,4 +1,4 @@
-from importlib.metadata import version, PackageNotFoundError
+from importlib.metadata import PackageNotFoundError, version
 
 try:
     __version__ = version("torch_brain")

--- a/torch_brain/batching/__init__.py
+++ b/torch_brain/batching/__init__.py
@@ -2,14 +2,14 @@ from .collate import (
     chain,
     collate,
     pad,
-    pad8,
     pad2d,
     pad2d8,
+    pad8,
     track_batch,
     track_mask,
-    track_mask8,
     track_mask2d,
     track_mask2d8,
+    track_mask8,
 )
 
 __all__ = [

--- a/torch_brain/batching/collate.py
+++ b/torch_brain/batching/collate.py
@@ -1,6 +1,6 @@
 import copy
 from collections import namedtuple
-from typing import Callable, Dict, List, Optional, Tuple, Type, Union
+from collections.abc import Callable
 
 import numpy as np
 import torch
@@ -22,7 +22,7 @@ def pad(obj):
     return PaddedObject(obj)
 
 
-def track_mask(input: Union[torch.Tensor, np.ndarray]):
+def track_mask(input: torch.Tensor | np.ndarray):
     r"""Wrap an array or tensor to specify that its padding mask should be tracked.
 
     Args:
@@ -34,7 +34,7 @@ def track_mask(input: Union[torch.Tensor, np.ndarray]):
 def pad_collate_tensor_fn(
     batch,
     *,
-    collate_fn_map: Optional[Dict[Union[Type, Tuple[Type, ...]], Callable]] = None,
+    collate_fn_map: dict[type | tuple[type, ...], Callable] | None = None,
 ):
     # todo this will be more optimal than any code we'll write? it's in C++
     return torch.nn.utils.rnn.pad_sequence(batch, batch_first=True, padding_value=0)
@@ -47,7 +47,7 @@ pad_collate_fn_map[torch.Tensor] = pad_collate_tensor_fn
 def pad_collate_object_fn(
     batch,
     *,
-    collate_fn_map: Optional[Dict[Union[Type, Tuple[Type, ...]], Callable]] = None,
+    collate_fn_map: dict[type | tuple[type, ...], Callable] | None = None,
 ):
     return _collate([e.obj for e in batch], collate_fn_map=pad_collate_fn_map)
 
@@ -67,7 +67,7 @@ def pad8(obj):
     return Padded8Object(obj)
 
 
-def track_mask8(input: Union[torch.Tensor, np.ndarray]):
+def track_mask8(input: torch.Tensor | np.ndarray):
     r"""Wrap an array or tensor to specify that its padding mask should be tracked. This
     is used in conjunction with :obj:`pad8`.
 
@@ -80,7 +80,7 @@ def track_mask8(input: Union[torch.Tensor, np.ndarray]):
 def pad8_collate_tensor_fn(
     batch,
     *,
-    collate_fn_map: Optional[Dict[Union[Type, Tuple[Type, ...]], Callable]] = None,
+    collate_fn_map: dict[type | tuple[type, ...], Callable] | None = None,
 ):
     max_len = max([elem.shape[0] for elem in batch])
 
@@ -104,7 +104,7 @@ pad8_collate_fn_map[torch.Tensor] = pad8_collate_tensor_fn
 def pad8_collate_object_fn(
     batch,
     *,
-    collate_fn_map: Optional[Dict[Union[Type, Tuple[Type, ...]], Callable]] = None,
+    collate_fn_map: dict[type | tuple[type, ...], Callable] | None = None,
 ):
     return _collate([e.obj for e in batch], collate_fn_map=pad8_collate_fn_map)
 
@@ -121,7 +121,7 @@ def pad2d(obj):
     return Padded2dObject(obj)
 
 
-def track_mask2d(input: Union[torch.Tensor, np.ndarray]):
+def track_mask2d(input: torch.Tensor | np.ndarray):
     r"""Wrap an array or tensor to specify that its padding mask should be tracked. This
     is used in conjunction with :obj:`pad2d`.
 
@@ -138,7 +138,7 @@ def track_mask2d(input: Union[torch.Tensor, np.ndarray]):
 def pad2d_collate_tensor_fn(
     batch,
     *,
-    collate_fn_map: Optional[Dict[Union[Type, Tuple[Type, ...]], Callable]] = None,
+    collate_fn_map: dict[type | tuple[type, ...], Callable] | None = None,
 ):
     if any(elem.ndim < 2 for elem in batch):
         raise ValueError("All tensors must have at least 2 dimensions.")
@@ -159,7 +159,7 @@ pad2d_collate_fn_map[torch.Tensor] = pad2d_collate_tensor_fn
 def pad2d_collate_object_fn(
     batch,
     *,
-    collate_fn_map: Optional[Dict[Union[Type, Tuple[Type, ...]], Callable]] = None,
+    collate_fn_map: dict[type | tuple[type, ...], Callable] | None = None,
 ):
     return _collate([e.obj for e in batch], collate_fn_map=pad2d_collate_fn_map)
 
@@ -176,7 +176,7 @@ def pad2d8(obj):
     return Padded2d8Object(obj)
 
 
-def track_mask2d8(input: Union[torch.Tensor, np.ndarray]):
+def track_mask2d8(input: torch.Tensor | np.ndarray):
     r"""Wrap an array or tensor to specify that its padding mask should be tracked. This
     is used in conjunction with :obj:`pad2d8`.
 
@@ -193,7 +193,7 @@ def track_mask2d8(input: Union[torch.Tensor, np.ndarray]):
 def pad2d8_collate_tensor_fn(
     batch,
     *,
-    collate_fn_map: Optional[Dict[Union[Type, Tuple[Type, ...]], Callable]] = None,
+    collate_fn_map: dict[type | tuple[type, ...], Callable] | None = None,
 ):
     if any(elem.ndim < 2 for elem in batch):
         raise ValueError("All tensors must have at least 2 dimensions.")
@@ -216,7 +216,7 @@ pad2d8_collate_fn_map[torch.Tensor] = pad2d8_collate_tensor_fn
 def pad2d8_collate_object_fn(
     batch,
     *,
-    collate_fn_map: Optional[Dict[Union[Type, Tuple[Type, ...]], Callable]] = None,
+    collate_fn_map: dict[type | tuple[type, ...], Callable] | None = None,
 ):
     return _collate([e.obj for e in batch], collate_fn_map=pad2d8_collate_fn_map)
 
@@ -247,7 +247,7 @@ def chain(obj, allow_missing_keys: bool = False):
     return ChainObject(obj, allow_missing_keys)
 
 
-def track_batch(input: Union[torch.Tensor, np.ndarray]):
+def track_batch(input: torch.Tensor | np.ndarray):
     r"""Wrap an array or tensor to track the batch_index.
 
     Args:
@@ -259,7 +259,7 @@ def track_batch(input: Union[torch.Tensor, np.ndarray]):
 def chain_collate_str_fn(
     batch,
     *,
-    collate_fn_map: Optional[Dict[Union[Type, Tuple[Type, ...]], Callable]] = None,
+    collate_fn_map: dict[type | tuple[type, ...], Callable] | None = None,
 ):
     # No-op.
     return batch
@@ -268,7 +268,7 @@ def chain_collate_str_fn(
 def chain_collate_tensor_fn(
     batch,
     *,
-    collate_fn_map: Optional[Dict[Union[Type, Tuple[Type, ...]], Callable]] = None,
+    collate_fn_map: dict[type | tuple[type, ...], Callable] | None = None,
 ):
     return torch.cat(batch, dim=0)
 
@@ -276,7 +276,7 @@ def chain_collate_tensor_fn(
 def chain_batch_tracker_collate_tensor_fn(
     batch,
     *,
-    collate_fn_map: Optional[Dict[Union[Type, Tuple[Type, ...]], Callable]] = None,
+    collate_fn_map: dict[type | tuple[type, ...], Callable] | None = None,
 ):
     return _collate(
         [i * e.obj for i, e in enumerate(batch)],
@@ -293,7 +293,7 @@ chain_collate_fn_map[ChainBatchTrackerObject] = chain_batch_tracker_collate_tens
 def chain_collate_object_fn(
     batch,
     *,
-    collate_fn_map: Optional[Dict[Union[Type, Tuple[Type, ...]], Callable]] = None,
+    collate_fn_map: dict[type | tuple[type, ...], Callable] | None = None,
 ):
     allow_missing_keys = batch[0].allow_missing_keys
     # check that flag is consistent

--- a/torch_brain/data/__init__.py
+++ b/torch_brain/data/__init__.py
@@ -27,6 +27,7 @@ __all__ = [
     "SessionDescription",
     "SubjectDescription",
     "concat",
+    "serialize_fn_map",
 ]
 
 # Drives the generated API reference; see docs/source/api_reference.py.

--- a/torch_brain/data/__init__.py
+++ b/torch_brain/data/__init__.py
@@ -1,7 +1,5 @@
 from .arraydict import ArrayDict, LazyArrayDict
-from .irregular_ts import IrregularTimeSeries, LazyIrregularTimeSeries
-from .regular_ts import RegularTimeSeries, LazyRegularTimeSeries
-from .interval import Interval, LazyInterval
+from .concat import concat
 from .data import Data
 from .descriptions import (
     BrainsetDescription,
@@ -9,9 +7,10 @@ from .descriptions import (
     SessionDescription,
     SubjectDescription,
 )
+from .interval import Interval, LazyInterval
+from .irregular_ts import IrregularTimeSeries, LazyIrregularTimeSeries
+from .regular_ts import LazyRegularTimeSeries, RegularTimeSeries
 from .serialization import serialize_fn_map
-
-from .concat import concat
 
 __all__ = [
     "ArrayDict",

--- a/torch_brain/data/arraydict.py
+++ b/torch_brain/data/arraydict.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 import copy
-from typing import List
 import logging
+from typing import List
 
 import h5py
 import numpy as np

--- a/torch_brain/data/arraydict.py
+++ b/torch_brain/data/arraydict.py
@@ -114,7 +114,7 @@ class ArrayDict:
             ...     waveform_mean=np.random.rand(2, 48),
             ... )
 
-            >>> units_subset = units.select_by_mask([True, False])
+            >>> units_subset = units.select_by_mask(np.array([True, False]))
             >>> units_subset
             ArrayDict(
               unit_id=[1],

--- a/torch_brain/data/arraydict.py
+++ b/torch_brain/data/arraydict.py
@@ -12,7 +12,7 @@ from .typing import ArrayLike
 from .utils import _size_repr, _validate_select_by_mask_input
 
 
-class ArrayDict(object):
+class ArrayDict:
     r"""A dictionary of arrays that share the same first dimension. The number of
     dimensions for each array can be different, but they need to be at least
     1-dimensional.
@@ -43,7 +43,7 @@ class ArrayDict(object):
         for key, value in kwargs.items():
             self.__setattr__(key, value)
 
-    def keys(self) -> List[str]:
+    def keys(self) -> list[str]:
         r"""Returns a list of all array attribute names."""
         return list(filter(lambda x: not x.startswith("_"), self.__dict__))
 
@@ -82,7 +82,7 @@ class ArrayDict(object):
                     f"{value.shape[0]} but the first dimension of existing attributes "
                     f"is {first_dim}."
                 )
-        super(ArrayDict, self).__setattr__(name, value)
+        super().__setattr__(name, value)
 
     def __getattr__(self, name) -> np.ndarray:
         raise AttributeError(f"Attribute {name} not found.")
@@ -110,12 +110,12 @@ class ArrayDict(object):
             >>> import numpy as np
 
             >>> units = ArrayDict(
-            ...     unit_id=np.array(["unit01", "unit02"]),
-            ...     brain_region=np.array(["M1", "M1"]),
+            ...     unit_id=["unit01", "unit02"],
+            ...     brain_region=["M1", "M1"],
             ...     waveform_mean=np.random.rand(2, 48),
             ... )
 
-            >>> units_subset = units.select_by_mask(np.array([True, False]))
+            >>> units_subset = units.select_by_mask([True, False])
             >>> units_subset
             ArrayDict(
               unit_id=[1],
@@ -143,8 +143,8 @@ class ArrayDict(object):
         they will be skipped.
 
         Args:
-            df (pandas.DataFrame): DataFrame.
-            unsigned_to_long (bool, optional): If :obj:`True`, automatically converts
+            df: DataFrame.
+            unsigned_to_long: If :obj:`True`, automatically converts
                 unsigned integers to int64. Defaults to :obj:`True`.
         """
         data = {**kwargs}
@@ -210,7 +210,7 @@ class ArrayDict(object):
         r"""Saves the data object to an HDF5 file.
 
         Args:
-            file (h5py.File): HDF5 file.
+            file: HDF5 file.
 
         .. code-block:: python
 
@@ -218,8 +218,8 @@ class ArrayDict(object):
             from torch_brain.data import ArrayDict
 
             data = ArrayDict(
-                unit_id=np.array(["unit01", "unit02"]),
-                brain_region=np.array(["M1", "M1"]),
+                unit_id=["unit01", "unit02"],
+                brain_region=["M1", "M1"],
                 waveform_mean=np.zeros((2, 48)),
             )
 
@@ -257,7 +257,7 @@ class ArrayDict(object):
         r"""Loads the data object from an HDF5 file.
 
         Args:
-            file (h5py.File): HDF5 file.
+            file: HDF5 file.
 
         .. note::
             This method will load all data in memory, if you would like to use lazy
@@ -386,7 +386,7 @@ class LazyArrayDict(ArrayDict):
                     del self._lazy_ops, self._unicode_keys
                 return out
 
-        return super(LazyArrayDict, self).__getattribute__(name)
+        return super().__getattribute__(name)
 
     def select_by_mask(self, mask: np.ndarray):
         r"""Index all arrays with a boolean mask and return a copy.
@@ -437,7 +437,7 @@ class LazyArrayDict(ArrayDict):
         r"""Loads the data object from an HDF5 file.
 
         Args:
-            file (h5py.File): HDF5 file.
+            file: HDF5 file.
 
         .. code-block:: python
 

--- a/torch_brain/data/arraydict.py
+++ b/torch_brain/data/arraydict.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import copy
 import logging
-from typing import List
 
 import h5py
 import numpy as np
@@ -238,12 +237,12 @@ class ArrayDict:
                 try:
                     # convert string arrays to fixed length ASCII bytes
                     value = value.astype("S")
-                except UnicodeEncodeError:
+                except UnicodeEncodeError as err:
                     raise NotImplementedError(
                         f"Unable to convert column '{key}' from numpy 'U' string type "
                         "to fixed-length ASCII (np.dtype('S')). HDF5 does not support "
                         "numpy 'U' strings."
-                    )
+                    ) from err
                 # keep track of the keys of the arrays that were originally unicode
                 _unicode_keys.append(key)
             file.create_dataset(key, data=value)
@@ -356,7 +355,7 @@ class LazyArrayDict(ArrayDict):
             return self.__dict__[self.keys()[0]].shape[0]
 
     def __getattribute__(self, name):
-        if not name in ["__dict__", "keys"]:
+        if name not in ["__dict__", "keys"]:
             # intercept attribute calls. this is where data that is not loaded is loaded
             # and when any lazy operations are applied
             if name in self.keys():

--- a/torch_brain/data/concat.py
+++ b/torch_brain/data/concat.py
@@ -47,9 +47,7 @@ def concat(objs, sort=True):
     obj_type = type(objs[0])
     if any(not isinstance(obj, obj_type) for obj in objs):
         raise ValueError(
-            "All objects must be of the same type, got: {}".format(
-                [type(obj) for obj in objs]
-            )
+            f"All objects must be of the same type, got: {[type(obj) for obj in objs]}"
         )
 
     if obj_type == IrregularTimeSeries:
@@ -60,15 +58,11 @@ def concat(objs, sort=True):
         for obj in objs:
             if set(obj.keys()) != set(keys):
                 raise ValueError(
-                    "All objects must have the same keys, got {} and {}".format(
-                        keys, obj.keys()
-                    )
+                    f"All objects must have the same keys, got {keys} and {obj.keys()}"
                 )
             if set(obj.timekeys()) != set(timekeys):
                 raise ValueError(
-                    "All objects must have the same timekeys, got {} and {}".format(
-                        timekeys, obj.timekeys()
-                    )
+                    f"All objects must have the same timekeys, got {timekeys} and {obj.timekeys()}"
                 )
 
         obj_concat_dict = {}

--- a/torch_brain/data/concat.py
+++ b/torch_brain/data/concat.py
@@ -8,8 +8,8 @@ def concat(objs, sort=True):
     """Concatenates multiple time series objects into a single object.
 
     Args:
-        objs (List[Union[IrregularTimeSeries, RegularTimeSeries]]): List of time series objects to concatenate.
-        sort (bool, optional): Whether to sort the resulting time series by timestamps. Only applies to IrregularTimeSeries. Defaults to True.
+        objs: List of time series objects to concatenate.
+        sort: Whether to sort the resulting time series by timestamps. Only applies to IrregularTimeSeries. Defaults to True.
 
     Returns:
         Union[IrregularTimeSeries, RegularTimeSeries]: The concatenated time series object.
@@ -20,17 +20,16 @@ def concat(objs, sort=True):
 
     Example ::
 
-        >>> import numpy as np
         >>> from torch_brain.data import IrregularTimeSeries, Interval, concat
 
         >>> ts1 = IrregularTimeSeries(
-        ...     timestamps=np.array([0.0, 1.0]),
-        ...     values=np.array([1.0, 2.0]),
+        ...     timestamps=[0.0, 1.0],
+        ...     values=[1.0, 2.0],
         ...     domain="auto",
         ... )
         >>> ts2 = IrregularTimeSeries(
-        ...     timestamps=np.array([2.0, 3.0]),
-        ...     values=np.array([3.0, 4.0]),
+        ...     timestamps=[2.0, 3.0],
+        ...     values=[3.0, 4.0],
         ...     domain="auto",
         ... )
 
@@ -82,8 +81,6 @@ def concat(objs, sort=True):
         if sort:
             obj_concat.sort()
     else:
-        raise NotImplementedError(
-            "Concatenation not implemented for type: {}".format(obj_type)
-        )
+        raise NotImplementedError(f"Concatenation not implemented for type: {obj_type}")
 
     return obj_concat

--- a/torch_brain/data/concat.py
+++ b/torch_brain/data/concat.py
@@ -1,4 +1,5 @@
 from functools import reduce
+
 import numpy as np
 
 from .irregular_ts import IrregularTimeSeries

--- a/torch_brain/data/data.py
+++ b/torch_brain/data/data.py
@@ -2,17 +2,17 @@ from __future__ import annotations
 
 import copy
 import warnings
-from collections.abc import Callable, Mapping, Sequence
+from collections.abc import Callable
 from pathlib import Path
 from typing import Any, Literal
 
 import h5py
 import numpy as np
 
-from .arraydict import ArrayDict, LazyArrayDict
-from .interval import Interval, LazyInterval
-from .irregular_ts import IrregularTimeSeries, LazyIrregularTimeSeries
-from .regular_ts import LazyRegularTimeSeries, RegularTimeSeries
+from .arraydict import ArrayDict
+from .interval import Interval
+from .irregular_ts import IrregularTimeSeries
+from .regular_ts import RegularTimeSeries
 from .utils import _size_repr
 
 
@@ -130,7 +130,7 @@ class Data:
         if domain == "auto":
             # the domain is the union of the domains of the attributes
             domain = Interval(np.array([]), np.array([]))
-            for key, value in kwargs.items():
+            for _, value in kwargs.items():
                 if isinstance(value, (IrregularTimeSeries, RegularTimeSeries)):
                     domain = domain | value.domain
                 if isinstance(value, Interval):
@@ -564,10 +564,10 @@ class Data:
         for c in components:
             try:
                 out = getattr(out, c)
-            except AttributeError:
+            except AttributeError as err:
                 raise AttributeError(
                     f"Could not resolve {path} in data (specifically, at level {c})"
-                )
+                ) from err
         return out
 
     def set_nested_attribute(self, path: str, value: Any) -> Data:
@@ -592,10 +592,10 @@ class Data:
         for c in components[:-1]:
             try:
                 obj = getattr(obj, c)
-            except AttributeError:
+            except AttributeError as err:
                 raise AttributeError(
                     f"Could not resolve {path} in data (specifically, at level {c})"
-                )
+                ) from err
 
         setattr(obj, components[-1], value)
         return self

--- a/torch_brain/data/data.py
+++ b/torch_brain/data/data.py
@@ -9,10 +9,10 @@ from typing import Any, Literal
 import h5py
 import numpy as np
 
-from .arraydict import ArrayDict
-from .interval import Interval
-from .irregular_ts import IrregularTimeSeries
-from .regular_ts import RegularTimeSeries
+from .arraydict import ArrayDict, LazyArrayDict  # noqa: F401
+from .interval import Interval, LazyInterval  # noqa: F401
+from .irregular_ts import IrregularTimeSeries, LazyIrregularTimeSeries  # noqa: F401
+from .regular_ts import LazyRegularTimeSeries, RegularTimeSeries  # noqa: F401
 from .utils import _size_repr
 
 

--- a/torch_brain/data/data.py
+++ b/torch_brain/data/data.py
@@ -1,19 +1,18 @@
 from __future__ import annotations
 
 import copy
-from collections.abc import Mapping, Sequence
-from typing import Any, Literal
-from collections.abc import Callable
-from pathlib import Path
 import warnings
+from collections.abc import Callable, Mapping, Sequence
+from pathlib import Path
+from typing import Any, Literal
 
 import h5py
 import numpy as np
 
 from .arraydict import ArrayDict, LazyArrayDict
-from .irregular_ts import IrregularTimeSeries, LazyIrregularTimeSeries
-from .regular_ts import RegularTimeSeries, LazyRegularTimeSeries
 from .interval import Interval, LazyInterval
+from .irregular_ts import IrregularTimeSeries, LazyIrregularTimeSeries
+from .regular_ts import LazyRegularTimeSeries, RegularTimeSeries
 from .utils import _size_repr
 
 

--- a/torch_brain/data/data.py
+++ b/torch_brain/data/data.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 import copy
 from collections.abc import Mapping, Sequence
-from typing import Any, Dict, List, Literal, Tuple, Union, Callable, Optional, Type
+from typing import Any, Literal
+from collections.abc import Callable
 from pathlib import Path
 import warnings
 
@@ -16,7 +17,7 @@ from .interval import Interval, LazyInterval
 from .utils import _size_repr
 
 
-class Data(object):
+class Data:
     r"""A flexible container for other data objects such as
     :obj:`ArrayDict`, :obj:`RegularTimeSeries`, :obj:`IrregularTimeSeries`,
     and :obj:`Interval` objects, as well as nested :obj:`Data` objects and
@@ -44,8 +45,8 @@ class Data(object):
         >>> data = Data(
         ...     session_id="session_0",
         ...     spikes=IrregularTimeSeries(
-        ...         timestamps=np.array([0.1, 0.2, 0.3, 2.1, 2.2, 2.3]),
-        ...         unit_index=np.array([0, 0, 1, 0, 1, 2]),
+        ...         timestamps=[0.1, 0.2, 0.3, 2.1, 2.2, 2.3],
+        ...         unit_index=[0, 0, 1, 0, 1, 2],
         ...         waveforms=np.zeros((6, 48)),
         ...         domain=Interval(0., 3.),
         ...     ),
@@ -54,14 +55,14 @@ class Data(object):
         ...         sampling_rate=250.,
         ...     ),
         ...     units=ArrayDict(
-        ...         id=np.array(["unit_0", "unit_1", "unit_2"]),
-        ...         brain_region=np.array(["M1", "M1", "PMd"]),
+        ...         id=["unit_0", "unit_1", "unit_2"],
+        ...         brain_region=["M1", "M1", "PMd"],
         ...     ),
         ...     trials=Interval(
-        ...         start=np.array([0, 1, 2]),
-        ...         end=np.array([1, 2, 3]),
-        ...         go_cue_time=np.array([0.5, 1.5, 2.5]),
-        ...         drifting_gratings_dir=np.array([0, 45, 90]),
+        ...         start=[0, 1, 2],
+        ...         end=[1, 2, 3],
+        ...         go_cue_time=[0.5, 1.5, 2.5],
+        ...         drifting_gratings_dir=[0, 45, 90],
         ...     ),
         ...     drifting_gratings_imgs=np.zeros((8, 3, 32, 32)),
         ...     domain=Interval(0., 4.),
@@ -119,12 +120,12 @@ class Data(object):
 
     _absolute_start = 0.0
     _domain = None
-    _file: Optional[h5py.File] = None
+    _file: h5py.File | None = None
 
     def __init__(
         self,
         *,
-        domain: Union[Interval, Literal["auto"], None] = None,
+        domain: Interval | Literal["auto"] | None = None,
         **kwargs,
     ):
         if domain == "auto":
@@ -299,7 +300,7 @@ class Data(object):
         info = info.rstrip()
         return f"{cls}(\n{info}\n)"
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         r"""Returns a dictionary of stored key/value pairs."""
         out_dict = {k: v for k, v in self.__dict__.items() if k != "_file"}
         return copy.deepcopy(out_dict)
@@ -311,7 +312,7 @@ class Data(object):
         data object.
 
         Args:
-            file (h5py.File): HDF5 file.
+            file: HDF5 file.
 
         .. code-block:: python
 
@@ -356,7 +357,7 @@ class Data(object):
         data object.
 
         Args:
-            file (h5py.File): HDF5 file.
+            file: HDF5 file.
 
 
         .. code-block:: python
@@ -410,7 +411,7 @@ class Data(object):
         return self._file
 
     @classmethod
-    def load(cls, path: Union[Path, str], lazy: bool = True) -> Data:
+    def load(cls, path: Path | str, lazy: bool = True) -> Data:
         r"""Loads the :class:`Data` object from an HDF5 file given its file path.
 
         When ``lazy=True`` (default), the underlying HDF5 file remains open and
@@ -475,7 +476,7 @@ class Data(object):
         if strict:
             raise RuntimeError("No file handle is open")
 
-    def save(self, path: Union[Path, str]):
+    def save(self, path: Path | str):
         r"""Saves the data object to an HDF5 file at the given path.
 
         Args:
@@ -541,7 +542,7 @@ class Data(object):
         )
         return True
 
-    def keys(self) -> List[str]:
+    def keys(self) -> list[str]:
         r"""Returns a list of all attribute names."""
         return list(filter(lambda x: not x.startswith("_"), self.__dict__))
 
@@ -661,7 +662,7 @@ class Data(object):
 
 def _serialize(
     elem,
-    serialize_fn_map: Optional[Dict[Union[Type, Tuple[Type, ...]], Callable]] = None,
+    serialize_fn_map: dict[type | tuple[type, ...], Callable] | None = None,
 ):
     r"""
     General serialization function that handles object types that are not supported

--- a/torch_brain/data/dataset.py
+++ b/torch_brain/data/dataset.py
@@ -6,7 +6,7 @@ _MOVED = {
 def __getattr__(name):
     if name == "Dataset":
         raise ImportError(
-            f"`torch_brain.data.dataset.Dataset` is deprecated."
+            "`torch_brain.data.dataset.Dataset` is deprecated."
             "Please use torch_brain.datasets.Dataset"
         )
     raise AttributeError(f"module 'torch_brain.data.dataset' has no attribute {name!r}")

--- a/torch_brain/data/descriptions.py
+++ b/torch_brain/data/descriptions.py
@@ -14,6 +14,7 @@ __api_ref__ = {
 import datetime
 
 import torch_brain
+
 from .data import Data
 
 

--- a/torch_brain/data/interval.py
+++ b/torch_brain/data/interval.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import copy
 import logging
-from typing import List, Tuple, Union
 
 import h5py
 import numpy as np
@@ -631,8 +630,8 @@ class Interval(ArrayDict):
             unsigned_to_long: Whether to automatically convert unsigned
               integers to int64 dtype. Defaults to :obj:`True`.
         """
-        assert "start" in df.columns, f"Column 'start' not found in dataframe."
-        assert "end" in df.columns, f"Column 'end' not found in dataframe."
+        assert "start" in df.columns, "Column 'start' not found in dataframe."
+        assert "end" in df.columns, "Column 'end' not found in dataframe."
 
         return super().from_dataframe(
             df,
@@ -693,12 +692,12 @@ class Interval(ArrayDict):
                 try:
                     # convert string arrays to fixed length ASCII bytes
                     value = value.astype("S")
-                except UnicodeEncodeError:
+                except UnicodeEncodeError as err:
                     raise NotImplementedError(
                         f"Unable to convert column '{key}' from numpy 'U' string type "
                         "to fixed-length ASCII (np.dtype('S')). HDF5 does not support "
                         "numpy 'U' strings."
-                    )
+                    ) from err
                 # keep track of the keys of the arrays that were originally unicode
                 _unicode_keys.append(key)
             file.create_dataset(key, data=value)
@@ -879,7 +878,7 @@ class LazyInterval(Interval):
         return super()._maybe_first_dim()
 
     def __getattribute__(self, name):
-        if not name in ["__dict__", "keys"]:
+        if name not in ["__dict__", "keys"]:
             # intercept attribute calls
             if name in self.keys():
                 out = self.__dict__[name]

--- a/torch_brain/data/interval.py
+++ b/torch_brain/data/interval.py
@@ -1,16 +1,16 @@
 from __future__ import annotations
 
 import copy
-from typing import List, Tuple, Union
 import logging
+from typing import List, Tuple, Union
 
 import h5py
 import numpy as np
 import pandas as pd
 
 from .arraydict import ArrayDict
-from .utils import _validate_select_by_mask_input
 from .typing import ArrayLike
+from .utils import _validate_select_by_mask_input
 
 
 class Interval(ArrayDict):

--- a/torch_brain/data/interval.py
+++ b/torch_brain/data/interval.py
@@ -27,7 +27,6 @@ class Interval(ArrayDict):
 
     Example ::
 
-        >>> import numpy as np
         >>> from torch_brain.data import Interval
 
         >>> intervals = Interval(
@@ -123,7 +122,7 @@ class Interval(ArrayDict):
             self._timekeys.append(timekey)
 
     def __setattr__(self, name, value):
-        super(Interval, self).__setattr__(name, value)
+        super().__setattr__(name, value)
 
         if name == "start" or name == "end":
             value = self.__dict__[name]
@@ -141,7 +140,6 @@ class Interval(ArrayDict):
 
         .. Example ::
 
-            >>> import numpy as np
             >>> from torch_brain.data import Interval
 
             >>> intervals = Interval(
@@ -156,8 +154,7 @@ class Interval(ArrayDict):
             1.0 2.0
             2.0 3.0
         """
-        for s, e in zip(self.start, self.end):
-            yield (s, e)
+        yield from zip(self.start, self.end)
 
     def is_disjoint(self):
         r"""Returns :obj:`True` if the intervals are disjoint, i.e. if no two intervals
@@ -327,8 +324,8 @@ class Interval(ArrayDict):
 
         Example:
             >>> interval = Interval(
-            ...     start=np.array([0.0, 1.0, 2.0, 5.0, 5.5, 10.0]),
-            ...     end=np.array([1.0, 2.0, 3.0, 5.5, 7.0, 12.0]),
+            ...     start=[0.0, 1.0, 2.0, 5.0, 5.5, 10.0],
+            ...     end=[1.0, 2.0, 3.0, 5.5, 7.0, 12.0],
             ... )
             >>> coalesced = interval.coalesce()
             >>> coalesced.start
@@ -405,7 +402,7 @@ class Interval(ArrayDict):
 
     def split(
         self,
-        sizes: Union[List[int], List[float]],
+        sizes: list[int] | list[float],
         *,
         shuffle=False,
         random_seed=None,
@@ -522,12 +519,11 @@ class Interval(ArrayDict):
         Example ::
 
             >>> from torch_brain.data import Interval
-            >>> import numpy as np
 
             >>> interval = Interval(
-            ...     start=np.array([0.0, 20.0]),
-            ...     end=np.array([10.0, 30.0]),
-            ...     trial_id=np.array([1, 2])
+            ...     start=[0.0, 20.0],
+            ...     end=[10.0, 30.0],
+            ...     trial_id=[1, 2]
             ... )
             >>> subdivided = interval.subdivide(2.5)
             >>> subdivided
@@ -631,8 +627,8 @@ class Interval(ArrayDict):
         they will be skipped.
 
         Args:
-            df (pandas.DataFrame): DataFrame.
-            unsigned_to_long (bool, optional): Whether to automatically convert unsigned
+            df: DataFrame.
+            unsigned_to_long: Whether to automatically convert unsigned
               integers to int64 dtype. Defaults to :obj:`True`.
         """
         assert "start" in df.columns, f"Column 'start' not found in dataframe."
@@ -645,7 +641,7 @@ class Interval(ArrayDict):
         )
 
     @classmethod
-    def from_list(cls, interval_list: List[Tuple[float, float]]):
+    def from_list(cls, interval_list: list[tuple[float, float]]):
         r"""Create an :obj:`Interval` object from a list of (start, end) tuples.
 
         Args:
@@ -671,7 +667,7 @@ class Interval(ArrayDict):
         r"""Saves the data object to an HDF5 file.
 
         Args:
-            file (h5py.File): HDF5 file.
+            file: HDF5 file.
 
         .. code-block:: python
 
@@ -679,10 +675,10 @@ class Interval(ArrayDict):
                 from torch_brain.data import Interval
 
                 interval = Interval(
-                    start=np.array([0, 1, 2]),
-                    end=np.array([1, 2, 3]),
-                    go_cue_time=np.array([0.5, 1.5, 2.5]),
-                    drifting_gratins_dir=np.array([0, 45, 90]),
+                    start=[0, 1, 2],
+                    end=[1, 2, 3],
+                    go_cue_time=[0.5, 1.5, 2.5],
+                    drifting_gratins_dir=[0, 45, 90],
                     timekeys=["start", "end", "go_cue_time"],
                 )
 
@@ -716,7 +712,7 @@ class Interval(ArrayDict):
         r"""Loads the data object from an HDF5 file.
 
         Args:
-            file (h5py.File): HDF5 file.
+            file: HDF5 file.
 
         .. note::
             This method will load all data in memory, if you would like to use lazy
@@ -920,7 +916,7 @@ class LazyInterval(Interval):
                     del self._lazy_ops, self._unicode_keys
 
                 return out
-        return super(LazyInterval, self).__getattribute__(name)
+        return super().__getattribute__(name)
 
     def select_by_mask(self, mask: np.ndarray):
         r"""Index all arrays with a boolean mask and return a copy.
@@ -1063,7 +1059,7 @@ class LazyInterval(Interval):
         r"""Loads the data object from an HDF5 file.
 
         Args:
-            file (h5py.File): HDF5 file.
+            file: HDF5 file.
 
         .. code-block:: python
 

--- a/torch_brain/data/irregular_ts.py
+++ b/torch_brain/data/irregular_ts.py
@@ -81,7 +81,7 @@ class IrregularTimeSeries(ArrayDict):
         self,
         timestamps: ArrayLike,
         *,
-        timekeys: List[str] | None = None,
+        timekeys: list[str] | None = None,
         domain: Interval | Literal["auto"],
         **kwargs: ArrayLike,
     ):
@@ -151,7 +151,7 @@ class IrregularTimeSeries(ArrayDict):
             object.__setattr__(self, "_domain", value)
             return
 
-        super(IrregularTimeSeries, self).__setattr__(name, value)
+        super().__setattr__(name, value)
 
         if name == "timestamps":
             value = self.__dict__[name]
@@ -276,7 +276,7 @@ class IrregularTimeSeries(ArrayDict):
     def from_dataframe(
         cls,
         df: pd.DataFrame,
-        domain: Union[str, Interval] = "auto",
+        domain: str | Interval = "auto",
         unsigned_to_long: bool = True,
     ):
         r"""Create an :obj:`IrregularTimeseries` object from a pandas DataFrame.
@@ -290,7 +290,7 @@ class IrregularTimeSeries(ArrayDict):
             df: DataFrame.
             unsigned_to_long: Whether to automatically convert unsigned
               integers to int64 dtype. Defaults to :obj:`True`.
-            domain (optional): The domain over which the time
+            domain: The domain over which the time
                 series is defined. If set to :obj:`"auto"`, the domain will be
                 automatically the interval defined by the minimum and maximum
                 timestamps. Defaults to :obj:`"auto"`.
@@ -308,7 +308,7 @@ class IrregularTimeSeries(ArrayDict):
         r"""Saves the data object to an HDF5 file.
 
         Args:
-            file (h5py.File): HDF5 file.
+            file: HDF5 file.
 
         .. warning::
             If the time series is not sorted, it will be automatically sorted in place.
@@ -319,8 +319,8 @@ class IrregularTimeSeries(ArrayDict):
             from torch_brain.data import IrregularTimeseries
 
             data = IrregularTimeseries(
-                unit_index=np.array([0, 0, 1, 0, 1, 2]),
-                timestamps=np.array([0.1, 0.2, 0.3, 0.4, 0.5, 0.6]),
+                unit_index=[0, 0, 1, 0, 1, 2],
+                timestamps=[0.1, 0.2, 0.3, 0.4, 0.5, 0.6],
                 waveforms=np.zeros((6, 48)),
                 domain="auto",
             )
@@ -378,7 +378,7 @@ class IrregularTimeSeries(ArrayDict):
         r"""Loads the data object from an HDF5 file.
 
         Args:
-            file (h5py.File): HDF5 file.
+            file: HDF5 file.
 
         .. note::
             This method will load all data in memory, if you would like to use lazy
@@ -520,7 +520,7 @@ class LazyIrregularTimeSeries(IrregularTimeSeries):
                         del self._timestamp_indices_1s
 
                 return out
-        return super(LazyIrregularTimeSeries, self).__getattribute__(name)
+        return super().__getattribute__(name)
 
     def select_by_mask(self, mask: np.ndarray):
         r"""Index all arrays with a boolean mask and return a copy.
@@ -689,7 +689,7 @@ class LazyIrregularTimeSeries(IrregularTimeSeries):
         r"""Loads the data object from an HDF5 file.
 
         Args:
-            file (h5py.File): HDF5 file.
+            file: HDF5 file.
 
         .. code-block:: python
 

--- a/torch_brain/data/irregular_ts.py
+++ b/torch_brain/data/irregular_ts.py
@@ -1,16 +1,16 @@
 from __future__ import annotations
 
-from typing import List, Union, Literal
-import logging
 import copy
+import logging
+from typing import List, Literal, Union
 
 import h5py
 import numpy as np
 import pandas as pd
 
 from .arraydict import ArrayDict
-from .typing import ArrayLike
 from .interval import Interval
+from .typing import ArrayLike
 from .utils import _validate_select_by_mask_input
 
 
@@ -633,9 +633,9 @@ class LazyIrregularTimeSeries(IrregularTimeSeries):
             out.__dict__["timestamps"] = self.__dict__["timestamps"]
             out._timestamp_indices_1s = self._timestamp_indices_1s
         else:
-            assert (
-                "unresolved_slice" not in self._lazy_ops
-            ), "unresolved slice already exists"
+            assert "unresolved_slice" not in self._lazy_ops, (
+                "unresolved slice already exists"
+            )
             assert self.is_sorted(), "time series is not sorted, cannot slice"
 
             timestamps = self.timestamps
@@ -699,9 +699,9 @@ class LazyIrregularTimeSeries(IrregularTimeSeries):
             with h5py.File("data.h5", "r") as f:
                 data = ArrayDict.from_hdf5(f)
         """
-        assert (
-            file.attrs["object"] == IrregularTimeSeries.__name__
-        ), "object type mismatch"
+        assert file.attrs["object"] == IrregularTimeSeries.__name__, (
+            "object type mismatch"
+        )
 
         obj = cls.__new__(cls)
         for key, value in file.items():

--- a/torch_brain/data/irregular_ts.py
+++ b/torch_brain/data/irregular_ts.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import copy
 import logging
-from typing import List, Literal, Union
+from typing import Literal
 
 import h5py
 import numpy as np
@@ -156,7 +156,7 @@ class IrregularTimeSeries(ArrayDict):
         if name == "timestamps":
             value = self.__dict__[name]
             assert value.ndim == 1, "timestamps must be 1D."
-            assert ~np.isnan(value).any(), f"timestamps cannot contain NaNs."
+            assert ~np.isnan(value).any(), "timestamps cannot contain NaNs."
             if value.dtype != np.float64:
                 logging.warning(f"{name} is of type {value.dtype} not of type float64.")
             self._sorted = None
@@ -340,12 +340,12 @@ class IrregularTimeSeries(ArrayDict):
                 try:
                     # convert string arrays to fixed length ASCII bytes
                     value = value.astype("S")
-                except UnicodeEncodeError:
+                except UnicodeEncodeError as err:
                     raise NotImplementedError(
                         f"Unable to convert column '{key}' from numpy 'U' string type "
                         "to fixed-length ASCII (np.dtype('S')). HDF5 does not support "
                         "numpy 'U' strings."
-                    )
+                    ) from err
                 # keep track of the keys of the arrays that were originally unicode
                 _unicode_keys.append(key)
             file.create_dataset(key, data=value)
@@ -463,7 +463,7 @@ class LazyIrregularTimeSeries(IrregularTimeSeries):
             return self.__dict__[self.keys()[0]].shape[0]
 
     def __getattribute__(self, name):
-        if not name in ["__dict__", "keys"]:
+        if name not in ["__dict__", "keys"]:
             # intercept attribute calls
             if name in self.keys():
                 # out could either be a numpy array or a reference to a h5py dataset

--- a/torch_brain/data/regular_ts.py
+++ b/torch_brain/data/regular_ts.py
@@ -1,17 +1,17 @@
 from __future__ import annotations
 
-import math
-from typing import Any
-import warnings
 import copy
+import math
+import warnings
+from typing import Any
 
 import h5py
 import numpy as np
 
 from .arraydict import ArrayDict
-from .typing import ArrayLike
 from .interval import Interval
 from .irregular_ts import IrregularTimeSeries
+from .typing import ArrayLike
 
 _NP_DTYPE_KINDS = {"b", "i", "u", "f", "c", "m", "M", "O", "S", "U", "V"}
 # ^ From https://numpy.org/doc/2.2/reference/generated/numpy.dtype.kind.html
@@ -444,7 +444,7 @@ class RegularTimeSeries(ArrayDict):
         r"""Saves the data object to an HDF5 file.
 
         Args:
-            file (h5py.File): HDF5 file.
+            file: HDF5 file.
 
         .. code-block:: python
 
@@ -475,7 +475,7 @@ class RegularTimeSeries(ArrayDict):
         r"""Loads the data object from an HDF5 file.
 
         Args:
-            file (h5py.File): HDF5 file.
+            file: HDF5 file.
 
         .. note::
             This method will load all data in memory, if you would like to use lazy
@@ -567,10 +567,10 @@ class RegularTimeSeries(ArrayDict):
             >>> from torch_brain.data import RegularTimeSeries
 
             >>> # 4 samples at 100 Hz, the 0.02s sample is missing.
-            >>> ts = np.array([0.0, 0.01, 0.03, 0.04])
-            >>> raw = np.array([1.0, 2.0, 3.0, 4.0])
             >>> rts = RegularTimeSeries.from_gappy_timeseries(
-            ...     ts, sampling_rate=100.0, raw=raw,
+            ...     ts=[0.0, 0.01, 0.03, 0.04],
+            ...     sampling_rate=100.0,
+            ...     raw=[1.0, 2.0, 3.0, 4.0],
             ... )
             >>> rts.raw
             array([ 1.,  2., nan,  3.,  4.])
@@ -766,7 +766,7 @@ class LazyRegularTimeSeries(RegularTimeSeries):
                     del self._lazy_ops
 
                 return out
-        return super(LazyRegularTimeSeries, self).__getattribute__(name)
+        return super().__getattribute__(name)
 
     def slice(
         self,
@@ -873,7 +873,7 @@ class LazyRegularTimeSeries(RegularTimeSeries):
         r"""Loads the data object from an HDF5 file.
 
         Args:
-            file (h5py.File): HDF5 file.
+            file: HDF5 file.
 
         .. code-block:: python
 

--- a/torch_brain/data/regular_ts.py
+++ b/torch_brain/data/regular_ts.py
@@ -66,11 +66,11 @@ def _validate_gap_value_matches_array_dtype(v, array: np.ndarray, name: str):
 
         try:
             dst = src.astype(array.dtype)
-        except RuntimeWarning as _:
+        except RuntimeWarning as err:
             raise ValueError(
                 f"gap_value={v} cannot be losslessly stored in {name!r}; "
                 f"cannot cast {src.dtype!r} into {array.dtype!r}"
-            )
+            ) from err
 
     if not np.array_equal(src, dst, equal_nan=True):
         raise ValueError(
@@ -738,7 +738,7 @@ class LazyRegularTimeSeries(RegularTimeSeries):
             return self.__dict__[self.keys()[0]].shape[0]
 
     def __getattribute__(self, name):
-        if not name in ["__dict__", "keys"]:
+        if name not in ["__dict__", "keys"]:
             # intercept attribute calls
             if name in self.keys():
                 out = self.__dict__[name]

--- a/torch_brain/data/regular_ts.py
+++ b/torch_brain/data/regular_ts.py
@@ -240,10 +240,7 @@ class RegularTimeSeries(ArrayDict):
 
         if end_id[-1] != n:
             raise RuntimeError(  # pragma: no cover
-                f"This should never happen. Debug info:\n"
-                f"{n=}\n"
-                f"{start_id=}\n"
-                f"{end_id=}\n"
+                f"This should never happen. Debug info:\n{n=}\n{start_id=}\n{end_id=}\n"
             )
 
         # Create an array that marks start of a True run by +1
@@ -883,9 +880,9 @@ class LazyRegularTimeSeries(RegularTimeSeries):
             with h5py.File("data.h5", "r") as f:
                 data = ArrayDict.from_hdf5(f)
         """
-        assert (
-            file.attrs["object"] == RegularTimeSeries.__name__
-        ), "object type mismatch"
+        assert file.attrs["object"] == RegularTimeSeries.__name__, (
+            "object type mismatch"
+        )
 
         obj = cls.__new__(cls)
         for key, value in file.items():

--- a/torch_brain/data/regular_ts.py
+++ b/torch_brain/data/regular_ts.py
@@ -565,7 +565,7 @@ class RegularTimeSeries(ArrayDict):
 
             >>> # 4 samples at 100 Hz, the 0.02s sample is missing.
             >>> rts = RegularTimeSeries.from_gappy_timeseries(
-            ...     ts=[0.0, 0.01, 0.03, 0.04],
+            ...     timestamps=[0.0, 0.01, 0.03, 0.04],
             ...     sampling_rate=100.0,
             ...     raw=[1.0, 2.0, 3.0, 4.0],
             ... )

--- a/torch_brain/data/serialization.py
+++ b/torch_brain/data/serialization.py
@@ -1,5 +1,5 @@
 import datetime
-from typing import Callable
+from collections.abc import Callable
 
 
 def datetime_serialize_fn(obj, serialize_fn_map=None):

--- a/torch_brain/data/utils.py
+++ b/torch_brain/data/utils.py
@@ -1,5 +1,6 @@
 from collections.abc import Mapping, Sequence
 from typing import Any
+
 import numpy as np
 
 

--- a/torch_brain/dataset/__init__.py
+++ b/torch_brain/dataset/__init__.py
@@ -1,15 +1,16 @@
-"""Deprecated. Use torch_brain.datasets instead """
+"""Deprecated. Use torch_brain.datasets instead"""
+
+import warnings
 
 from torch_brain.datasets import (
+    CalciumImagingDatasetMixin,
     Dataset,
     DatasetIndex,
+    MultiChannelDatasetMixin,
     NestedDataset,
     NestedSpikingDataset,
     SpikingDatasetMixin,
-    CalciumImagingDatasetMixin,
-    MultiChannelDatasetMixin,
 )
-import warnings
 
 warnings.warn(
     "All components in moduel torch_brain.dataset have been moved to "

--- a/torch_brain/dataset/__init__.py
+++ b/torch_brain/dataset/__init__.py
@@ -2,7 +2,7 @@
 
 import warnings
 
-from torch_brain.datasets import (
+from torch_brain.datasets import (  # noqa: F401
     CalciumImagingDatasetMixin,
     Dataset,
     DatasetIndex,

--- a/torch_brain/datasets/AllenVisualCodingOphys2016.py
+++ b/torch_brain/datasets/AllenVisualCodingOphys2016.py
@@ -1,7 +1,8 @@
-from typing import Callable, Optional, Literal
+from collections.abc import Callable
 from pathlib import Path
+from typing import Literal
 
-from torch_brain.datasets import Dataset, CalciumImagingDatasetMixin
+from torch_brain.datasets import CalciumImagingDatasetMixin, Dataset
 
 from ._utils import get_processed_dir
 
@@ -24,10 +25,10 @@ class AllenVisualCodingOphys2016(CalciumImagingDatasetMixin, Dataset):
 
     def __init__(
         self,
-        root: Optional[str] = None,
-        recording_ids: Optional[list[str]] = None,
-        transform: Optional[Callable] = None,
-        split_type: Optional[Literal["poyo_plus"]] = "poyo_plus",
+        root: str | None = None,
+        recording_ids: list[str] | None = None,
+        transform: Callable | None = None,
+        split_type: Literal["poyo_plus"] | None = "poyo_plus",
         dirname: str = "allen_visual_coding_ophys_2016",
         **kwargs,
     ):
@@ -49,7 +50,7 @@ class AllenVisualCodingOphys2016(CalciumImagingDatasetMixin, Dataset):
 
     def get_sampling_intervals(
         self,
-        split: Optional[Literal["train", "valid", "test"]] = None,
+        split: Literal["train", "valid", "test"] | None = None,
     ):
 
         if split is None:

--- a/torch_brain/datasets/AllenVisualCodingOphys2016.py
+++ b/torch_brain/datasets/AllenVisualCodingOphys2016.py
@@ -2,10 +2,9 @@ from collections.abc import Callable
 from pathlib import Path
 from typing import Literal
 
-from torch_brain.datasets.dataset import Dataset
-from torch_brain.datasets.mixins import CalciumImagingDatasetMixin
-
 from ._utils import get_processed_dir
+from .dataset import Dataset
+from .mixins import CalciumImagingDatasetMixin
 
 
 class AllenVisualCodingOphys2016(CalciumImagingDatasetMixin, Dataset):

--- a/torch_brain/datasets/AllenVisualCodingOphys2016.py
+++ b/torch_brain/datasets/AllenVisualCodingOphys2016.py
@@ -2,7 +2,8 @@ from collections.abc import Callable
 from pathlib import Path
 from typing import Literal
 
-from torch_brain.datasets import CalciumImagingDatasetMixin, Dataset
+from torch_brain.datasets.dataset import Dataset
+from torch_brain.datasets.mixins import CalciumImagingDatasetMixin
 
 from ._utils import get_processed_dir
 

--- a/torch_brain/datasets/ChurchlandShenoyNeural2012.py
+++ b/torch_brain/datasets/ChurchlandShenoyNeural2012.py
@@ -2,7 +2,8 @@ from collections.abc import Callable
 from pathlib import Path
 from typing import Literal
 
-from torch_brain.datasets import Dataset, SpikingDatasetMixin
+from torch_brain.datasets.dataset import Dataset
+from torch_brain.datasets.mixins import SpikingDatasetMixin
 
 from ._utils import get_processed_dir
 

--- a/torch_brain/datasets/ChurchlandShenoyNeural2012.py
+++ b/torch_brain/datasets/ChurchlandShenoyNeural2012.py
@@ -1,5 +1,6 @@
+from collections.abc import Callable
 from pathlib import Path
-from typing import Callable, Literal, Optional
+from typing import Literal
 
 from torch_brain.datasets import Dataset, SpikingDatasetMixin
 
@@ -44,20 +45,20 @@ class ChurchlandShenoyNeural2012(SpikingDatasetMixin, Dataset):
     Version 0.251218.1714.
 
     Args:
-        root (str, optional): Root directory for the dataset. Defaults to ``processed_dir`` from brainsets config.
-        recording_ids (list[str], optional): List of recording IDs to load.
-        transform (Callable, optional): Data transformation to apply.
-        split_type (str, optional): Which split type to use. Defaults to "cursor_velocity".
-        dirname (str, optional): Subdirectory for the dataset. Defaults to "churchland_shenoy_neural_2012".
+        root: Root directory for the dataset. Defaults to ``processed_dir`` from brainsets config.
+        recording_ids: List of recording IDs to load.
+        transform: Data transformation to apply.
+        split_type: Which split type to use. Defaults to "cursor_velocity".
+        dirname: Subdirectory for the dataset. Defaults to "churchland_shenoy_neural_2012".
 
     """
 
     def __init__(
         self,
-        root: Optional[str] = None,
-        recording_ids: Optional[list[str]] = None,
-        transform: Optional[Callable] = None,
-        split_type: Optional[Literal["cursor_velocity"]] = "cursor_velocity",
+        root: str | None = None,
+        recording_ids: list[str] | None = None,
+        transform: Callable | None = None,
+        split_type: Literal["cursor_velocity"] | None = "cursor_velocity",
         dirname: str = "churchland_shenoy_neural_2012",
         **kwargs,
     ):
@@ -76,7 +77,7 @@ class ChurchlandShenoyNeural2012(SpikingDatasetMixin, Dataset):
 
     def get_sampling_intervals(
         self,
-        split: Optional[Literal["train", "valid", "test"]] = None,
+        split: Literal["train", "valid", "test"] | None = None,
     ):
         domain_key = "domain" if split is None else f"{split}_domain"
         ans = {}

--- a/torch_brain/datasets/ChurchlandShenoyNeural2012.py
+++ b/torch_brain/datasets/ChurchlandShenoyNeural2012.py
@@ -2,10 +2,9 @@ from collections.abc import Callable
 from pathlib import Path
 from typing import Literal
 
-from torch_brain.datasets.dataset import Dataset
-from torch_brain.datasets.mixins import SpikingDatasetMixin
-
 from ._utils import get_processed_dir
+from .dataset import Dataset
+from .mixins import SpikingDatasetMixin
 
 
 class ChurchlandShenoyNeural2012(SpikingDatasetMixin, Dataset):

--- a/torch_brain/datasets/FlintSlutzkyAccurate2012.py
+++ b/torch_brain/datasets/FlintSlutzkyAccurate2012.py
@@ -2,7 +2,8 @@ from collections.abc import Callable
 from pathlib import Path
 from typing import Literal
 
-from torch_brain.datasets import Dataset, SpikingDatasetMixin
+from torch_brain.datasets.dataset import Dataset
+from torch_brain.datasets.mixins import SpikingDatasetMixin
 
 from ._utils import get_processed_dir
 

--- a/torch_brain/datasets/FlintSlutzkyAccurate2012.py
+++ b/torch_brain/datasets/FlintSlutzkyAccurate2012.py
@@ -1,5 +1,6 @@
+from collections.abc import Callable
 from pathlib import Path
-from typing import Callable, Literal, Optional
+from typing import Literal
 
 from torch_brain.datasets import Dataset, SpikingDatasetMixin
 
@@ -42,20 +43,20 @@ class FlintSlutzkyAccurate2012(SpikingDatasetMixin, Dataset):
     `Journal of Neural Engineering <https://doi.org/10.1088/1741-2560/9/4/046006>`_, 9(4), 046006.
 
     Args:
-        root (str, optional): Root directory for the dataset. Defaults to ``processed_dir`` from brainsets config.
-        recording_ids (list[str], optional): List of recording IDs to load.
-        transform (Callable, optional): Data transformation to apply.
-        split_type (str, optional): Which split type to use. Defaults to "hand_velocity".
-        dirname (str, optional): Subdirectory for the dataset. Defaults to "flint_slutzky_accurate_2012".
+        root: Root directory for the dataset. Defaults to ``processed_dir`` from brainsets config.
+        recording_ids: List of recording IDs to load.
+        transform: Data transformation to apply.
+        split_type: Which split type to use. Defaults to "hand_velocity".
+        dirname: Subdirectory for the dataset. Defaults to "flint_slutzky_accurate_2012".
 
     """
 
     def __init__(
         self,
-        root: Optional[str] = None,
-        recording_ids: Optional[list[str]] = None,
-        transform: Optional[Callable] = None,
-        split_type: Optional[Literal["hand_velocity"]] = "hand_velocity",
+        root: str | None = None,
+        recording_ids: list[str] | None = None,
+        transform: Callable | None = None,
+        split_type: Literal["hand_velocity"] | None = "hand_velocity",
         dirname: str = "flint_slutzky_accurate_2012",
         **kwargs,
     ):
@@ -74,7 +75,7 @@ class FlintSlutzkyAccurate2012(SpikingDatasetMixin, Dataset):
 
     def get_sampling_intervals(
         self,
-        split: Optional[Literal["train", "valid", "test"]] = None,
+        split: Literal["train", "valid", "test"] | None = None,
     ):
         domain_key = "domain" if split is None else f"{split}_domain"
         ans = {}

--- a/torch_brain/datasets/FlintSlutzkyAccurate2012.py
+++ b/torch_brain/datasets/FlintSlutzkyAccurate2012.py
@@ -2,10 +2,9 @@ from collections.abc import Callable
 from pathlib import Path
 from typing import Literal
 
-from torch_brain.datasets.dataset import Dataset
-from torch_brain.datasets.mixins import SpikingDatasetMixin
-
 from ._utils import get_processed_dir
+from .dataset import Dataset
+from .mixins import SpikingDatasetMixin
 
 
 class FlintSlutzkyAccurate2012(SpikingDatasetMixin, Dataset):

--- a/torch_brain/datasets/KempSleepEDF2013.py
+++ b/torch_brain/datasets/KempSleepEDF2013.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from typing import Literal, get_args
 
 from torch_brain.data import Data
-from torch_brain.datasets import Dataset
+from torch_brain.datasets.dataset import Dataset
 from torch_brain.utils import np_string_prefix
 
 from ._utils import get_processed_dir

--- a/torch_brain/datasets/KempSleepEDF2013.py
+++ b/torch_brain/datasets/KempSleepEDF2013.py
@@ -3,10 +3,10 @@ from pathlib import Path
 from typing import Literal, get_args
 
 from torch_brain.data import Data
-from torch_brain.datasets.dataset import Dataset
 from torch_brain.utils import np_string_prefix
 
 from ._utils import get_processed_dir
+from .dataset import Dataset
 
 FoldType = Literal["intrasession", "intersubject", "intersession"]
 VALID_FOLD_TYPES = get_args(FoldType)

--- a/torch_brain/datasets/KempSleepEDF2013.py
+++ b/torch_brain/datasets/KempSleepEDF2013.py
@@ -1,9 +1,10 @@
-from typing import Callable, Optional, Literal, get_args
+from collections.abc import Callable
 from pathlib import Path
+from typing import Literal, get_args
 
-from torch_brain.utils import np_string_prefix
 from torch_brain.data import Data
 from torch_brain.datasets import Dataset
+from torch_brain.utils import np_string_prefix
 
 from ._utils import get_processed_dir
 
@@ -23,24 +24,24 @@ class KempSleepEDF2013(Dataset):
             brainsets prepare kemp_sleep_edf_2013
 
     Args:
-        root (str, optional): Root directory for the dataset. Defaults to ``processed_dir`` from brainsets config.
-        recording_ids (list[str], optional): List of recording IDs to load.
-        transform (Callable, optional): Data transformation to apply.
-        uniquify_channel_ids (bool, optional): Whether to prefix channel IDs with session ID to ensure uniqueness. Defaults to True.
-        fold_number (int, optional): The cross-validation fold index (0 to 2 for a 3-fold split). Defaults to 0.
-        fold_type (str, optional): The splitting strategy. Must be one of:
+        root: Root directory for the dataset. Defaults to ``processed_dir`` from brainsets config.
+        recording_ids: List of recording IDs to load.
+        transform: Data transformation to apply.
+        uniquify_channel_ids: Whether to prefix channel IDs with session ID to ensure uniqueness. Defaults to True.
+        fold_number: The cross-validation fold index (0 to 2 for a 3-fold split). Defaults to 0.
+        fold_type: The splitting strategy. Must be one of:
             - \"intrasession\": Epoch-level stratified split within each session.
             - \"intersubject\": Subject-level split (subjects are assigned to train/valid/test).
             - \"intersession\": Session-level split (subject-session pairs are assigned to train/valid/test).
             Defaults to \"intrasession\".
-        dirname (str, optional): Subdirectory for the dataset. Defaults to "kemp_sleep_edf_2013".
+        dirname: Subdirectory for the dataset. Defaults to "kemp_sleep_edf_2013".
     """
 
     def __init__(
         self,
-        root: Optional[str] = None,
-        recording_ids: Optional[list[str]] = None,
-        transform: Optional[Callable] = None,
+        root: str | None = None,
+        recording_ids: list[str] | None = None,
+        transform: Callable | None = None,
         uniquify_channel_ids: bool = True,
         fold_number: int = 0,
         fold_type: FoldType = "intrasession",
@@ -74,7 +75,7 @@ class KempSleepEDF2013(Dataset):
 
     def get_sampling_intervals(
         self,
-        split: Optional[Literal["train", "valid", "test"]] = None,
+        split: Literal["train", "valid", "test"] | None = None,
     ):
 
         if split is None:

--- a/torch_brain/datasets/KlinzingSleepDS005555.py
+++ b/torch_brain/datasets/KlinzingSleepDS005555.py
@@ -1,4 +1,4 @@
-from typing import Callable, Optional
+from collections.abc import Callable
 
 from .OpenNeuroDataset import OpenNeuroDataset, OpenNeuroSplitType
 
@@ -19,10 +19,10 @@ class KlinzingSleepDS005555(OpenNeuroDataset):
     restricted to specific recordings via recording_ids.
 
     Args:
-        root (str): Root directory containing processed Klinzing Sleep artifacts.
-        split_type (OpenNeuroSplitType): Dataset split strategy, e.g. train/valid/test as designated by the workflow.
-        recording_ids (list[str], optional): List of explicit recording IDs to load. If omitted, the dataset uses split-based recording selection.
-        transform (Callable, optional): Optional transform to apply to each sample.
+        root: Root directory containing processed Klinzing Sleep artifacts.
+        split_type: Dataset split strategy, e.g. train/valid/test as designated by the workflow.
+        recording_ids: List of explicit recording IDs to load. If omitted, the dataset uses split-based recording selection.
+        transform: Optional transform to apply to each sample.
         **kwargs: Additional keyword arguments forwarded to OpenNeuroDataset.
 
     **References**
@@ -34,8 +34,8 @@ class KlinzingSleepDS005555(OpenNeuroDataset):
         self,
         root: str,
         split_type: OpenNeuroSplitType,
-        recording_ids: Optional[list[str]] = None,
-        transform: Optional[Callable] = None,
+        recording_ids: list[str] | None = None,
+        transform: Callable | None = None,
         **kwargs,
     ):
         dataset_dir = "klinzing_sleep_ds005555"

--- a/torch_brain/datasets/KochiVisualNamingDS006914.py
+++ b/torch_brain/datasets/KochiVisualNamingDS006914.py
@@ -1,4 +1,4 @@
-from typing import Callable, Optional
+from collections.abc import Callable
 
 from .OpenNeuroDataset import OpenNeuroDataset, OpenNeuroSplitType
 
@@ -19,10 +19,10 @@ class KochiVisualNamingDS006914(OpenNeuroDataset):
     restricted to specific recordings via recording_ids.
 
     Args:
-        root (str): Root directory containing processed Visual Naming artifacts.
-        split_type (OpenNeuroSplitType): The split type describing train/valid/test regime.
-        recording_ids (list[str], optional): List of explicit recording IDs to load. If omitted, the dataset uses split-based recording selection.
-        transform (Callable, optional): Optional transform to apply to samples.
+        root: Root directory containing processed Visual Naming artifacts.
+        split_type: The split type describing train/valid/test regime.
+        recording_ids: List of explicit recording IDs to load. If omitted, the dataset uses split-based recording selection.
+        transform: Optional transform to apply to samples.
         **kwargs: Additional keyword arguments forwarded to the base OpenNeuroDataset.
 
     **References**
@@ -34,8 +34,8 @@ class KochiVisualNamingDS006914(OpenNeuroDataset):
         self,
         root: str,
         split_type: OpenNeuroSplitType,
-        recording_ids: Optional[list[str]] = None,
-        transform: Optional[Callable] = None,
+        recording_ids: list[str] | None = None,
+        transform: Callable | None = None,
         **kwargs,
     ):
         dataset_dir = "kochi_visualnaming_ds006914"

--- a/torch_brain/datasets/Neuroprobe2025.py
+++ b/torch_brain/datasets/Neuroprobe2025.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
+import re
+from collections.abc import Callable
 from numbers import Integral
 from pathlib import Path
-import re
-from typing import Callable, Literal, Optional, get_args
+from typing import Literal, get_args
 
 import numpy as np
 
@@ -213,9 +214,9 @@ class Neuroprobe2025(MultiChannelDatasetMixin, Dataset):
 
     def __init__(
         self,
-        root: Optional[str] = None,
-        recording_ids: Optional[list[str]] = None,
-        transform: Optional[Callable] = None,
+        root: str | None = None,
+        recording_ids: list[str] | None = None,
+        transform: Callable | None = None,
         *,
         subset_tier: SubsetTier | None = None,
         test_subject: int | None = None,

--- a/torch_brain/datasets/Neuroprobe2025.py
+++ b/torch_brain/datasets/Neuroprobe2025.py
@@ -9,10 +9,10 @@ from typing import Literal, get_args
 import numpy as np
 
 from torch_brain.data import Data, Interval
-from torch_brain.datasets.dataset import Dataset
-from torch_brain.datasets.mixins import MultiChannelDatasetMixin
 
 from ._utils import get_processed_dir
+from .dataset import Dataset
+from .mixins import MultiChannelDatasetMixin
 
 SubsetTier = Literal["full", "lite", "nano"]
 LabelMode = Literal["binary", "multiclass"]

--- a/torch_brain/datasets/Neuroprobe2025.py
+++ b/torch_brain/datasets/Neuroprobe2025.py
@@ -481,15 +481,13 @@ class Neuroprobe2025(MultiChannelDatasetMixin, Dataset):
             self.test_subject, bool
         ):
             raise TypeError(
-                "test_subject must be an int, got "
-                f"{type(self.test_subject).__name__}."
+                f"test_subject must be an int, got {type(self.test_subject).__name__}."
             )
         if not isinstance(self.test_session, Integral) or isinstance(
             self.test_session, bool
         ):
             raise TypeError(
-                "test_session must be an int, got "
-                f"{type(self.test_session).__name__}."
+                f"test_session must be an int, got {type(self.test_session).__name__}."
             )
 
         h5_regime = H5_REGIME_BY_REGIME[self.regime]

--- a/torch_brain/datasets/Neuroprobe2025.py
+++ b/torch_brain/datasets/Neuroprobe2025.py
@@ -9,7 +9,8 @@ from typing import Literal, get_args
 import numpy as np
 
 from torch_brain.data import Data, Interval
-from torch_brain.datasets import Dataset, MultiChannelDatasetMixin
+from torch_brain.datasets.dataset import Dataset
+from torch_brain.datasets.mixins import MultiChannelDatasetMixin
 
 from ._utils import get_processed_dir
 

--- a/torch_brain/datasets/OdohertySabesNonhuman2017.py
+++ b/torch_brain/datasets/OdohertySabesNonhuman2017.py
@@ -2,7 +2,8 @@ from collections.abc import Callable
 from pathlib import Path
 from typing import Literal
 
-from torch_brain.datasets import Dataset, SpikingDatasetMixin
+from torch_brain.datasets.dataset import Dataset
+from torch_brain.datasets.mixins import SpikingDatasetMixin
 
 from ._utils import get_processed_dir
 

--- a/torch_brain/datasets/OdohertySabesNonhuman2017.py
+++ b/torch_brain/datasets/OdohertySabesNonhuman2017.py
@@ -1,5 +1,6 @@
+from collections.abc import Callable
 from pathlib import Path
-from typing import Callable, Literal, Optional
+from typing import Literal
 
 from torch_brain.datasets import Dataset, SpikingDatasetMixin
 
@@ -42,20 +43,20 @@ class OdohertySabesNonhuman2017(SpikingDatasetMixin, Dataset):
     `Zenodo Dataset <https://doi.org/10.5281/zenodo.788569>`_.
 
     Args:
-        root (str, optional): Root directory for the dataset. Defaults to ``processed_dir`` from brainsets config.
-        recording_ids (list[str], optional): List of recording IDs to load.
-        transform (Callable, optional): Data transformation to apply.
-        split_type (str, optional): Which split type to use. Defaults to "cursor_velocity".
-        dirname (str, optional): Subdirectory for the dataset. Defaults to "odoherty_sabes_nonhuman_2017".
+        root: Root directory for the dataset. Defaults to ``processed_dir`` from brainsets config.
+        recording_ids: List of recording IDs to load.
+        transform: Data transformation to apply.
+        split_type: Which split type to use. Defaults to "cursor_velocity".
+        dirname: Subdirectory for the dataset. Defaults to "odoherty_sabes_nonhuman_2017".
 
     """
 
     def __init__(
         self,
-        root: Optional[str] = None,
-        recording_ids: Optional[list[str]] = None,
-        transform: Optional[Callable] = None,
-        split_type: Optional[Literal["cursor_velocity"]] = "cursor_velocity",
+        root: str | None = None,
+        recording_ids: list[str] | None = None,
+        transform: Callable | None = None,
+        split_type: Literal["cursor_velocity"] | None = "cursor_velocity",
         dirname: str = "odoherty_sabes_nonhuman_2017",
         **kwargs,
     ):
@@ -74,7 +75,7 @@ class OdohertySabesNonhuman2017(SpikingDatasetMixin, Dataset):
 
     def get_sampling_intervals(
         self,
-        split: Optional[Literal["train", "valid", "test"]] = None,
+        split: Literal["train", "valid", "test"] | None = None,
     ):
         domain_key = "domain" if split is None else f"{split}_domain"
         ans = {}

--- a/torch_brain/datasets/OdohertySabesNonhuman2017.py
+++ b/torch_brain/datasets/OdohertySabesNonhuman2017.py
@@ -2,10 +2,9 @@ from collections.abc import Callable
 from pathlib import Path
 from typing import Literal
 
-from torch_brain.datasets.dataset import Dataset
-from torch_brain.datasets.mixins import SpikingDatasetMixin
-
 from ._utils import get_processed_dir
+from .dataset import Dataset
+from .mixins import SpikingDatasetMixin
 
 
 class OdohertySabesNonhuman2017(SpikingDatasetMixin, Dataset):

--- a/torch_brain/datasets/OpenNeuroDataset.py
+++ b/torch_brain/datasets/OpenNeuroDataset.py
@@ -1,11 +1,11 @@
+from collections.abc import Callable
 from pathlib import Path
-from typing import Callable, Literal, Optional, get_args
-import hashlib
+from typing import Literal, get_args
 
 import numpy as np
 
 from torch_brain.data import Data, Interval
-from torch_brain.datasets import MultiChannelDatasetMixin, Dataset
+from torch_brain.datasets import Dataset, MultiChannelDatasetMixin
 from torch_brain.utils.split import _get_integer_hash_from_string
 
 OpenNeuroSplitType = Literal["intrasession", "intersubject", "intersession"]
@@ -27,9 +27,9 @@ class OpenNeuroDataset(MultiChannelDatasetMixin, Dataset):
         dataset_dir: Relative dataset directory within the root path.
         split_type: The split strategy to use, must be one of
             'intrasession', 'intersubject', or 'intersession'.
-        recording_ids (Optional[list[str]]): List of recording IDs to include,
+        recording_ids: List of recording IDs to include,
             or None to use all available recordings.
-        transform (Optional[Callable]): Optional sample transform.
+        transform: Optional sample transform.
         uniquify_channel_ids_with_subject: Whether to prefix channel IDs with
             ``subject.id`` via ``MultiChannelDatasetMixin``.
             Defaults to ``False``.
@@ -51,8 +51,8 @@ class OpenNeuroDataset(MultiChannelDatasetMixin, Dataset):
         root: str,
         dataset_dir: str,
         split_type: OpenNeuroSplitType,
-        recording_ids: Optional[list[str]] = None,
-        transform: Optional[Callable] = None,
+        recording_ids: list[str] | None = None,
+        transform: Callable | None = None,
         uniquify_channel_ids_with_subject: bool = False,
         uniquify_channel_ids_with_session: bool = True,
         split_ratios: tuple[float, float, float] = (0.8, 0.1, 0.1),
@@ -107,7 +107,7 @@ class OpenNeuroDataset(MultiChannelDatasetMixin, Dataset):
 
     def get_sampling_intervals(
         self,
-        split: Optional[Literal["train", "val", "test"]] = None,
+        split: Literal["train", "val", "test"] | None = None,
     ) -> dict[str, Interval]:
         """
         Retrieve the sampling intervals for each recording according to the specified split.

--- a/torch_brain/datasets/OpenNeuroDataset.py
+++ b/torch_brain/datasets/OpenNeuroDataset.py
@@ -5,9 +5,10 @@ from typing import Literal, get_args
 import numpy as np
 
 from torch_brain.data import Data, Interval
-from torch_brain.datasets.dataset import Dataset
-from torch_brain.datasets.mixins import MultiChannelDatasetMixin
 from torch_brain.utils.split import _get_integer_hash_from_string
+
+from .dataset import Dataset
+from .mixins import MultiChannelDatasetMixin
 
 OpenNeuroSplitType = Literal["intrasession", "intersubject", "intersession"]
 

--- a/torch_brain/datasets/OpenNeuroDataset.py
+++ b/torch_brain/datasets/OpenNeuroDataset.py
@@ -5,7 +5,8 @@ from typing import Literal, get_args
 import numpy as np
 
 from torch_brain.data import Data, Interval
-from torch_brain.datasets import Dataset, MultiChannelDatasetMixin
+from torch_brain.datasets.dataset import Dataset
+from torch_brain.datasets.mixins import MultiChannelDatasetMixin
 from torch_brain.utils.split import _get_integer_hash_from_string
 
 OpenNeuroSplitType = Literal["intrasession", "intersubject", "intersession"]

--- a/torch_brain/datasets/PeiPandarinathNLB2021.py
+++ b/torch_brain/datasets/PeiPandarinathNLB2021.py
@@ -2,7 +2,8 @@ from collections.abc import Callable
 from pathlib import Path
 from typing import Literal
 
-from torch_brain.datasets import Dataset, SpikingDatasetMixin
+from torch_brain.datasets.dataset import Dataset
+from torch_brain.datasets.mixins import SpikingDatasetMixin
 
 from ._utils import get_processed_dir
 

--- a/torch_brain/datasets/PeiPandarinathNLB2021.py
+++ b/torch_brain/datasets/PeiPandarinathNLB2021.py
@@ -2,10 +2,9 @@ from collections.abc import Callable
 from pathlib import Path
 from typing import Literal
 
-from torch_brain.datasets.dataset import Dataset
-from torch_brain.datasets.mixins import SpikingDatasetMixin
-
 from ._utils import get_processed_dir
+from .dataset import Dataset
+from .mixins import SpikingDatasetMixin
 
 
 class PeiPandarinathNLB2021(SpikingDatasetMixin, Dataset):

--- a/torch_brain/datasets/PeiPandarinathNLB2021.py
+++ b/torch_brain/datasets/PeiPandarinathNLB2021.py
@@ -1,5 +1,6 @@
-from typing import Callable, Optional, Literal
+from collections.abc import Callable
 from pathlib import Path
+from typing import Literal
 
 from torch_brain.datasets import Dataset, SpikingDatasetMixin
 
@@ -23,9 +24,9 @@ class PeiPandarinathNLB2021(SpikingDatasetMixin, Dataset):
 
     def __init__(
         self,
-        root: Optional[str] = None,
-        recording_ids: Optional[list[str]] = None,
-        transform: Optional[Callable] = None,
+        root: str | None = None,
+        recording_ids: list[str] | None = None,
+        transform: Callable | None = None,
         dirname: str = "pei_pandarinath_nlb_2021",
         **kwargs,
     ):
@@ -43,7 +44,7 @@ class PeiPandarinathNLB2021(SpikingDatasetMixin, Dataset):
 
     def get_sampling_intervals(
         self,
-        split: Optional[Literal["train", "valid", "test"]] = None,
+        split: Literal["train", "valid", "test"] | None = None,
     ):
         domain_key = "domain" if split is None else f"{split}_domain"
         return {

--- a/torch_brain/datasets/PerichMillerPopulation2018.py
+++ b/torch_brain/datasets/PerichMillerPopulation2018.py
@@ -2,7 +2,8 @@ from collections.abc import Callable
 from pathlib import Path
 from typing import Literal
 
-from torch_brain.datasets import Dataset, SpikingDatasetMixin
+from torch_brain.datasets.dataset import Dataset
+from torch_brain.datasets.mixins import SpikingDatasetMixin
 
 from ._utils import get_processed_dir
 

--- a/torch_brain/datasets/PerichMillerPopulation2018.py
+++ b/torch_brain/datasets/PerichMillerPopulation2018.py
@@ -1,5 +1,6 @@
-from typing import Callable, Optional, Literal
+from collections.abc import Callable
 from pathlib import Path
+from typing import Literal
 
 from torch_brain.datasets import Dataset, SpikingDatasetMixin
 
@@ -39,17 +40,17 @@ class PerichMillerPopulation2018(SpikingDatasetMixin, Dataset):
     Dataset: `Dandiset 000688 <https://doi.org/10.48324/dandi.000688/0.250122.1735>`_.
 
     Args:
-        root (str, optional): Root directory for the dataset. Defaults to ``processed_dir`` from brainsets config.
-        recording_ids (list[str], optional): List of recording IDs to load.
-        transform (Callable, optional): Data transformation to apply.
-        dirname (str, optional): Subdirectory for the dataset. Defaults to "perich_miller_population_2018".
+        root: Root directory for the dataset. Defaults to ``processed_dir`` from brainsets config.
+        recording_ids: List of recording IDs to load.
+        transform: Data transformation to apply.
+        dirname: Subdirectory for the dataset. Defaults to "perich_miller_population_2018".
     """
 
     def __init__(
         self,
-        root: Optional[str] = None,
-        recording_ids: Optional[list[str]] = None,
-        transform: Optional[Callable] = None,
+        root: str | None = None,
+        recording_ids: list[str] | None = None,
+        transform: Callable | None = None,
         dirname: str = "perich_miller_population_2018",
         **kwargs,
     ):
@@ -67,7 +68,7 @@ class PerichMillerPopulation2018(SpikingDatasetMixin, Dataset):
 
     def get_sampling_intervals(
         self,
-        split: Optional[Literal["train", "valid", "test"]] = None,
+        split: Literal["train", "valid", "test"] | None = None,
     ):
         domain_key = "domain" if split is None else f"{split}_domain"
         return {

--- a/torch_brain/datasets/PerichMillerPopulation2018.py
+++ b/torch_brain/datasets/PerichMillerPopulation2018.py
@@ -2,10 +2,9 @@ from collections.abc import Callable
 from pathlib import Path
 from typing import Literal
 
-from torch_brain.datasets.dataset import Dataset
-from torch_brain.datasets.mixins import SpikingDatasetMixin
-
 from ._utils import get_processed_dir
+from .dataset import Dataset
+from .mixins import SpikingDatasetMixin
 
 
 class PerichMillerPopulation2018(SpikingDatasetMixin, Dataset):

--- a/torch_brain/datasets/ShiraziHBNR1DS005505.py
+++ b/torch_brain/datasets/ShiraziHBNR1DS005505.py
@@ -1,4 +1,4 @@
-from typing import Callable, Optional
+from collections.abc import Callable
 
 from .OpenNeuroDataset import OpenNeuroDataset, OpenNeuroSplitType
 
@@ -19,10 +19,10 @@ class ShiraziHBNR1DS005505(OpenNeuroDataset):
     restricted to specific recordings via recording_ids.
 
     Args:
-        root (str): Root directory containing processed HBN-R1 artifacts.
-        split_type (OpenNeuroSplitType): The split type describing train/valid/test regime.
-        recording_ids (list[str], optional): List of explicit recording IDs to load. If omitted, the dataset uses split-based recording selection.
-        transform (Callable, optional): Optional transform to apply to samples.
+        root: Root directory containing processed HBN-R1 artifacts.
+        split_type: The split type describing train/valid/test regime.
+        recording_ids: List of explicit recording IDs to load. If omitted, the dataset uses split-based recording selection.
+        transform: Optional transform to apply to samples.
         **kwargs: Additional keyword arguments forwarded to the base OpenNeuroDataset.
 
     **References**
@@ -34,8 +34,8 @@ class ShiraziHBNR1DS005505(OpenNeuroDataset):
         self,
         root: str,
         split_type: OpenNeuroSplitType,
-        recording_ids: Optional[list[str]] = None,
-        transform: Optional[Callable] = None,
+        recording_ids: list[str] | None = None,
+        transform: Callable | None = None,
         **kwargs,
     ):
         dataset_dir = "shirazi_hbnr1_ds005505"

--- a/torch_brain/datasets/VollanMoserAlternating2025.py
+++ b/torch_brain/datasets/VollanMoserAlternating2025.py
@@ -2,7 +2,8 @@ from collections.abc import Callable
 from pathlib import Path
 from typing import Literal
 
-from torch_brain.datasets import Dataset, SpikingDatasetMixin
+from torch_brain.datasets.dataset import Dataset
+from torch_brain.datasets.mixins import SpikingDatasetMixin
 
 from ._utils import get_processed_dir
 

--- a/torch_brain/datasets/VollanMoserAlternating2025.py
+++ b/torch_brain/datasets/VollanMoserAlternating2025.py
@@ -1,5 +1,6 @@
+from collections.abc import Callable
 from pathlib import Path
-from typing import Callable, Literal, Optional
+from typing import Literal
 
 from torch_brain.datasets import Dataset, SpikingDatasetMixin
 
@@ -208,8 +209,8 @@ class VollanMoserAlternating2025(SpikingDatasetMixin, Dataset):
     Dataset: `EBRAINS <https://search.kg.ebrains.eu/instances/4080b78d-edc5-4ae4-8144-7f6de79930ea>`_.
 
     Args:
-        root (str, optional): Root directory for the dataset. Defaults to ``processed_dir`` from brainsets config.
-        recording_ids (list[str] or str, optional): Recording IDs to load.
+        root: Root directory for the dataset. Defaults to ``processed_dir`` from brainsets config.
+        recording_ids: Recording IDs to load.
             Defaults to all sessions.  Can be:
 
             - A **list** of individual recording IDs.
@@ -221,8 +222,8 @@ class VollanMoserAlternating2025(SpikingDatasetMixin, Dataset):
                   from torch_brain.datasets.VollanMoserAlternating2025 import RECORDING_IDS
                   ds = VollanMoserAlternating2025(root, recording_ids=RECORDING_IDS.navigation.of)
 
-        transform (Callable, optional): Data transformation to apply.
-        dirname (str, optional): Subdirectory for the dataset. Defaults to "vollan_moser_alternating_2025".
+        transform: Data transformation to apply.
+        dirname: Subdirectory for the dataset. Defaults to "vollan_moser_alternating_2025".
     """
 
     # Map string shorthands to RECORDING_IDS sub-groups.
@@ -239,9 +240,9 @@ class VollanMoserAlternating2025(SpikingDatasetMixin, Dataset):
 
     def __init__(
         self,
-        root: Optional[str] = None,
-        recording_ids: Optional[list[str] or str] = None,
-        transform: Optional[Callable] = None,
+        root: str | None = None,
+        recording_ids: list[str] or str | None = None,
+        transform: Callable | None = None,
         dirname: str = "vollan_moser_alternating_2025",
         **kwargs,
     ):
@@ -268,7 +269,7 @@ class VollanMoserAlternating2025(SpikingDatasetMixin, Dataset):
 
     def get_sampling_intervals(
         self,
-        split: Optional[Literal["train", "valid", "test"]] = None,
+        split: Literal["train", "valid", "test"] | None = None,
     ):
         domain_key = "domain" if split is None else f"{split}_domain"
         return {

--- a/torch_brain/datasets/VollanMoserAlternating2025.py
+++ b/torch_brain/datasets/VollanMoserAlternating2025.py
@@ -2,10 +2,9 @@ from collections.abc import Callable
 from pathlib import Path
 from typing import Literal
 
-from torch_brain.datasets.dataset import Dataset
-from torch_brain.datasets.mixins import SpikingDatasetMixin
-
 from ._utils import get_processed_dir
+from .dataset import Dataset
+from .mixins import SpikingDatasetMixin
 
 
 class _RecordingGroup(list):

--- a/torch_brain/datasets/__init__.py
+++ b/torch_brain/datasets/__init__.py
@@ -63,25 +63,24 @@ __api_ref__ = {
     "sections": [],
 }
 
-from .dataset import Dataset, DatasetIndex
-from .nested import NestedDataset, NestedSpikingDataset
-from .mixins import (
-    SpikingDatasetMixin,
-    CalciumImagingDatasetMixin,
-    MultiChannelDatasetMixin,
-)
-from .OpenNeuroDataset import OpenNeuroDataset, OpenNeuroSplitType
-
-from .PerichMillerPopulation2018 import PerichMillerPopulation2018
-from .PeiPandarinathNLB2021 import PeiPandarinathNLB2021
-from .FlintSlutzkyAccurate2012 import FlintSlutzkyAccurate2012
-from .ChurchlandShenoyNeural2012 import ChurchlandShenoyNeural2012
-from .OdohertySabesNonhuman2017 import OdohertySabesNonhuman2017
 from .AllenVisualCodingOphys2016 import AllenVisualCodingOphys2016
+from .ChurchlandShenoyNeural2012 import ChurchlandShenoyNeural2012
+from .dataset import Dataset, DatasetIndex
+from .FlintSlutzkyAccurate2012 import FlintSlutzkyAccurate2012
 from .KempSleepEDF2013 import KempSleepEDF2013
-from .Neuroprobe2025 import Neuroprobe2025
 from .KlinzingSleepDS005555 import KlinzingSleepDS005555
 from .KochiVisualNamingDS006914 import KochiVisualNamingDS006914
+from .mixins import (
+    CalciumImagingDatasetMixin,
+    MultiChannelDatasetMixin,
+    SpikingDatasetMixin,
+)
+from .nested import NestedDataset, NestedSpikingDataset
+from .Neuroprobe2025 import Neuroprobe2025
+from .OdohertySabesNonhuman2017 import OdohertySabesNonhuman2017
+from .OpenNeuroDataset import OpenNeuroDataset, OpenNeuroSplitType
+from .PeiPandarinathNLB2021 import PeiPandarinathNLB2021
+from .PerichMillerPopulation2018 import PerichMillerPopulation2018
 from .ShiraziHBNR1DS005505 import ShiraziHBNR1DS005505
 from .VollanMoserAlternating2025 import VollanMoserAlternating2025
 

--- a/torch_brain/datasets/_utils.py
+++ b/torch_brain/datasets/_utils.py
@@ -1,9 +1,6 @@
 from pathlib import Path
 
-import numpy as np
-
 from torch_brain.pipeline.config import CONFIG_FILE, load_config
-from torch_brain.data import Interval
 
 
 def get_processed_dir(path: Path = CONFIG_FILE) -> str:

--- a/torch_brain/datasets/dataset.py
+++ b/torch_brain/datasets/dataset.py
@@ -1,7 +1,7 @@
 import copy
+from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Callable, Optional
 
 import h5py
 import numpy as np
@@ -86,10 +86,10 @@ class Dataset(torch.utils.data.Dataset):
     def __init__(
         self,
         dataset_dir: str | Path,
-        recording_ids: Optional[list[str]] = None,
-        transform: Optional[Callable] = None,
+        recording_ids: list[str] | None = None,
+        transform: Callable | None = None,
         keep_files_open: bool = True,
-        namespace_attributes: Optional[list[str]] = None,
+        namespace_attributes: list[str] | None = None,
     ):
 
         dataset_dir = Path(dataset_dir)

--- a/torch_brain/datasets/nested.py
+++ b/torch_brain/datasets/nested.py
@@ -1,7 +1,8 @@
-from typing import Optional, Iterable, Mapping, Callable
+from collections.abc import Callable, Iterable, Mapping
 
-from torch_brain.utils import np_string_prefix
 from torch_brain.data import Data, Interval
+from torch_brain.utils import np_string_prefix
+
 from .dataset import Dataset, DatasetIndex
 from .mixins import SpikingDatasetMixin
 
@@ -36,7 +37,7 @@ class NestedDataset(Dataset):
     def __init__(
         self,
         datasets: Iterable[Dataset] | Mapping[str, Dataset],
-        transform: Optional[Callable] = None,
+        transform: Callable | None = None,
     ):
         if isinstance(datasets, Mapping):
             dataset_dict = datasets

--- a/torch_brain/models/poyo.py
+++ b/torch_brain/models/poyo.py
@@ -1,15 +1,14 @@
 import inspect
 import logging
 from pathlib import Path
-from typing import Dict, List
 
 import numpy as np
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-from torch_brain.data import Data
 
 from torch_brain.batching import pad8, track_mask8
+from torch_brain.data import Data
 from torch_brain.datasets import Dataset
 from torch_brain.nn import (
     Embedding,
@@ -174,7 +173,7 @@ class POYO(nn.Module):
         output_timestamps: torch.Tensor,
         output_mask: torch.Tensor | None = None,
         unpack_output: bool = False,
-    ) -> torch.Tensor | List[torch.Tensor]:
+    ) -> torch.Tensor | list[torch.Tensor]:
         """Forward pass of the POYO model.
 
         The model processes input spike sequences through its encoder-processor-decoder
@@ -260,7 +259,7 @@ class POYO(nn.Module):
 
         return output
 
-    def tokenize(self, data: Data) -> Dict:
+    def tokenize(self, data: Data) -> dict:
         r"""Tokenizer used to tokenize Data for the POYO model.
 
         This tokenizer can be called as a transform. If you are applying multiple

--- a/torch_brain/models/poyo.py
+++ b/torch_brain/models/poyo.py
@@ -122,7 +122,7 @@ class POYO(nn.Module):
 
         # process layers
         self.proc_layers = nn.ModuleList([])
-        for i in range(depth):
+        for _ in range(depth):
             self.proc_layers.append(
                 nn.Sequential(
                     RotarySelfAttention(

--- a/torch_brain/nn/embedding.py
+++ b/torch_brain/nn/embedding.py
@@ -9,9 +9,9 @@ class Embedding(nn.Embedding):
     :math:`\mathcal{N}(0, \text{init_scale})`.
 
     Args:
-        num_embeddings (int): size of the dictionary of embeddings
-        embedding_dim (int): the size of each embedding vector
-        init_scale (float, optional): standard deviation of the normal distribution used
+        num_embeddings: size of the dictionary of embeddings
+        embedding_dim: the size of each embedding vector
+        init_scale: standard deviation of the normal distribution used
             for the initialization. Defaults to 0.02, which is the default value used in
             most transformer models
         **kwargs: Additional arguments. Refer to the documentation of

--- a/torch_brain/nn/infinite_vocab_embedding.py
+++ b/torch_brain/nn/infinite_vocab_embedding.py
@@ -86,9 +86,9 @@ class InfiniteVocabEmbedding(nn.Module):
             >>> embedding.weight.shape
             torch.Size([4, 64])
         """
-        assert (
-            self.vocab is None
-        ), f"Vocabulary already initialized, and has {len(self.vocab)} words. "
+        assert self.vocab is None, (
+            f"Vocabulary already initialized, and has {len(self.vocab)} words. "
+        )
         "If you want to add new words to the vocabulary, use extend_vocab() instead."
 
         # Create a mapping from words to indices

--- a/torch_brain/nn/infinite_vocab_embedding.py
+++ b/torch_brain/nn/infinite_vocab_embedding.py
@@ -382,8 +382,8 @@ class InfiniteVocabEmbedding(nn.Module):
             # incoming_vocab and self.vocab might have the same keys but in a different order
             # reorder incoming_vocab to match self.vocab, and get the remapping indices
             remap_indices = []
-            for word, index in self.vocab.items():
-                if not word in incoming_vocab:
+            for word, _ in self.vocab.items():
+                if word not in incoming_vocab:
                     raise ValueError(
                         f"Vocabulary mismatch: word {word} is missing. If "
                         "you would like to add new words, or a new "
@@ -420,6 +420,4 @@ class InfiniteVocabEmbedding(nn.Module):
         return F.embedding(input, self.weight, self.padding_idx)
 
     def extra_repr(self) -> str:
-        return "embedding_dim={}, num_embeddings={}".format(
-            self.embedding_dim, len(self.vocab) if self.vocab is not None else 0
-        )
+        return f"embedding_dim={self.embedding_dim}, num_embeddings={len(self.vocab) if self.vocab is not None else 0}"

--- a/torch_brain/nn/infinite_vocab_embedding.py
+++ b/torch_brain/nn/infinite_vocab_embedding.py
@@ -1,11 +1,9 @@
-import warnings
-from collections.abc import Iterable
-from typing import List, Union
 from collections import OrderedDict
+from collections.abc import Iterable
 
 import torch
-from torch import nn
 import torch.nn.functional as F
+from torch import nn
 from torch.nn.parameter import UninitializedParameter
 
 
@@ -42,8 +40,8 @@ class InfiniteVocabEmbedding(nn.Module):
     .. warning:: If you are only interested in loading a subset of words from a checkpoint, do not call :meth:`initialize_vocab()`, first load the checkpoint then use :meth:`subset_vocab`.
 
     Args:
-        embedding_dim (int): Embedding dimension.
-        init_scale (float): The standard deviation of the normal distribution used to
+        embedding_dim: Embedding dimension.
+        init_scale: The standard deviation of the normal distribution used to
             initialize the embedding matrix. Default is 0.02.
     """
 
@@ -63,7 +61,7 @@ class InfiniteVocabEmbedding(nn.Module):
             self._hook_vocab_on_load_state_dict, with_module=False
         )
 
-    def initialize_vocab(self, vocab: List[str]):
+    def initialize_vocab(self, vocab: list[str]):
         r"""Initialize the vocabulary with a list of words. This method should be called
         only once, and before the model is trained. If you would like to add new words
         to the vocabulary, use :obj:`extend_vocab()` instead.
@@ -71,7 +69,7 @@ class InfiniteVocabEmbedding(nn.Module):
         .. note:: A special word "NA" will always be in the vocabulary, and is assigned the index 0. 0 is used for padding.
 
         Args:
-            vocab (List[str]): A list of words to initialize the vocabulary.
+            vocab: A list of words to initialize the vocabulary.
 
         Example ::
 
@@ -109,14 +107,14 @@ class InfiniteVocabEmbedding(nn.Module):
 
         self.initialize_parameters(len(self.vocab))
 
-    def extend_vocab(self, vocab: List[str], exist_ok=False):
+    def extend_vocab(self, vocab: list[str], exist_ok=False):
         r"""Extend the vocabulary with a list of words. If a word already exists in the
         vocabulary, an error will be raised. The embeddings for the new words will be
         initialized randomly, and new ids will be assigned to the new words.
 
         Args:
-            vocab (List[str]): A list of words to add to the vocabulary.
-            exist_ok (bool): If True, the method will not raise an error if the new words
+            vocab: A list of words to add to the vocabulary.
+            exist_ok: If True, the method will not raise an error if the new words
                 already exist in the vocabulary and will skip them. Default is False.
 
         Example ::
@@ -191,7 +189,7 @@ class InfiniteVocabEmbedding(nn.Module):
         )
         return self
 
-    def subset_vocab(self, vocab: List[str], inplace=True):
+    def subset_vocab(self, vocab: list[str], inplace=True):
         r"""Select a subset of the vocabulary. The embeddings for the selected words
         will be copied from the original embeddings, and the ids for the selected words
         will be updated accordingly.
@@ -199,8 +197,8 @@ class InfiniteVocabEmbedding(nn.Module):
         An error will be raised if one of the words does not exist in the vocabulary.
 
         Args:
-            vocab (List[str]): A list of words to select from the vocabulary.
-            inplace (bool): If True, the method will modify the vocabulary and the weight
+            vocab: A list of words to select from the vocabulary.
+            inplace: If True, the method will modify the vocabulary and the weight
                 matrix in place. If False, a new InfiniteVocabEmbedding will be returned
                 with the selected words. Default is True.
 
@@ -261,11 +259,11 @@ class InfiniteVocabEmbedding(nn.Module):
             new_embedding.weight.data = embeddings_for_selected_words
             return new_embedding
 
-    def tokenizer(self, words: Union[str, List[str]]):
+    def tokenizer(self, words: str | list[str]):
         r"""Convert a word or a list of words to their token indices.
 
         Args:
-            words (Union[str, List[str]]): A word or a list of words.
+            words: A word or a list of words.
 
         Returns:
             Union[int, List[int]]: A token index or a list of token indices.
@@ -296,7 +294,7 @@ class InfiniteVocabEmbedding(nn.Module):
         r"""Convert a token index to a word.
 
         Args:
-            index (int): A token index.
+            index: A token index.
 
         Returns:
             str: A word.

--- a/torch_brain/nn/position_embeddings.py
+++ b/torch_brain/nn/position_embeddings.py
@@ -35,7 +35,7 @@ class SinusoidalTimeEmbedding(nn.Module):
         r"""Convert raw timestamps to sinusoidal embeddings
 
         Args:
-            timestamps (torch.Tensor): timestamps tensor
+            timestamps: timestamps tensor
         """
         angles = timestamps[..., None] * self.omega  # (...,) x (F,)-> (..., F)
         return torch.cat((angles.sin(), angles.cos()), dim=-1)  # (..., D)

--- a/torch_brain/nn/position_embeddings.py
+++ b/torch_brain/nn/position_embeddings.py
@@ -1,5 +1,5 @@
 import torch
-from torch import nn, Tensor
+from torch import Tensor, nn
 
 
 class SinusoidalTimeEmbedding(nn.Module):

--- a/torch_brain/nn/rotary_attention.py
+++ b/torch_brain/nn/rotary_attention.py
@@ -1,6 +1,6 @@
 import torch
-import torch.nn.functional as F
 import torch.nn as nn
+import torch.nn.functional as F
 
 try:
     import xformers.ops as xops

--- a/torch_brain/pipeline/_cli/__init__.py
+++ b/torch_brain/pipeline/_cli/__init__.py
@@ -1,1 +1,1 @@
-from .cli import cli
+from .cli import cli as cli

--- a/torch_brain/pipeline/_cli/__init__.py
+++ b/torch_brain/pipeline/_cli/__init__.py
@@ -1,1 +1,1 @@
-from .cli import cli as cli
+from .cli import cli  # noqa: F401

--- a/torch_brain/pipeline/_cli/cli_completion.py
+++ b/torch_brain/pipeline/_cli/cli_completion.py
@@ -4,7 +4,6 @@ from pathlib import Path
 import click
 from click.shell_completion import get_completion_class
 
-
 SUPPORTED_SHELLS = {"bash", "zsh"}
 
 SHELL_COMPLETION_DIRS = {

--- a/torch_brain/pipeline/_cli/cli_config.py
+++ b/torch_brain/pipeline/_cli/cli_config.py
@@ -1,9 +1,10 @@
-from typing import Optional
-import click
 from pathlib import Path
+from typing import Optional
+
+import click
 from prompt_toolkit import prompt
-from prompt_toolkit.shortcuts import CompleteStyle
 from prompt_toolkit.completion import PathCompleter
+from prompt_toolkit.shortcuts import CompleteStyle
 
 from torch_brain.pipeline.config import CONFIG_FILE, load_config, save_config
 

--- a/torch_brain/pipeline/_cli/cli_config.py
+++ b/torch_brain/pipeline/_cli/cli_config.py
@@ -49,7 +49,7 @@ def config(ctx, raw_dir, processed_dir):
     type=click.Path(file_okay=False, dir_okay=True),
     required=False,
 )
-def set_config(raw_dir: Optional[Path], processed_dir: Optional[Path]):
+def set_config(raw_dir: Path | None, processed_dir: Path | None):
     """Set raw and processed data directories."""
 
     # Get missing args from user prompts

--- a/torch_brain/pipeline/_cli/cli_config.py
+++ b/torch_brain/pipeline/_cli/cli_config.py
@@ -1,5 +1,4 @@
 from pathlib import Path
-from typing import Optional
 
 import click
 from prompt_toolkit import prompt

--- a/torch_brain/pipeline/_cli/cli_prepare.py
+++ b/torch_brain/pipeline/_cli/cli_prepare.py
@@ -1,12 +1,11 @@
-import os
+import json
+import re
+import subprocess
 import sys
 from pathlib import Path
-from typing import Optional
+
 import click
-import subprocess
 from prompt_toolkit import prompt
-import re
-import json
 
 try:  # Python 3.11+
     import tomllib  # type: ignore[import-not-fount]
@@ -19,8 +18,8 @@ from torch_brain.pipeline.config import CONFIG_FILE, load_config
 
 from .utils import (
     PIPELINES_PATH,
-    get_available_brainsets,
     expand_path,
+    get_available_brainsets,
 )
 
 
@@ -105,8 +104,8 @@ def prepare(
     list_flag_: bool,
     single: str,
     use_active_env: bool,
-    raw_dir: Optional[str],
-    processed_dir: Optional[str],
+    raw_dir: str | None,
+    processed_dir: str | None,
     local: bool,
 ):
     """Download and process a single brainset.
@@ -289,13 +288,13 @@ def _determine_torch_brain_spec() -> str:
         return "torch_brain"
 
 
-def _detect_torch_brain_installation_url() -> Optional[str]:
+def _detect_torch_brain_installation_url() -> str | None:
     """
     Detect if the current torch_brain package was installed via something like
     pip install <url>.
     """
 
-    from importlib.metadata import distribution, PackageNotFoundError
+    from importlib.metadata import PackageNotFoundError, distribution
 
     try:
         dist = distribution("torch_brain")
@@ -309,7 +308,7 @@ def _detect_torch_brain_installation_url() -> Optional[str]:
 
     if direct_url_file:
         direct_url_path = Path(dist.locate_file(direct_url_file))
-        with open(direct_url_path, "r") as f:
+        with open(direct_url_path) as f:
             direct_url = json.load(f)
 
         url_info = direct_url.get("url", "")
@@ -334,7 +333,7 @@ _ALLOWED_INLINE_MD_KEYS = {
 }
 
 
-def _read_inline_metadata(filepath: Path) -> Optional[dict]:
+def _read_inline_metadata(filepath: Path) -> dict | None:
     """
     Extract and parse the inline metadata block of type '# /// brainset-pipeline' from the given script file.
 
@@ -346,7 +345,7 @@ def _read_inline_metadata(filepath: Path) -> Optional[dict]:
     Implementation adapted from reference implementation in PEP 723:
     https://peps.python.org/pep-0723/#reference-implementation
     """
-    with open(filepath, "r", encoding="utf-8") as f:
+    with open(filepath, encoding="utf-8") as f:
         script = f.read()
 
     REGEX = r"(?m)^# /// (?P<type>[a-zA-Z0-9-]+)$\s(?P<content>(^#(| .*)$\s)+)^# ///$"

--- a/torch_brain/pipeline/_cli/cli_prepare.py
+++ b/torch_brain/pipeline/_cli/cli_prepare.py
@@ -5,7 +5,6 @@ import sys
 from pathlib import Path
 
 import click
-from prompt_toolkit import prompt
 
 try:  # Python 3.11+
     import tomllib  # type: ignore[import-not-fount]
@@ -240,7 +239,7 @@ def prepare(
         click.echo(f"Command: {command}")
 
     try:
-        process = subprocess.run(
+        subprocess.run(
             command,
             check=True,
             capture_output=False,

--- a/torch_brain/pipeline/_cli/utils.py
+++ b/torch_brain/pipeline/_cli/utils.py
@@ -1,12 +1,12 @@
 import os
-from typing import Union
-import click
 from pathlib import Path
+
+import click
 
 PIPELINES_PATH = Path(__file__).parents[3] / "brainsets_pipelines"
 
 
-def expand_path(path: Union[str, Path]) -> Path:
+def expand_path(path: str | Path) -> Path:
     """
     Convert string path to absolute Path, expanding environment variables and user.
     """

--- a/torch_brain/pipeline/config.py
+++ b/torch_brain/pipeline/config.py
@@ -1,12 +1,11 @@
 from pathlib import Path
-from typing import Optional
 
 import yaml
 
 CONFIG_FILE = Path.home() / ".brainsets.yaml"
 
 
-def load_config(path: Path = CONFIG_FILE) -> Optional[dict]:
+def load_config(path: Path = CONFIG_FILE) -> dict | None:
     """Load and validate the brainsets config file.
 
     Returns the config dict, or ``None`` if the file is missing or invalid.
@@ -15,7 +14,7 @@ def load_config(path: Path = CONFIG_FILE) -> Optional[dict]:
         return None
 
     try:
-        with open(path, "r") as f:
+        with open(path) as f:
             config = yaml.safe_load(f)
     except (OSError, yaml.YAMLError):
         return None

--- a/torch_brain/pipeline/openneuro.py
+++ b/torch_brain/pipeline/openneuro.py
@@ -18,7 +18,6 @@ from pathlib import Path
 from typing import Literal
 
 import h5py
-import numpy as np
 import pandas as pd
 
 try:

--- a/torch_brain/pipeline/openneuro.py
+++ b/torch_brain/pipeline/openneuro.py
@@ -10,12 +10,12 @@ __api_ref__ = {
     "sections": [{"autosummary": __all__}],
 }
 
+import logging
+import sys
 from abc import ABC
 from argparse import ArgumentParser, Namespace
 from pathlib import Path
-from typing import Literal, Optional
-import logging
-import sys
+from typing import Literal
 
 import h5py
 import numpy as np
@@ -30,38 +30,37 @@ except ImportError:
     MNE_BIDS_AVAILABLE = False
 
 from torch_brain.data import (
-    Data,
-    Interval,
     BrainsetDescription,
+    Data,
     DeviceDescription,
     SessionDescription,
     SubjectDescription,
     serialize_fn_map,
 )
-from .pipeline import BrainsetPipeline
 from torch_brain.utils.bids import (
     build_bids_path,
-    fetch_eeg_recordings,
-    fetch_ieeg_recordings,
     check_eeg_recording_files_exist,
     check_ieeg_recording_files_exist,
+    fetch_eeg_recordings,
+    fetch_ieeg_recordings,
     get_subject_info,
 )
 from torch_brain.utils.mne import (
-    extract_signal,
-    extract_measurement_date,
     extract_channels,
+    extract_measurement_date,
+    extract_signal,
 )
-from torch_brain.utils.split import generate_string_kfold_assignment
 from torch_brain.utils.openneuro import (
     construct_s3_url_from_path,
     download_dataset_description,
     download_recording,
     fetch_all_filenames,
+    fetch_latest_snapshot_tag,
     fetch_participants_tsv,
     fetch_species,
-    fetch_latest_snapshot_tag,
 )
+
+from .pipeline import BrainsetPipeline
 
 base_openneuro_parser = ArgumentParser()
 base_openneuro_parser.add_argument("--redownload", action="store_true")
@@ -142,24 +141,24 @@ class OpenNeuroPipeline(BrainsetPipeline, ABC):
     derived_version: str
     """Version of the processed data. Must be specified by the author of each pipeline."""
 
-    description: Optional[str] = None
+    description: str | None = None
     """Optional description of the dataset."""
 
-    CHANNEL_NAME_REMAPPING: Optional[dict[str, str]] = None
+    CHANNEL_NAME_REMAPPING: dict[str, str] | None = None
     """Optional dict mapping original channel name to new standardized name.
 
     For more complex configurations (e.g., per-recording mappings), override
     get_channel_name_remapping() instead.
     """
 
-    TYPE_CHANNELS_REMAPPING: Optional[dict[str, list[str]]] = None
+    TYPE_CHANNELS_REMAPPING: dict[str, list[str]] | None = None
     """Optional dict mapping channel types to lists of channel names.
 
     For more complex configurations (e.g., per-recording mappings), override
     get_type_channels_remapping() instead.
     """
 
-    IGNORE_CHANNELS: Optional[list[str]] = None
+    IGNORE_CHANNELS: list[str] | None = None
     """Optional list of channel names to ignore.
 
     Channel names should be specified as they appear in the original namespace of
@@ -296,7 +295,7 @@ class OpenNeuroPipeline(BrainsetPipeline, ABC):
         return None
 
     @classmethod
-    def get_manifest(cls, raw_dir: Path, args: Optional[Namespace]) -> pd.DataFrame:
+    def get_manifest(cls, raw_dir: Path, args: Namespace | None) -> pd.DataFrame:
         """Generate a manifest DataFrame by discovering recordings from OpenNeuro.
 
         This implementation queries OpenNeuro S3 and parses BIDS-compliant
@@ -422,7 +421,7 @@ class OpenNeuroPipeline(BrainsetPipeline, ABC):
 
         return manifest_item
 
-    def process_common(self, download_output: pd.Series) -> Optional[tuple[Data, Path]]:
+    def process_common(self, download_output: pd.Series) -> tuple[Data, Path] | None:
         """Process data files and create a Data object.
 
         This method handles common OpenNeuro processing tasks:
@@ -543,7 +542,7 @@ class OpenNeuroPipeline(BrainsetPipeline, ABC):
     def get_channel_name_remapping(
         self,
         recording_id: str | None = None,
-    ) -> Optional[dict[str, str]]:
+    ) -> dict[str, str] | None:
         """Return channel name remapping for a given recording.
 
         Override this method to provide per-recording channel name remappings.
@@ -561,7 +560,7 @@ class OpenNeuroPipeline(BrainsetPipeline, ABC):
     def get_type_channels_remapping(
         self,
         recording_id: str | None = None,
-    ) -> Optional[dict[str, list[str]]]:
+    ) -> dict[str, list[str]] | None:
         """Return channel type remapping for a given recording.
 
         Override this method to provide per-recording channel type remappings.

--- a/torch_brain/pipeline/pipeline.py
+++ b/torch_brain/pipeline/pipeline.py
@@ -1,13 +1,14 @@
-from abc import ABC, abstractmethod
 import sys
-from argparse import ArgumentParser, Namespace
-from typing import Optional, NamedTuple, Any
-from pathlib import Path
-import ray.actor
-import pandas as pd
-from rich.console import Console
-from contextlib import contextmanager
 import traceback
+from abc import ABC, abstractmethod
+from argparse import ArgumentParser, Namespace
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any, NamedTuple
+
+import pandas as pd
+import ray.actor
+from rich.console import Console
 
 
 class BrainsetPipeline(ABC):
@@ -59,7 +60,7 @@ class BrainsetPipeline(ABC):
 
     brainset_id: str
     """Unique identifier for the brainset. Must be set by the Pipeline subclass."""
-    parser: Optional[ArgumentParser] = None
+    parser: ArgumentParser | None = None
     """Optional :obj:`argparse.ArgumentParser` object for pipeline-specific
     command-line arguments.
     If set by a subclass, the runner will automatically parse any extra
@@ -67,7 +68,7 @@ class BrainsetPipeline(ABC):
     passed to `get_manifest()` as a method argument, and to the `download()` and
     `process()` methods via `self.args`.
     """
-    args: Optional[Namespace]
+    args: Namespace | None
     """Pipeline-specific arguments parsed from the command line. Set by the runner
     if :attr:`parser` is defined by subclass.
     """
@@ -86,8 +87,8 @@ class BrainsetPipeline(ABC):
         self,
         raw_dir: Path,
         processed_dir: Path,
-        args: Optional[Namespace],
-        tracker_handle: Optional[ray.actor.ActorHandle] = None,
+        args: Namespace | None,
+        tracker_handle: ray.actor.ActorHandle | None = None,
         download_only: bool = False,
     ):
         self.raw_dir = raw_dir
@@ -101,7 +102,7 @@ class BrainsetPipeline(ABC):
     def get_manifest(
         cls,
         raw_dir: Path,
-        args: Optional[Namespace],
+        args: Namespace | None,
     ) -> pd.DataFrame:
         r"""Returns a :obj:`pandas.DataFrame`, which is a table of assets to be
         downloaded and processed. Each row will be passed individually to the

--- a/torch_brain/pipeline/runner.py
+++ b/torch_brain/pipeline/runner.py
@@ -1,10 +1,9 @@
 import sys
-from typing import Type
+from typing import Any
 from argparse import ArgumentParser
 import os
 import time
 from collections import defaultdict
-from typing import Dict, Any, List
 from pathlib import Path
 import logging
 import ray
@@ -17,7 +16,7 @@ import pandas as pd
 from .pipeline import BrainsetPipeline
 
 
-def import_pipeline_cls_from_file(pipeline_filepath: Path) -> Type[BrainsetPipeline]:
+def import_pipeline_cls_from_file(pipeline_filepath: Path) -> type[BrainsetPipeline]:
     import importlib.util
 
     spec = importlib.util.spec_from_file_location("pipeline_module", pipeline_filepath)
@@ -29,7 +28,7 @@ def import_pipeline_cls_from_file(pipeline_filepath: Path) -> Type[BrainsetPipel
 @ray.remote
 class StatusTracker:
     def __init__(self):
-        self.statuses: Dict[Any, str] = {}
+        self.statuses: dict[Any, str] = {}
 
     def update_status(self, id: Any, status: str):
         self.statuses[id] = status
@@ -49,7 +48,7 @@ def get_style(status: str) -> str:
         return "yellow"
 
 
-def generate_status_table(status_dict: Dict[Any, str]) -> str:
+def generate_status_table(status_dict: dict[Any, str]) -> str:
     # Sort files for a consistent display
     sorted_files = sorted(status_dict.keys())
 
@@ -71,7 +70,7 @@ def generate_status_table(status_dict: Dict[Any, str]) -> str:
 
 
 @ray.remote
-def run_pool_in_background(actor_pool: ActorPool, work_items: List[Any]):
+def run_pool_in_background(actor_pool: ActorPool, work_items: list[Any]):
     results_generator = actor_pool.map_unordered(
         lambda actor, task: actor._run_item_on_parallel_worker.remote(task),
         work_items,

--- a/torch_brain/pipeline/runner.py
+++ b/torch_brain/pipeline/runner.py
@@ -1,17 +1,17 @@
-import sys
-from typing import Any
-from argparse import ArgumentParser
+import logging
 import os
+import sys
 import time
+from argparse import ArgumentParser
 from collections import defaultdict
 from pathlib import Path
-import logging
+from typing import Any
+
+import pandas as pd
 import ray
 from ray.util.actor_pool import ActorPool
-
-from rich.live import Live
 from rich.console import Console
-import pandas as pd
+from rich.live import Live
 
 from .pipeline import BrainsetPipeline
 

--- a/torch_brain/samplers/__init__.py
+++ b/torch_brain/samplers/__init__.py
@@ -1,8 +1,8 @@
+from .distributed_evaluation_sampler import DistributedEvaluationSamplerWrapper
+from .distributed_stitching_fixed_window import DistributedStitchingFixedWindowSampler
 from .random_fixed_window import RandomFixedWindowSampler
 from .sequential_fixed_window import SequentialFixedWindowSampler
 from .trial_sampler import TrialSampler
-from .distributed_evaluation_sampler import DistributedEvaluationSamplerWrapper
-from .distributed_stitching_fixed_window import DistributedStitchingFixedWindowSampler
 
 __all__ = [
     "RandomFixedWindowSampler",

--- a/torch_brain/samplers/distributed_evaluation_sampler.py
+++ b/torch_brain/samplers/distributed_evaluation_sampler.py
@@ -30,7 +30,6 @@ class DistributedEvaluationSamplerWrapper(torch.utils.data.Sampler):
 
     Example::
 
-        >>> import numpy as np
         >>> from torch_brain.data import Interval
         >>> from torch_brain.samplers import SequentialFixedWindowSampler, DistributedEvaluationSamplerWrapper
 

--- a/torch_brain/samplers/distributed_evaluation_sampler.py
+++ b/torch_brain/samplers/distributed_evaluation_sampler.py
@@ -100,9 +100,9 @@ class DistributedEvaluationSamplerWrapper(torch.utils.data.Sampler):
         Raises:
             AssertionError: If :meth:`set_params` has not been called yet.
         """
-        assert (
-            self._check_params()
-        ), "Rank and num_replicas must be set before using the distributed sampler."
+        assert self._check_params(), (
+            "Rank and num_replicas must be set before using the distributed sampler."
+        )
         indices = list(self.sampler)
         indices = indices[self.rank : len(indices) : self.num_replicas]
         return iter(indices)

--- a/torch_brain/samplers/distributed_stitching_fixed_window.py
+++ b/torch_brain/samplers/distributed_stitching_fixed_window.py
@@ -1,5 +1,3 @@
-from typing import Dict, List, Tuple
-
 import torch
 import torch.distributed as dist
 
@@ -42,14 +40,13 @@ class DistributedStitchingFixedWindowSampler(torch.utils.data.DistributedSampler
             :func:`torch.distributed.get_rank`.
 
     Attributes:
-        sequence_index (torch.Tensor): 1-D integer tensor of length ``len(self)``
+        sequence_index: 1-D integer tensor of length ``len(self)``
             mapping each window index to its contiguous-interval index on this rank.
             Consecutive windows sharing the same value belong to the same interval and
             will be stitched together.
 
     Example::
 
-        >>> import numpy as np
         >>> from torch_brain.data import Interval
         >>> from torch_brain.samplers import DistributedStitchingFixedWindowSampler
 
@@ -71,7 +68,7 @@ class DistributedStitchingFixedWindowSampler(torch.utils.data.DistributedSampler
     def __init__(
         self,
         *,
-        sampling_intervals: Dict[str, Interval],
+        sampling_intervals: dict[str, Interval],
         batch_size: int,
         window_length: float,
         step: float | None = None,
@@ -111,7 +108,7 @@ class DistributedStitchingFixedWindowSampler(torch.utils.data.DistributedSampler
         self.indices, self.sequence_index = self._generate_indices()
         self.num_samples = len(self.indices)
 
-    def _generate_indices(self) -> Tuple[List[DatasetIndex], torch.Tensor]:
+    def _generate_indices(self) -> tuple[list[DatasetIndex], torch.Tensor]:
         """Build window indices for this rank using a greedy load-balancing assignment.
 
         Intervals are sorted by window count (largest first) and assigned to the rank

--- a/torch_brain/samplers/random_fixed_window.py
+++ b/torch_brain/samplers/random_fixed_window.py
@@ -1,7 +1,6 @@
 import logging
 import math
 from functools import cached_property
-from typing import Dict
 
 import torch
 
@@ -38,7 +37,6 @@ class RandomFixedWindowSampler(torch.utils.data.Sampler[DatasetIndex]):
 
     Example::
 
-        >>> import numpy as np
         >>> from torch_brain.data import Interval
         >>> from torch_brain.samplers import RandomFixedWindowSampler
 
@@ -57,7 +55,7 @@ class RandomFixedWindowSampler(torch.utils.data.Sampler[DatasetIndex]):
     def __init__(
         self,
         *,
-        sampling_intervals: Dict[str, Interval],
+        sampling_intervals: dict[str, Interval],
         window_length: float,
         generator: torch.Generator | None = None,
         drop_short: bool = True,

--- a/torch_brain/samplers/sequential_fixed_window.py
+++ b/torch_brain/samplers/sequential_fixed_window.py
@@ -1,6 +1,5 @@
 import logging
 from functools import cached_property
-from typing import Dict, List
 
 import torch
 
@@ -35,7 +34,6 @@ class SequentialFixedWindowSampler(torch.utils.data.Sampler[DatasetIndex]):
 
     Example::
 
-        >>> import numpy as np
         >>> from torch_brain.data import Interval
         >>> from torch_brain.samplers import SequentialFixedWindowSampler
 
@@ -55,7 +53,7 @@ class SequentialFixedWindowSampler(torch.utils.data.Sampler[DatasetIndex]):
     def __init__(
         self,
         *,
-        sampling_intervals: Dict[str, Interval],
+        sampling_intervals: dict[str, Interval],
         window_length: float,
         step: float | None = None,
         drop_short: bool = False,
@@ -69,7 +67,7 @@ class SequentialFixedWindowSampler(torch.utils.data.Sampler[DatasetIndex]):
 
     # we cache the indices since they are deterministic
     @cached_property
-    def _indices(self) -> List[DatasetIndex]:
+    def _indices(self) -> list[DatasetIndex]:
         indices = []
         total_short_dropped = 0.0
 

--- a/torch_brain/samplers/trial_sampler.py
+++ b/torch_brain/samplers/trial_sampler.py
@@ -1,5 +1,3 @@
-from typing import Dict
-
 import torch
 
 from torch_brain.data import Interval
@@ -29,14 +27,13 @@ class TrialSampler(torch.utils.data.Sampler[DatasetIndex]):
 
     Example::
 
-        >>> import numpy as np
         >>> from torch_brain.data import Interval
         >>> from torch_brain.samplers import TrialSampler
 
         >>> sampling_intervals = {
         ...     "session_1": Interval(
-        ...         start=np.array([0.0, 5.0, 10.0]),
-        ...         end=np.array([2.0, 8.0, 15.0]),
+        ...         start=[0.0, 5.0, 10.0],
+        ...         end=[2.0, 8.0, 15.0],
         ...     ),
         ... }
         >>> sampler = TrialSampler(
@@ -50,7 +47,7 @@ class TrialSampler(torch.utils.data.Sampler[DatasetIndex]):
     def __init__(
         self,
         *,
-        sampling_intervals: Dict[str, Interval],
+        sampling_intervals: dict[str, Interval],
         shuffle: bool = False,
         generator: torch.Generator | None = None,
     ):

--- a/torch_brain/transforms/bin_spikes.py
+++ b/torch_brain/transforms/bin_spikes.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 import numpy as np
 
 from torch_brain.data import Data, RegularTimeSeries
@@ -30,7 +28,7 @@ class BinSpikes:
         bin_size: float,
         spikes_attribute: str = "spikes",
         units_attribute: str = "units",
-        max_spikes: Optional[int] = None,
+        max_spikes: int | None = None,
         right: bool = True,
         eps: float = 1e-3,
         dtype: np.dtype = np.int32,

--- a/torch_brain/transforms/container.py
+++ b/torch_brain/transforms/container.py
@@ -34,7 +34,7 @@ class RandomChoice:
             all transforms have the same probability.
     """
 
-    def __init__(self, transforms: list[Callable], p: list[float] = None) -> None:
+    def __init__(self, transforms: list[Callable], p: list[float] = None):
         if p is None:
             p = [1] * len(transforms)
         elif len(p) != len(transforms):
@@ -67,7 +67,7 @@ class ConditionalChoice:
 
     def __init__(
         self, condition: Callable, true_transform: Callable, false_transform: Callable
-    ) -> None:
+    ):
         self.condition = condition
         self.true_transform = true_transform
         self.false_transform = false_transform

--- a/torch_brain/transforms/container.py
+++ b/torch_brain/transforms/container.py
@@ -1,4 +1,4 @@
-from typing import Any, Callable, List
+from collections.abc import Callable
 
 import numpy as np
 
@@ -11,10 +11,10 @@ class Compose:
     the last transform, which can return any object.
 
     Args:
-        transforms (list of callable): list of transforms to compose.
+        transforms: list of transforms to compose.
     """
 
-    def __init__(self, transforms: List[Callable]):
+    def __init__(self, transforms: list[Callable]):
         self.transforms = transforms
 
     def __call__(self, data: Data) -> Data:
@@ -29,12 +29,12 @@ class RandomChoice:
 
     Args:
         transforms: list of transformations
-        p (list of floats, optional): probability of each transform being picked.
+        p: probability of each transform being picked.
             If :obj:`p` doesn't sum to 1, it is automatically normalized. By default,
             all transforms have the same probability.
     """
 
-    def __init__(self, transforms: List[Callable], p: List[float] = None) -> None:
+    def __init__(self, transforms: list[Callable], p: list[float] = None) -> None:
         if p is None:
             p = [1] * len(transforms)
         elif len(p) != len(transforms):

--- a/torch_brain/transforms/random_time_scaling.py
+++ b/torch_brain/transforms/random_time_scaling.py
@@ -1,7 +1,8 @@
 import copy
+
 import torch
 
-from torch_brain.data import IrregularTimeSeries, RegularTimeSeries, Interval, Data
+from torch_brain.data import Data, Interval, IrregularTimeSeries, RegularTimeSeries
 
 
 def rescale(data: Data, scale: float, offset: float):

--- a/torch_brain/transforms/random_time_scaling.py
+++ b/torch_brain/transforms/random_time_scaling.py
@@ -8,9 +8,9 @@ def rescale(data: Data, scale: float, offset: float):
     r"""Rescale the time axis of the data by a factor and offset.
 
     Args:
-        data (Data): The data to rescale.
-        scale (float): The scaling factor.
-        offset (float): The offset.
+        data: The data to rescale.
+        scale: The scaling factor.
+        offset: The offset.
     """
     out = data.__class__.__new__(data.__class__)
 

--- a/torch_brain/transforms/unit_dropout.py
+++ b/torch_brain/transforms/unit_dropout.py
@@ -1,5 +1,4 @@
 import logging
-from typing import Optional
 
 import numpy as np
 
@@ -23,17 +22,17 @@ class TriangleDistribution:
         \end{cases}
 
     Args:
-        min_units (int): Minimum number of units to sample. If the population has fewer
+        min_units: Minimum number of units to sample. If the population has fewer
             units than this, all units will be kept.
-        mode_units (int): Mode of the distribution.
-        max_units (int): Maximum number of units to sample.
-        tail_right (int, optional): Right tail of the distribution. If None, it is set to
+        mode_units: Mode of the distribution.
+        max_units: Maximum number of units to sample.
+        tail_right: Right tail of the distribution. If None, it is set to
             `max_units`.
-        peak (float, optional): Height of the peak of the distribution.
-        M (float, optional): Normalization constant for the proposal distribution.
-        max_attempts (int, optional): Maximum number of attempts to sample from the
+        peak: Height of the peak of the distribution.
+        M: Normalization constant for the proposal distribution.
+        max_attempts: Maximum number of attempts to sample from the
             distribution.
-        seed (int, optional): Seed for the random number generator.
+        seed: Seed for the random number generator.
 
     .. image:: /_static/img/triangle_distribution.png
 
@@ -48,11 +47,11 @@ class TriangleDistribution:
         min_units: int = 20,
         mode_units: int = 100,
         max_units: int = 300,
-        tail_right: Optional[int] = None,
+        tail_right: int | None = None,
         peak: float = 4,
         M: int = 10,
         max_attempts: int = 100,
-        seed: Optional[int] = None,
+        seed: int | None = None,
     ):
         super().__init__()
         self.min_units = min_units
@@ -117,7 +116,7 @@ class UnitDropout:
     corresponding columns from the data.
 
     Args:
-        field (str, optional): Field to apply the dropout. Defaults to "spikes".
+        field: Field to apply the dropout. Defaults to "spikes".
         \*args, \*\*kwargs: Arguments to pass to the :class:`TriangleDistribution` constructor.
     """
 

--- a/torch_brain/transforms/unit_filter.py
+++ b/torch_brain/transforms/unit_filter.py
@@ -1,5 +1,6 @@
 import re
-from typing import Callable, Pattern, Union
+from collections.abc import Callable
+from re import Pattern
 
 import numpy as np
 
@@ -11,9 +12,9 @@ class UnitFilter:
     Drop units based on the `mask_fn` given in the constructor.
 
     Args:
-        mask_fn (Callable[[ArrayDict], np.ndarray]): A function that takes the unit ids and returns a mask to keep the units.
-        field (str): The field to apply the filter.
-        reset_index (bool, optional): If True, it will reset_index the unit index of the time series.
+        mask_fn: A function that takes the unit ids and returns a mask to keep the units.
+        field: The field to apply the filter.
+        reset_index: If True, it will reset_index the unit index of the time series.
     """
 
     def __init__(
@@ -61,15 +62,15 @@ class UnitFilterById(UnitFilter):
 
 
     Args:
-        pattern (Union[str, Pattern]): The regex pattern to match against the unit ids.
-        field (str): The field to apply the filter.
-        reset_index (bool, optional): If True, it will reset_index the unit index of the time series.
-        keep_matches (bool, optional): If True, units matching the pattern will be kept.
+        pattern: The regex pattern to match against the unit ids.
+        field: The field to apply the filter.
+        reset_index: If True, it will reset_index the unit index of the time series.
+        keep_matches: If True, units matching the pattern will be kept.
     """
 
     def __init__(
         self,
-        pattern: Union[str, Pattern],
+        pattern: str | Pattern,
         field: str,
         reset_index: bool = True,
         keep_matches: bool = True,

--- a/torch_brain/utils/__init__.py
+++ b/torch_brain/utils/__init__.py
@@ -1,5 +1,6 @@
 from .binning import bin_spikes
-from .misc import calculate_sampling_rate, np_string_prefix
+from .misc import calculate_sampling_rate as calculate_sampling_rate
+from .misc import np_string_prefix
 from .tokenizers import create_linspace_latent_tokens, create_start_end_unit_tokens
 from .weights import isin_interval, resolve_weights_based_on_interval_membership
 

--- a/torch_brain/utils/__init__.py
+++ b/torch_brain/utils/__init__.py
@@ -1,7 +1,7 @@
-from .tokenizers import create_linspace_latent_tokens, create_start_end_unit_tokens
-from .weights import resolve_weights_based_on_interval_membership, isin_interval
-from .misc import np_string_prefix, calculate_sampling_rate
 from .binning import bin_spikes
+from .misc import calculate_sampling_rate, np_string_prefix
+from .tokenizers import create_linspace_latent_tokens, create_start_end_unit_tokens
+from .weights import isin_interval, resolve_weights_based_on_interval_membership
 
 # from .stitcher import stitch
 

--- a/torch_brain/utils/bids.py
+++ b/torch_brain/utils/bids.py
@@ -24,20 +24,21 @@ __api_ref__ = {
 }
 
 
-from collections import defaultdict
-from typing import Optional, Literal
-from pathlib import Path
-import warnings
-import re
 import json
+import re
+import warnings
+from collections import defaultdict
+from pathlib import Path
+from typing import Literal
+
 import pandas as pd
 
 try:
     from mne_bids import (
+        BIDSPath,
         get_bids_path_from_fname,
         get_entities_from_fname,
         get_entity_vals,
-        BIDSPath,
     )
 
     MNE_BIDS_AVAILABLE = True
@@ -166,7 +167,7 @@ def fetch_ieeg_recordings(
 
 def group_recordings_by_entity(
     recordings: list[dict],
-    fixed_entities: Optional[list[str]] = None,
+    fixed_entities: list[str] | None = None,
 ) -> dict[str, list[dict]]:
     """Group BIDS-compliant recordings by specified fixed entities.
 
@@ -384,7 +385,7 @@ def load_json_sidecar(bids_path: BIDSPath) -> dict:
         raise FileNotFoundError(f"No JSON sidecar file found for {bids_path}.") from err
 
 
-def load_participants_tsv(bids_root: Path | str) -> Optional[pd.DataFrame]:
+def load_participants_tsv(bids_root: Path | str) -> pd.DataFrame | None:
     """Load participants.tsv data from a BIDS root directory.
 
     The participants.tsv file is a tab-delimited file containing information about all subjects
@@ -637,7 +638,7 @@ def _is_bids_root(path: str | Path) -> bool:
         This is checked using get_entity_vals(path, 'subject'), which searches for subject-level entities.
 
     Args:
-        path (str or Path): The path to check.
+        path: The path to check.
 
     Returns:
         bool: True if the path is a valid BIDS root (i.e., it is a directory and has at least one BIDS subject entity).

--- a/torch_brain/utils/bids.py
+++ b/torch_brain/utils/bids.py
@@ -215,7 +215,8 @@ def group_recordings_by_entity(
             "No fixed_entities were specified for grouping recordings. "
             "By default, recordings will be grouped by all BIDS entities present in the filename, except for the 'run' entity "
             "(so only the run may vary within each group). "
-            "To control grouping more precisely, specify 'fixed_entities' as a list of BIDS entities (e.g., ['subject', 'session', 'task'])."
+            "To control grouping more precisely, specify 'fixed_entities' as a list of BIDS entities (e.g., ['subject', 'session', 'task']).",
+            stacklevel=2,
         )
 
     normalized_fixed = (
@@ -379,7 +380,7 @@ def load_json_sidecar(bids_path: BIDSPath) -> dict:
         sidecar_path = bids_path.find_matching_sidecar(
             extension=".json", on_error="raise"
         )
-        with open(sidecar_path, "r", encoding="utf-8") as f:
+        with open(sidecar_path, encoding="utf-8") as f:
             return json.load(f)
     except RuntimeError as err:
         raise FileNotFoundError(f"No JSON sidecar file found for {bids_path}.") from err
@@ -418,7 +419,8 @@ def load_participants_tsv(bids_root: Path | str) -> pd.DataFrame | None:
     if "participant_id" not in df.columns:
         warnings.warn(
             f"No participant_id column found in participants.tsv file in BIDS root directory {bids_root}. "
-            "Returning None."
+            "Returning None.",
+            stacklevel=2,
         )
         return None
 
@@ -442,14 +444,16 @@ def get_subject_info(
     if participants_data is None:
         warnings.warn(
             "The participants.tsv file was not provided. No subject information can be retrieved. "
-            "Returning None for age and sex. Please provide a valid participants.tsv file."
+            "Returning None for age and sex. Please provide a valid participants.tsv file.",
+            stacklevel=2,
         )
         return {"age": None, "sex": None}
 
     if subject_id not in participants_data.index:
         warnings.warn(
             f"Subject {subject_id} not found in participants.tsv file. "
-            "Setting age and sex to None."
+            "Setting age and sex to None.",
+            stacklevel=2,
         )
         return {"age": None, "sex": None}
 
@@ -459,7 +463,8 @@ def get_subject_info(
     if pd.isna(age):
         warnings.warn(
             f"Age for subject {subject_id} is NaN in participants.tsv file. "
-            "Setting age to None."
+            "Setting age to None.",
+            stacklevel=2,
         )
         age = None
 
@@ -467,7 +472,8 @@ def get_subject_info(
     if pd.isna(sex):
         warnings.warn(
             f"Sex for subject {subject_id} is NaN in participants.tsv file. "
-            "Setting sex to None."
+            "Setting sex to None.",
+            stacklevel=2,
         )
         sex = None
 

--- a/torch_brain/utils/binning.py
+++ b/torch_brain/utils/binning.py
@@ -1,6 +1,5 @@
-from typing import Optional
-
 import numpy as np
+
 from torch_brain.data import IrregularTimeSeries
 
 
@@ -8,7 +7,7 @@ def bin_spikes(
     spikes: IrregularTimeSeries,
     num_units: int,
     bin_size: float,
-    max_spikes: Optional[int] = None,
+    max_spikes: int | None = None,
     right: bool = True,
     eps: float = 1e-3,
     dtype: np.dtype = np.int32,

--- a/torch_brain/utils/callbacks.py
+++ b/torch_brain/utils/callbacks.py
@@ -1,7 +1,6 @@
-from typing import List
-import time
-import subprocess
 import logging
+import subprocess
+import time
 from dataclasses import dataclass
 
 import torch
@@ -36,7 +35,7 @@ def _check_lightning_available(cls):
 class EpochTimeLogger(L.Callback):
     r"""Lightning callback to log the time taken for each epoch.
     Args:
-        enable (bool, optional): Whether to enable the callback. Defaults to `True`.
+        enable: Whether to enable the callback. Defaults to `True`.
     """
 
     def __init__(self, enable=True):
@@ -57,10 +56,10 @@ class ModelWeightStatsLogger(L.Callback):
     r"""Lightning callback to log the mean and standard deviation of the weights and
     gradients of the model.
     Args:
-        enable (bool, optional): Whether to enable the callback. Defaults to `True`.
-        grads (bool, optional): Whether to log the statistics of gradients.
+        enable: Whether to enable the callback. Defaults to `True`.
+        grads: Whether to log the statistics of gradients.
             Defaults to `True`.
-        module_name (str, optional): The name of the :class:`torch.nn.Module` object inside your
+        module_name: The name of the :class:`torch.nn.Module` object inside your
             :class:`lightning.LightningModule` object to log the statistics of. Defaults to "model".
             This name is prefixed to the keys in the logs, allowing logging the statistics
             of multiple modules with multiple instances of this callback.
@@ -133,5 +132,5 @@ class DataForDecodingStitchEvaluator:
     preds: torch.FloatTensor  # B x T_max x D_output
     targets: torch.FloatTensor  # B x T_max x D_output
     eval_masks: torch.BoolTensor  # B x T_max
-    session_ids: List[str]  # A list of session ID strings, 1 for each sample in batch
+    session_ids: list[str]  # A list of session ID strings, 1 for each sample in batch
     absolute_starts: torch.Tensor  # Batch

--- a/torch_brain/utils/dandi.py
+++ b/torch_brain/utils/dandi.py
@@ -22,7 +22,7 @@ from pynwb import NWBFile
 from torch_brain.data import ArrayDict, IrregularTimeSeries, SubjectDescription
 
 try:
-    import dandi
+    import dandi  # noqa: F401
 
     DANDI_AVAILABLE = True
 except ImportError:

--- a/torch_brain/utils/misc.py
+++ b/torch_brain/utils/misc.py
@@ -1,5 +1,5 @@
-from packaging import version
 import numpy as np
+from packaging import version
 
 
 def np_string_prefix(prefix: str, array: np.ndarray) -> np.ndarray:

--- a/torch_brain/utils/misc.py
+++ b/torch_brain/utils/misc.py
@@ -7,8 +7,8 @@ def np_string_prefix(prefix: str, array: np.ndarray) -> np.ndarray:
     Adds a string prefix to each element of a numpy string array.
 
     Args:
-        prefix (str): The string to prepend to each element.
-        array (np.ndarray): An array of strings or string-like objects.
+        prefix: The string to prepend to each element.
+        array: An array of strings or string-like objects.
 
     Returns:
         np.ndarray: New array with the prefix added to each element.

--- a/torch_brain/utils/mne.py
+++ b/torch_brain/utils/mne.py
@@ -64,7 +64,7 @@ def extract_measurement_date(
     _check_mne_available("extract_measurement_date")
     ans = recording_data.info["meas_date"]
     if ans is None:
-        warnings.warn("No measurement date found, using None")
+        warnings.warn("No measurement date found, using None", stacklevel=2)
     return ans
 
 
@@ -203,7 +203,8 @@ def concatenate_recordings(
         elif on_missing_meas_date == "warn":
             warnings.warn(
                 "One or more recordings have missing measurement dates (meas_date=None). "
-                "Concatenating in input order; measurement date validation and temporal sorting will be skipped."
+                "Concatenating in input order; measurement date validation and temporal sorting will be skipped.",
+                stacklevel=2,
             )
         # For both 'warn' and 'ignore', skip the date-based validation and sort by input order
         copies = []
@@ -221,7 +222,7 @@ def concatenate_recordings(
         if on_mismatch == "raise":
             raise ValueError(msg)
         elif on_mismatch == "warn":
-            warnings.warn(msg)
+            warnings.warn(msg, stacklevel=2)
 
     # Sort recordings by measurement date
     indexed_recordings = [
@@ -233,7 +234,7 @@ def concatenate_recordings(
     )
 
     # Validate that gap between consecutive recordings is within max_gap
-    for (idx1, rec1, date1), (idx2, rec2, date2) in zip(
+    for (idx1, rec1, date1), (idx2, _rec2, date2) in zip(
         sorted_recordings, sorted_recordings[1:]
     ):
         # Gap is the difference between the meas_date (date2) of the next recording (rec2)
@@ -247,7 +248,7 @@ def concatenate_recordings(
             if on_gap == "raise":
                 raise ValueError(msg)
             elif on_gap == "warn":
-                warnings.warn(msg)
+                warnings.warn(msg, stacklevel=2)
 
     copies = []
     for _, rec, _ in sorted_recordings:
@@ -281,7 +282,8 @@ def extract_signal(
     if ignore_channels is not None:
         warnings.warn(
             "The 'ignore_channels' argument was passed to extract_signal. "
-            "Ensure you also pass the same value to extract_channels to maintain consistency."
+            "Ensure you also pass the same value to extract_channels to maintain consistency.",
+            stacklevel=2,
         )
 
     sfreq = recording_data.info["sfreq"]
@@ -361,7 +363,8 @@ def extract_channels(
     if ignore_channels is not None:
         warnings.warn(
             "The 'ignore_channels' argument was passed to extract_channels. "
-            "Ensure you also pass the same value to extract_signal to maintain consistency."
+            "Ensure you also pass the same value to extract_signal to maintain consistency.",
+            stacklevel=2,
         )
 
     if not isinstance(recording_data, mne.io.BaseRaw):
@@ -438,7 +441,9 @@ def extract_channels(
             if montage is not None:
                 channel_pos_mapping = montage.get_positions()["ch_pos"]
         except Exception as e:
-            warnings.warn(f"Could not extract channel positions from montage: {e}")
+            warnings.warn(
+                f"Could not extract channel positions from montage: {e}", stacklevel=2
+            )
 
     if channel_pos_mapping is not None:
         channel_pos = np.array(
@@ -501,7 +506,8 @@ def _validate_channel_names_mapping(
 
     if not any([ch_name in channel_names_mapping.keys() for ch_name in raw_ch_names]):
         warnings.warn(
-            f"Some channel names in the raw data are not present in the mapping keys: {set(raw_ch_names) - set(channel_names_mapping.keys())}"
+            f"Some channel names in the raw data are not present in the mapping keys: {set(raw_ch_names) - set(channel_names_mapping.keys())}",
+            stacklevel=2,
         )
 
     mapping_keys_set = set(channel_names_mapping.keys())

--- a/torch_brain/utils/mne.py
+++ b/torch_brain/utils/mne.py
@@ -647,7 +647,7 @@ def _transpose_type_channels_mapping(
     corresponding type for each channel.
 
     Args:
-        type_channels_mapping (dict[str, list[str]] | None): Mapping from channel types to lists of channel names.
+        type_channels_mapping: Mapping from channel types to lists of channel names.
             Example: {"eeg": ["C3", "C4"], "eog": ["EOG1"]}
 
     Returns:

--- a/torch_brain/utils/openneuro.py
+++ b/torch_brain/utils/openneuro.py
@@ -295,7 +295,6 @@ def _graphql_query_openneuro(query: str, variables: dict | None = None) -> dict:
 
     def _retry(max_attempts=5, initial_wait=4, max_wait=10):
         def decorator(func):
-            import random
             import time
 
             def wrapper(*args, **kwargs):
@@ -304,7 +303,7 @@ def _graphql_query_openneuro(query: str, variables: dict | None = None) -> dict:
                 while True:
                     try:
                         return func(*args, **kwargs)
-                    except Exception as e:
+                    except Exception:
                         attempt += 1
                         if attempt >= max_attempts:
                             raise

--- a/torch_brain/utils/openneuro.py
+++ b/torch_brain/utils/openneuro.py
@@ -20,12 +20,12 @@ __api_ref__ = {
     "sections": [{"autosummary": __all__}],
 }
 
+import logging
 from io import BytesIO
 from pathlib import Path
-from typing import Optional
-import logging
-import requests
+
 import pandas as pd
+import requests
 
 try:
     from botocore.exceptions import ClientError
@@ -114,7 +114,7 @@ def fetch_all_filenames(dataset_id: str) -> list[str]:
     return filenames
 
 
-def fetch_participants_tsv(dataset_id: str) -> Optional[pd.DataFrame]:
+def fetch_participants_tsv(dataset_id: str) -> pd.DataFrame | None:
     """Fetch and parse participants.tsv from OpenNeuro S3.
 
     Args:
@@ -295,8 +295,8 @@ def _graphql_query_openneuro(query: str, variables: dict | None = None) -> dict:
 
     def _retry(max_attempts=5, initial_wait=4, max_wait=10):
         def decorator(func):
-            import time
             import random
+            import time
 
             def wrapper(*args, **kwargs):
                 attempt = 0

--- a/torch_brain/utils/signal.py
+++ b/torch_brain/utils/signal.py
@@ -81,9 +81,9 @@ def extract_bands(
         )
 
     target_Fs = 50
-    assert (
-        Fs % target_Fs == 0
-    ), "Sampling rate must be a multiple of the target frequency"
+    assert Fs % target_Fs == 0, (
+        "Sampling rate must be a multiple of the target frequency"
+    )
 
     assert lfps.shape[0] == ts.shape[0], "Time should be first dimension."
     info = mne.create_info(

--- a/torch_brain/utils/signal.py
+++ b/torch_brain/utils/signal.py
@@ -74,11 +74,11 @@ def extract_bands(
     """
     try:
         import mne
-    except ImportError:
+    except ImportError as err:
         raise ImportError(
             "This function requires the MNE library which you can install with "
             "`pip install mne`"
-        )
+        ) from err
 
     target_Fs = 50
     assert Fs % target_Fs == 0, (

--- a/torch_brain/utils/signal.py
+++ b/torch_brain/utils/signal.py
@@ -16,13 +16,12 @@ __api_ref__ = {
     "sections": [{"autosummary": __all__}],
 }
 
-from typing import List, Tuple
 
 import numpy as np
 import tqdm
 from scipy import signal
 
-from torch_brain.data import Data, IrregularTimeSeries, ArrayDict
+from torch_brain.data import ArrayDict, Data, IrregularTimeSeries
 
 
 def downsample_wideband(
@@ -63,7 +62,7 @@ def downsample_wideband(
 
 def extract_bands(
     lfps: np.ndarray, ts: np.ndarray, Fs: float = 1000, notch: float = 60
-) -> Tuple[np.ndarray, np.ndarray, List]:
+) -> tuple[np.ndarray, np.ndarray, list]:
     """Extract bands from LFP
 
     We prefer to extract bands from the LFP upstream rather than downstream, because
@@ -122,7 +121,7 @@ def extract_bands(
 
 def cube_to_long(
     ts: np.ndarray, cube: np.ndarray, channel_prefix="chan"
-) -> Tuple[List[IrregularTimeSeries], Data]:
+) -> tuple[list[IrregularTimeSeries], Data]:
     """Convert a cube of threshold crossings to a list of trials and units."""
     assert cube.shape[1] == len(ts)
     assert cube.ndim == 3

--- a/torch_brain/utils/split.py
+++ b/torch_brain/utils/split.py
@@ -10,10 +10,10 @@ __api_ref__ = {
 }
 
 import hashlib
-import numpy as np
-from typing import List
 
-from torch_brain.data import Interval, Data
+import numpy as np
+
+from torch_brain.data import Data, Interval
 
 
 def _create_interval_split(intervals: Interval, indices: np.ndarray) -> Interval:
@@ -31,7 +31,7 @@ def generate_stratified_folds(
     n_folds: int = 5,
     val_ratio: float = 0.2,
     seed: int = 42,
-) -> List[Data]:
+) -> list[Data]:
     """
     Generates stratified train/valid/test splits using a two-stage splitting process.
 
@@ -120,7 +120,7 @@ def generate_string_kfold_assignment(
     n_folds: int = 3,
     val_ratio: float = 0.2,
     seed: int = 42,
-) -> List[str]:
+) -> list[str]:
     """Generate deterministic per-fold train/valid/test assignments for one ID.
 
     The assignment is independent for each fold index ``k``, but follows a
@@ -175,7 +175,7 @@ def generate_string_kfold_assignment(
     hash_int = _get_integer_hash_from_string(base_str)
     bucket = hash_int % n_folds
 
-    assignments: List[str] = []
+    assignments: list[str] = []
     for k in range(n_folds):
         if bucket == k:
             assignments.append("test")

--- a/torch_brain/utils/split.py
+++ b/torch_brain/utils/split.py
@@ -61,11 +61,11 @@ def generate_stratified_folds(
     """
     try:
         from sklearn.model_selection import StratifiedKFold, StratifiedShuffleSplit
-    except ImportError:
+    except ImportError as err:
         raise ImportError(
             "This function requires the scikit-learn library which you can install with "
             "`pip install scikit-learn`"
-        )
+        ) from err
 
     if not hasattr(intervals, stratify_by):
         raise ValueError(

--- a/torch_brain/utils/stitcher.py
+++ b/torch_brain/utils/stitcher.py
@@ -21,8 +21,8 @@ def stitch(
     value per timestamp.
 
     Args:
-        timestamps (torch.Tensor): A 1D tensor containing timestamps. Shape: ``(N,)``.
-        values (torch.Tensor): A tensor of values corresponding to the timestamps.
+        timestamps: A 1D tensor containing timestamps. Shape: ``(N,)``.
+        values: A tensor of values corresponding to the timestamps.
             Shape ``(N, ...)`` for floating point types, or ``(N,)`` for categorical
             types (``torch.long`` only).
 

--- a/torch_brain/utils/tokenizers.py
+++ b/torch_brain/utils/tokenizers.py
@@ -1,5 +1,6 @@
-import numpy as np
 from enum import Enum
+
+import numpy as np
 
 
 class TokenType(Enum):

--- a/torch_brain/utils/weights.py
+++ b/torch_brain/utils/weights.py
@@ -1,4 +1,5 @@
 import numpy as np
+
 from torch_brain.data import Interval
 
 


### PR DESCRIPTION
## Summary
- Replaced all legacy `typing` imports (`Optional`, `Dict`, `List`, `Tuple`, `Union`) with modern Python 3.10+ syntax (`X | None`, `dict`, `list`, etc.) using `pyupgrade`
- Replaced `black` with `ruff` for formatting and linting — covers import sorting (`I`), unused imports (`F`), pyupgrade rules (`UP`), bugbear (`B`), and pycodestyle (`E`); updated pre-commit hook and CI accordingly
- Cleaned up docstrings: removed inline `(type)` annotations from `Args:` sections and `np.array([...])` wrappers from examples
- Fixed circular imports in `torch_brain/datasets/` by switching to relative imports (`.dataset`, `.mixins`) instead of going through the package `__init__.py`
- Fixed ~200 ruff violations across `torch_brain/`, `tests/`, `brainsets_pipelines/`, `docs/` (unused imports, missing `raise ... from err`, missing `stacklevel` on `warnings.warn`, unused loop variables)
