### PR TITLE
docs: cleanup `torch_brain.data` API doc page

### DIFF
--- a/torch_brain/data/__init__.py
+++ b/torch_brain/data/__init__.py
@@ -1,4 +1,5 @@
-"""
+"""Core data structures for representing neural and behavioral recordings.
+
 **User guide.** See :ref:`data_guide` section for further details.
 """
 
@@ -39,7 +40,40 @@ __api_ref__ = {
     "description": None,
     "sections": [
         {
-            "autosummary": __all__,
+            "title": "Core Objects",
+            "autosummary": [
+                "ArrayDict",
+                "Data",
+                "Interval",
+                "IrregularTimeSeries",
+                "RegularTimeSeries",
+            ],
+        },
+        {
+            "title": "Lazy Counterparts",
+            "autosummary": [
+                "LazyArrayDict",
+                "LazyInterval",
+                "LazyIrregularTimeSeries",
+                "LazyRegularTimeSeries",
+            ],
+        },
+        {
+            "title": "Description Containers",
+            "autosummary": [
+                "BrainsetDescription",
+                "DeviceDescription",
+                "SessionDescription",
+                "SubjectDescription",
+            ],
+        },
+        {
+            "title": "Utility Functions",
+            "autosummary": ["concat"],
+        },
+        {
+            "title": "Constants",
+            "autosummary": ["serialize_fn_map"],
         },
     ],
 }


### PR DESCRIPTION
Improves [this](https://torch-brain--287.org.readthedocs.build/en/287/generated/api/torch_brain.data.html) page of docs.

Closes #238.