### PR TITLE
Limiting Benchmark Runs

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -3,6 +3,11 @@ name: Benchmarks
 on:
   pull_request:
     types: [opened, reopened, synchronize]
+    paths:
+      - torch_brain/data/**
+      - pyproject.toml
+      - scripts/data_benchmarks/**
+      - .github/workflows/benchmarks.yml
 
 permissions:
   contents: read


### PR DESCRIPTION
Added paths to the benchmarks workflow to ensure it triggers on changes to relevant files in the data and scripts directories, as well as the workflow file itself. Closes #285 

I've created a non-benchmarkable PR #289 and a benchmarkable PR #290 to make sure it behaves properly and it all looks good. 