### PR TITLE
docs: improve torch_brain.data guide

### DIFF
--- a/docs/source/guides/data/data_objects_intro.rst
+++ b/docs/source/guides/data/data_objects_intro.rst
@@ -4,14 +4,14 @@ Meet the Data Objects
 =====================
 
 The :obj:`torch_brain.data` module defines several key data objects.
-Here we'll look at the different ways to create and interact with each type of object.
+This guide covers how to create and interact with each type of object.
 
 
 RegularTimeSeries
 -----------------
-:obj:`RegularTimeSeries` is the first time-oriented data object we will look
-at. As the name suggests, it is meant to store time-series that are regularly
-sampled. This could be anything from behavior measurements to EEG signals.
+:obj:`RegularTimeSeries` stores regularly sampled time-series, such as behavior
+measurements or EEG signals. It can store multiple signals that are sampled at
+the same timestamps.
 
 .. code-block:: pycon
 
@@ -39,15 +39,15 @@ sampled. This could be anything from behavior measurements to EEG signals.
 
    >>> # timestamps are automatically created from the sampling rate
    >>> behavior.timestamps
-   array([0.  , 0.01, 0.02, 0.03, 0.04, 0.05, 0.06, ...])
+   array([0.  , 0.01, 0.02, 0.03, 0.04, 0.05, ..., 9.99])
 
 
-Here, we have created a 10-second-long collection of behavioral measurements
-(hand velocity, eye position, and pupil size) inside the *same* data object.
-This allows us to get time-slices of the entire set of signals at once.
+This creates a 10-second collection of behavioral measurements (hand velocity,
+eye position, and pupil size) inside a single object.
 
-Let's grab a slice starting at 2 seconds and ending at 4 seconds.
-Since our signals are sampled at 100Hz, we should get 200 samples.
+This entire set of signals can be time-sliced at once. As an example, we slice
+it from :math:`t=2s` to :math:`t=4s` below. The signals are sampled at 100Hz,
+so the slice returns 200 samples.
 
 .. code-block:: pycon
 
@@ -65,19 +65,42 @@ Since our signals are sampled at 100Hz, we should get 200 samples.
    >>> sliced.pupil_size
    array([-0.07094018,  1.1442879 ,  1.26022563,  1.57259098, ..., ])
 
+:obj:`RegularTimeSeries` can also incorporate a starting time offset:
+
+.. code-block:: pycon
+
+   >>> behavior = RegularTimeSeries(
+   ...     sampling_rate=100.0,  # in Hz
+   ...     hand_vel=np.random.randn(1000, 2),
+   ...     eye_pos=np.random.randn(1000, 2),
+   ...     pupil_size=np.random.randn(1000),
+   ...     domain_start=10.0,  # <- the starting time offset
+   ... )
+
+   >>> # timestamps start from 10s
+   >>> behavior.timestamps
+   array([10.  , 10.01, 10.02, 10.03, 10.04, ..., 19.99]])
+
 
 .. admonition:: Other constructors
    :class: tip
 
    :obj:`RegularTimeSeries.from_gappy_timeseries()`: If your raw data has missing
-   timesteps. Also see :doc:`gappy_regular_ts`.
+   timestamps. Also see the :doc:`gappy_regular_ts` guide.
 
+
+**torch_brain** follows some common conventions throughout:
+
+* Time is always represented in seconds.
+* ``data.slice(a, b)`` is inclusive on the left side and exclusive on the right
+  side.
 
 IrregularTimeSeries
 -------------------
 An :obj:`IrregularTimeSeries` represents event-based or irregularly sampled
 time-series data, and is well suited for things like discrete events and
-spike-trains.
+spike-trains. It can also store multiple time-series that share the same
+timestamps.
 
 .. code-block:: pycon
 
@@ -90,8 +113,7 @@ spike-trains.
    ...     user_id=[1, 2, 1],
    ... )
 
-   >>> # Real spike-trains would be much longer ofcourse,
-   >>> # here we show a spike-train with only 3 spikes.
+   >>> # Real spike-trains are much longer; this one has only 3 spikes.
    >>> spikes = IrregularTimeSeries(
    ...     timestamps=[1.2, 2.3, 3.1],  # required
    ...     unit_id=[1, 2, 1],
@@ -99,9 +121,12 @@ spike-trains.
    ...     waveforms=np.random.randn(3, 32),
    ... )
 
-IrregularTimeSeries objects can also be time-sliced.
-In this example, slicing ``spikes`` from 2 to 4 seconds should give us the
-2 spikes that fall within that window.
+Inputs passed as Python lists are automatically converted to :obj:`numpy`
+arrays internally.
+
+:obj:`IrregularTimeSeries` objects also support time-slicing. We slice
+``spikes`` from :math:`t=2s` to :math:`t=4s`, which returns the 2 spikes within
+that window.
 
 .. code-block:: pycon
 
@@ -120,8 +145,8 @@ In this example, slicing ``spikes`` from 2 to 4 seconds should give us the
    >>> sliced.unit_id
    array([2, 1])
 
-Notice how slicing *shifted* the timestamps so that the slice starts at zero.
-You can opt out of this by passing ``reset_origin=False``:
+Slicing *shifts* the timestamps to the left by the start time of the slicing
+window. Pass ``reset_origin=False`` to keep the original timestamps:
 
 .. code-block:: pycon
 
@@ -140,8 +165,8 @@ You can opt out of this by passing ``reset_origin=False``:
 
 Interval
 --------
-:obj:`Interval` represents time-periods and any metadata attached to them. A
-common use of this is to represent the trial structure of an experiment:
+:obj:`Interval` represents time-periods and any metadata attached to them, such
+as the trial structure of an experiment:
 
 .. code-block:: pycon
 
@@ -161,15 +186,14 @@ common use of this is to represent the trial structure of an experiment:
      outcome=[3]
    )
 
-This says that during the interval :math:`[0, 1)` the stimulus was ``'left'``
-and the outcome was ``'correct'``; during :math:`[2, 3)` the stimulus was
-``'right'`` and the outcome was ``'error'``, and so on.
+Each *pair* of start and end timestamps defines the boundary of a time-period,
+and the remaining attributes hold metadata for that period. By convention,
+start times are inclusive and end times are non-inclusive. Here, during the
+interval :math:`[0s, 1s)` the stimulus is ``'left'`` and the outcome is
+``'correct'``; during :math:`[2s, 3s)` the stimulus is ``'right'`` and the
+outcome is ``'error'``, and so on.
 
-In other words, each *pair* of start and end timestamps describes the boundary
-of a period, and the remaining attributes act as metadata for what happened
-within that period.
-
-Trials can also be sliced:
+Intervals also support slicing:
 
 .. code-block:: pycon
 
@@ -183,6 +207,24 @@ Trials can also be sliced:
     array(['right'], dtype='<U5'),
     array(['error'], dtype='<U7'))
 
+When a slicing window partially overlaps a time-period, the slice includes the
+entire period, and the start time of the slice sets the shift. Below, we slice
+from :math:`t=2.5s` to :math:`t=4s`. The time-period :math:`[2s, 3s)` partially
+overlaps this window, so the slice includes it and shifts its timestamps to the
+left by :math:`2.5s`.
+
+.. code-block:: pycon
+
+   >>> sliced = trials.slice(2.5, 4.0)
+   >>> len(sliced)
+   1
+
+   >>> sliced.start, sliced.end, sliced.stimulus, sliced.outcome
+   (array([-0.5]),
+    array([0.5]),
+    array(['right'], dtype='<U5'),
+    array(['error'], dtype='<U7'))
+
 .. admonition:: Other constructors
    :class: tip
 
@@ -190,10 +232,9 @@ Trials can also be sliced:
 
 ArrayDict
 ---------
-Our final *core* data object is :obj:`ArrayDict`. It is a simple container
-for arbitrary arrays *that share the same first dimension*.
-This data structure is useful for storing things like metadata associated with
-different recording channels, or any other data in a tabular form.
+:obj:`ArrayDict` is the final *core* data object. It is a simple container for
+arbitrary arrays *that share the same first dimension*. Use it to store tabular
+data, such as metadata associated with different recording channels.
 
 .. code-block:: pycon
 
@@ -227,8 +268,7 @@ different recording channels, or any other data in a tabular form.
 
 Data
 ----
-:obj:`Data` objects act as containers for all four types of objects we
-discussed above:
+:obj:`Data` objects act as containers for all four object types above:
 
 .. code-block:: pycon
 
@@ -242,8 +282,8 @@ discussed above:
    ...     domain="auto",  # don't worry about this for now; "auto" is the right choice most of the time
    ... )
 
-Let's say this ``data`` object represents one entire neural recording.
-The nice thing about this container is that it can be sliced *as a whole*:
+This ``data`` object represents one entire neural recording. We can slice the
+container *as a whole*:
 
 .. code-block:: pycon
 
@@ -276,15 +316,15 @@ The nice thing about this container is that it can be sliced *as a whole*:
    >>> sliced.spikes.timestamps
    array([0.3, 1.1])  # same as the IrregularTimeSeries example above
 
-The sliced object also remembers the absolute time at which it was sliced:
+The sliced object remembers the absolute time at which it was sliced:
 
 .. code-block:: pycon
 
    >>> sliced.absolute_start
    2.0
 
-The sliced data object is itself just another :obj:`Data` object, which means
-you can slice it again:
+The sliced data object is itself another :obj:`Data` object, so you can slice it
+again:
 
 .. code-block:: pycon
 
@@ -317,18 +357,8 @@ you can slice it again:
      ),
    )
 
-You can also store a few other things in :obj:`Data`: numpy arrays and Python
-primitives (scalars, lists, tuples, strings, etc.).
-Additionally, :obj:`Data` objects can be *nested* — a :obj:`Data` object can
-itself contain another :obj:`Data` object — which lets you organize your data
-in a hierarchy.
+:obj:`Data` can also store numpy arrays and Python primitives (scalars, lists,
+tuples, strings, etc.). :obj:`Data` objects also *nest* — a :obj:`Data` object
+can contain another :obj:`Data` object — which can be used to organize data in
+a meaningful hierarchy.
 
-
-Conventions
------------
-
-Some conventions to note:
-
-* In ``torch_brain``, time is always represented in the units of seconds.
-* Slicing like ``data.slice(a, b)`` is inclusive on the left side, and
-  exclusive on the right side.

--- a/docs/source/guides/data/domain.rst
+++ b/docs/source/guides/data/domain.rst
@@ -132,7 +132,7 @@ while ``behavior`` spans only :math:`[1s, 9s)`, so the union is :math:`[0s, 10s)
 Why domains matter
 ------------------
 
-When you train a model in **torch_brian**, :ref:`Samplers <samplers_ref>` use
+When you train a model in **torch_brain**, :ref:`Samplers <samplers_ref>` use
 each recording's domain to decide *where* they can draw time-windows from.
 Sampling from time periods where the data is absent or corrupted should be
 avoided, so removing those periods from the domain is good practice. In

--- a/docs/source/guides/data/domain.rst
+++ b/docs/source/guides/data/domain.rst
@@ -3,9 +3,9 @@
 Domains
 =======
 
-A **domain** is simply the span of time over which a data object is considered
-*valid*. Let's make this concrete. Below we create a spike train with 1000
-spikes scattered randomly over a 10-second window, and inspect its domain:
+A **domain** is the span of time over which a data object is *valid*. Below, we
+create a spike train with 1000 spikes scattered randomly over a 10-second window
+and inspect its domain:
 
 .. code:: pycon
 
@@ -28,15 +28,14 @@ spikes scattered randomly over a 10-second window, and inspect its domain:
    >>> min(spikes.timestamps), max(spikes.timestamps)
    (np.float64(0.015414725327748124), np.float64(9.999305627648218))
 
-The domain is itself an :obj:`Interval`, and here it was filled in automatically:
-by default, an :obj:`IrregularTimeSeries` sets its domain to the span between its
+The domain is itself an :obj:`Interval`. Here it is filled in automatically: by
+default, an :obj:`IrregularTimeSeries` sets its domain to the span between its
 first and last timestamps.
 
-This default is just a convenience. Often you know more about the recording than
-the timestamps alone reveal. Suppose, for instance, that the probe was switched
-off between :math:`t=3` and :math:`t=4`, so no spikes *could* have been recorded
-there. You can express that by passing the domain yourself when constructing the
-object:
+Often you know more about a recording than its timestamps reveal. For example, if
+the probe was switched off between :math:`t=3s` and :math:`t=4s`, no spikes could
+have been recorded in that gap. To capture this, we pass the domain directly when
+constructing the object:
 
 .. code:: pycon
 
@@ -54,41 +53,40 @@ object:
    >>> spikes.domain.start, spikes.domain.end
    (array([0., 4.]), array([3., 10.]))
 
-Notice that the domain is now made up of *two* intervals. A domain can be any set
-of disjoint time periods, not just a single one.
+The domain is now made up of *two* intervals. A domain can be any set of disjoint
+time periods, not just a single one.
 
 
 Which objects have a domain?
 ----------------------------
 
-Not every data object carries a domain; it depends on whether the object is
+Not every data object has a domain; it depends on whether the object is
 inherently temporal.
 
-- :obj:`IrregularTimeSeries` **has a domain.** As we saw above, it defaults to the
-  span of its timestamps, but you can also set it explicitly.
+- :obj:`IrregularTimeSeries` **has a domain.** It defaults to the span of its
+  timestamps, but you can also set it explicitly.
 
-- :obj:`RegularTimeSeries` **has a domain.** Because its samples are evenly
-  spaced, the domain is computed for you from the ``sampling_rate``, the number
-  of samples, and the ``domain_start`` offset, so you never set it by hand.
-  Although, regular time series *can* handle missing timepoints too; see
-  :doc:`gappy_regular_ts`.
+- :obj:`RegularTimeSeries` **has a domain.** Its samples are evenly spaced, so
+  the domain is computed from the ``sampling_rate``, the number of samples, and
+  the ``domain_start`` offset; you never set it by hand. Regular time series can
+  also handle missing timepoints; see the :doc:`gappy_regular_ts` guide.
 
-- :obj:`Interval` **does not have a separate domain.** Its own ``start`` and ``end``
+- :obj:`Interval` **does not have a separate domain.** Its ``start`` and ``end``
   times already describe the periods it spans, so there is nothing extra to track.
 
-- :obj:`ArrayDict` **does not have a domain.** It holds non-temporal data, so the
-  notion of a time span simply doesn't apply.
+- :obj:`ArrayDict` **does not have a domain.** It holds non-temporal data, so a
+  time span does not apply.
 
-- :obj:`Data` **can have a domain**, if it contains temporal objects. We take a closer
-  look at this below.
+- :obj:`Data` **can have a domain**, if it contains temporal objects. We cover
+  this case below.
 
 
 Domains on ``Data`` objects
 ---------------------------
 
 A :obj:`Data` object groups several of the objects above into a single recording,
-so any :obj:`Data` that holds time-based data must be given a domain. You can set
-it explicitly:
+so any :obj:`Data` that holds time-based data must have a domain. We set it
+explicitly:
 
 .. code:: pycon
 
@@ -116,10 +114,9 @@ it explicitly:
    >>> data.domain.start, data.domain.end
    (array([0.]), array([10.]))
 
-You can also let :obj:`Data` work it out for you. Passing ``domain="auto"``
-tells the constructor to take the union of the domains of all the objects it
-contains. Here ``spikes`` spans the full :math:`[0, 10)` while ``behavior``
-spans only :math:`[1, 9)`, so the union is :math:`[0, 10)`:
+Passing ``domain="auto"`` tells the constructor to take the union of the domains
+of all the objects it contains. Here ``spikes`` spans the full :math:`[0s, 10s)`
+while ``behavior`` spans only :math:`[1s, 9s)`, so the union is :math:`[0s, 10s)`:
 
 .. code:: pycon
 
@@ -135,8 +132,9 @@ spans only :math:`[1, 9)`, so the union is :math:`[0, 10)`:
 Why domains matter
 ------------------
 
-When you train a model in TorchBrain, :ref:`Samplers <samplers_ref>` look at
-each recording's domain to decide *where* they are allowed to draw time-windows
-from. You may not want to draw samples from time periods where you know the
-data is absent or corrupted. And so, explicitly removing such time periods from
-the domain becomes good practice.
+When you train a model in **torch_brian**, :ref:`Samplers <samplers_ref>` use
+each recording's domain to decide *where* they can draw time-windows from.
+Sampling from time periods where the data is absent or corrupted should be
+avoided, so removing those periods from the domain is good practice. In
+addition, knowing where different recording variables are and aren't valid can
+be useful when exploring an existing dataset.

--- a/docs/source/guides/data/interval_ops/index.rst
+++ b/docs/source/guides/data/interval_ops/index.rst
@@ -5,7 +5,7 @@ Interval Operations
 
 :obj:`Interval` objects can be manipulated using standard set-arithmetic
 operations such as union, intersection, and difference, along with a few other
-useful operations like dilation and coalescing.
+useful operations like :obj:`~Interval.dilate` and :obj:`~Interval.coalesce`.
 
 
 Intersection

--- a/docs/source/guides/data/interval_ops/index.rst
+++ b/docs/source/guides/data/interval_ops/index.rst
@@ -7,7 +7,12 @@ Interval Operations
 operations such as union, intersection, and difference, along with a few other
 useful operations like dilation and coalescing.
 
-First, let's create some simple intervals:
+
+Intersection
+------------
+
+The intersection operation (``&``) creates a new :obj:`Interval`
+containing only the overlapping time periods between two objects.
 
 .. code-block:: pycon
 
@@ -18,15 +23,6 @@ First, let's create some simple intervals:
 
    >>> # second interval over [2, 5), [7, 10), and [14, 17)
    >>> interval2 = Interval(start=[2., 7., 14.], end=[5., 10., 17.])
-
-
-Intersection
-------------
-
-The intersection operation (``&``) creates a new :obj:`Interval`
-containing only the overlapping time periods between two objects.
-
-.. code-block:: pycon
 
    >>> intersection = interval1 & interval2
    >>> intersection.start, intersection.end
@@ -72,8 +68,8 @@ interval.
    Visualization of the difference operation
 
 
-Dilation
---------
+Dilate
+------
 
 The :obj:`~Interval.dilate` method expands each interval by a specified amount
 on both sides.
@@ -98,8 +94,8 @@ The dilation operation is particularly useful when you need to:
 - Account for uncertainty in interval boundaries
 - Merge intervals that are close together
 
-Coalescing
-----------
+Coalesce
+--------
 
 The :obj:`~Interval.coalesce` method merges overlapping or touching intervals
 into single continuous intervals. This is useful for simplifying interval sets
@@ -130,51 +126,11 @@ The coalesce operation is useful for:
 - Simplifying interval representations
 
 
-.. note::
-
-   There are multiple edge cases that can occur when performing interval
-   operations. For more details, see the :ref:`interval_ops_edge_cases`
-   section below.
-
-Introspection
--------------
-
-We also provide some introspection methods to check whether the periods in an
-:obj:`Interval` are *disjoint* (non-overlapping) and *sorted* (in increasing
-order of start time).
-
-Here, the two periods ``[0, 1.1)`` and ``[1, 2)`` overlap, so the interval is
-not disjoint, but its start times are still in increasing order:
-
-.. code-block:: pycon
-
-   >>> # Create two intervals [1., 1.1), and [1., 2.)
-   >>> interval = Interval(start=[0., 1.], end=[1.1, 2.0])
-   >>> interval.is_disjoint(), interval.is_sorted()
-   (False, True)
-
-By contrast, these periods don't overlap and are already ordered, so both
-checks return ``True``:
-
-.. code-block:: pycon
-
-   >>> # Create two intervals [0., 1.), and [3., 4.)
-   >>> interval = Interval(start=[0., 3.], end=[1., 4.])
-   >>> interval.is_disjoint(), interval.is_sorted()
-   (True, True)
-
-The set operations above (intersection, union, and difference) require their
-inputs to be disjoint and sorted, and will raise a ``ValueError`` otherwise, so
-these methods are handy for validating an :obj:`Interval` object.
-
-
-.. _interval_ops_edge_cases:
-
 Edge Cases
 ----------
 
-Interval operations also handle a number of edge cases gracefully. Here we walk
-through a few of them.
+Interval operations also handle a number of edge cases gracefully, and below
+are a few important cases to keep in mind.
 
 Adjacent Intervals
 ~~~~~~~~~~~~~~~~~~~

--- a/docs/source/guides/data/io.rst
+++ b/docs/source/guides/data/io.rst
@@ -156,7 +156,7 @@ into a normal (non-lazy) :obj:`RegularTimeSeries` object:
      ),
    )
 
-Lazy objects are also sliced lazily:
+Slicing preserves laziness for any attributes that are still lazy:
 
 .. code-block:: pycon
 

--- a/docs/source/guides/data/io.rst
+++ b/docs/source/guides/data/io.rst
@@ -174,9 +174,9 @@ Slicing preserves laziness for any attributes that are still lazy:
      ),
    )
 
-Here, ``behavior`` is sliced immediately (indicated by the change in the shape
-of the arrays), On the other hand, ``spikes`` remains lazy.
-
+Here, ``behavior`` is already in memory (non-lazy), so it is sliced immediately
+(indicated by the change in array shapes). On the other hand, ``spikes`` remains
+lazy.
 Upon accessing ``sliced.spikes.timestamps``, only the two timestamps that fall
 within the :math:`[2s, 4s)` window are read from disk and not the full
 timestamps array.

--- a/docs/source/guides/data/io.rst
+++ b/docs/source/guides/data/io.rst
@@ -180,6 +180,8 @@ lazy.
 Upon accessing ``sliced.spikes.timestamps``, only the two timestamps that fall
 within the :math:`[2s, 4s)` window are read from disk and not the full
 timestamps array.
+The returned timestamps are shifted by the slice start time, so the values shown
+ below are relative to :math:`t=2s`.
 
 .. code-block:: pycon
 

--- a/docs/source/guides/data/io.rst
+++ b/docs/source/guides/data/io.rst
@@ -129,10 +129,10 @@ Let's access ``eye_pos``:
      ),
    )
 
-Since ``eye_pos`` has been loaded into memory, it is no longer an ``<HDF5
-dataset...>``, while the remaining attributes remain lazy. Accessing the
-remainig attributes of ``behavior`` will load its data into memory and turn it
-into a normal (non-lazy) :obj:`RegularTimeSeries` object:
+Since ``eye_pos`` has been loaded into memory, it is no longer an ``<HDF5 dataset...>``,
+while the remaining attributes remain lazy. Accessing the remaining attributes of
+``behavior`` loads its data into memory and turns it into a normal (non-lazy)
+:obj:`RegularTimeSeries` object:
 
 .. code-block:: pycon
 

--- a/docs/source/guides/data/io.rst
+++ b/docs/source/guides/data/io.rst
@@ -5,14 +5,14 @@ Saving and Loading Data
 
 :obj:`Data` objects can be saved to and loaded from `HDF5 <https://en.wikipedia.org/wiki/Hierarchical_Data_Format>`_
 files. HDF5 is a specialized data format that allows streaming chunks of data
-from disk without loading all of it into memory (RAM), giving us an efficient
+from disk without loading all of it into memory (RAM), providing an efficient
 way to work with large datasets.
 
 
 Saving
 ------
 
-To save a data object to disk, use the :obj:`~Data.save()` method:
+The :obj:`~Data.save()` method saves a :obj:`Data` object to disk.
 
 .. code-block:: pycon
 
@@ -41,8 +41,8 @@ To save a data object to disk, use the :obj:`~Data.save()` method:
 Loading
 -------
 
-To load data back from disk, use :obj:`Data.load()`.
-Let's first load it "non-lazily" by passing ``lazy=False``:
+:obj:`Data.load()` loads data from disk. We first load it "non-lazily" by
+passing ``lazy=False``:
 
 .. code-block:: pycon
 
@@ -70,28 +70,17 @@ Let's first load it "non-lazily" by passing ``lazy=False``:
       ),
     )
 
-By setting ``lazy=False``, we load the entire dataset into memory upfront.
+Setting ``lazy=False`` loads the entire data file into memory upfront.
 This quickly becomes infeasible for datasets of any real size (a few hundred GBs
-to a few TBs). To address this, we provide a *Lazy Loading* mode.
+to a few TBs). To address this, **torch_brain** features a *Lazy Loading* mode.
 
 
 Lazy Loading
 ------------
 
-Under lazy-loading:
-
-- Data is read from disk only when an attribute is accessed.
-
-- Slicing is also deferred: only the attributes you access get sliced, and
-  only at the moment you access them. Importantly, only the sliced portion is
-  read from disk, not the whole array. So slicing a small window out of a
-  huge recording is cheap, both in terms of disk I/O and memory usage.
-
-- The same goes for masking (via methods such as :obj:`ArrayDict.select_by_mask()`):
-  the masking is deferred until the attribute is actually requested.
-
-
-To load data in lazy mode, simply omit the ``lazy=False`` flag we used above:
+Lazy loading provides data access efficiencies in terms of, both, disk I/O and
+memory usage. To load data in lazy mode, simply omit the ``lazy=False`` flag
+used above (or explicitly provide ``lazy=True``):
 
 .. code-block:: pycon
 
@@ -110,10 +99,15 @@ To load data in lazy mode, simply omit the ``lazy=False`` flag we used above:
      ),
    )
 
-First note that the internal objects are :obj:`LazyRegularTimeSeries` and
-:obj:`LazyIrregularTimeSeries`. Secondly, the presence of ``<HDF5 dataset...>``
-indicates that the arrays are yet to be loaded. Let's see what happens when we
-access ``eye_pos``:
+Note that:
+
+1. The internal objects are :obj:`LazyRegularTimeSeries` and
+   :obj:`LazyIrregularTimeSeries`.
+
+2. The arrays are printed as ``<HDF5 dataset...>``, which indicates that the
+   arrays are yet to be loaded.
+
+Let's access ``eye_pos``:
 
 .. code-block:: pycon
 
@@ -135,9 +129,10 @@ access ``eye_pos``:
      ),
    )
 
-We can see that ``eye_pos`` has been loaded, and the remaining attributes
-are still lazy. If we access both ``hand_vel`` and ``pupil_size``, ``behavior``
-will then turn into a :obj:`RegularTimeSeries` object:
+Since ``eye_pos`` has been loaded into memory, it is no longer an ``<HDF5
+dataset...>``, while the remaining attributes remain lazy. Accessing the
+remainig attributes of ``behavior`` will load its data into memory and turn it
+into a normal (non-lazy) :obj:`RegularTimeSeries` object:
 
 .. code-block:: pycon
 
@@ -161,7 +156,7 @@ will then turn into a :obj:`RegularTimeSeries` object:
      ),
    )
 
-We can also slice a lazy object:
+Lazy objects are also sliced lazily:
 
 .. code-block:: pycon
 
@@ -173,17 +168,47 @@ We can also slice a lazy object:
        hand_vel=[200, 2],
        pupil_size=[200]
      ),
-     spikes=LazyIrregularTimeSeries(  # Note that this remains lazy!!
+     spikes=LazyIrregularTimeSeries(  # Note that this remains lazy!
        timestamps=<HDF5 dataset "timestamps": shape (3,), type "<f8">,
        unit_id=<HDF5 dataset "unit_id": shape (3,), type "<i8">
+     ),
+   )
+
+Here, ``behavior`` is sliced immediately (indicated by the change in the shape
+of the arrays), On the other hand, ``spikes`` remains lazy.
+
+Upon accessing ``sliced.spikes.timestamps``, only the two timestamps that fall
+within the :math:`[2s, 4s)` window are read from disk and not the full
+timestamps array.
+
+.. code-block:: pycon
+
+   >>> sliced
+   Data(
+     behavior=RegularTimeSeries(
+       eye_pos=[200, 2],
+       hand_vel=[200, 2],
+       pupil_size=[200]
+     ),
+     spikes=LazyIrregularTimeSeries(
+       timestamps=[2],
+       unit_id=<HDF5 dataset "unit_id": shape (3,), type "<i8">  # still lazy
      ),
    )
 
    >>> sliced.spikes.timestamps
    array([0.3, 1.1])
 
-Here, ``spikes`` stayed lazy after slicing. When we finally access
-``sliced.spikes.timestamps``, only the two timestamps that fall within the
-:math:`[2, 4)` window are read from disk and not the full timestamps array.
-This is what makes lazy loading efficient: you only pay for the slice you ask for.
+
+In summary, under lazy-loading:
+
+- Data is read from disk only when an attribute is accessed.
+
+- Slicing is deferred: only the attributes you access get sliced, and only when
+  you access them. Importantly, only the sliced portion is read from disk, not
+  the whole array.
+
+- Masking (via methods such as :obj:`ArrayDict.select_by_mask()`) is also
+  deferred until an attribute is accessed.
+
 


### PR DESCRIPTION
Addressing the remaining concerns in #253.

Reword the `torch_brain.data` user guide from having a conversational tone to an assertive tone. This is following [milo's suggestion](https://github.com/neuro-galaxy/torch_brain/pull/254#pullrequestreview-4428485059), which stems from how PyTorch writes its guides.

See the docs [here](https://torch-brain--281.org.readthedocs.build/en/281/)