### PR TITLE
feat: Add `delete_nested_attribute` in torch_brain.data`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 ### Added
+- Added `Data.delete_nested_attribute` to delete a nested attribute by dot-separated path ([#299](https://github.com/neuro-galaxy/torch_brain/pull/299))
 - Added `MultiChannelDatasetMixin` to provide `get_channel_ids` and prefixing interface for EEG-like datasets ([#173](https://github.com/neuro-galaxy/torch_brain/pull/173))
 - Added `BinSpikes` transform ([#170](https://github.com/neuro-galaxy/torch_brain/pull/170))
 - Added public weights for `CalciumPOYOPlus` ([#198](https://github.com/neuro-galaxy/torch_brain/pull/198))
@@ -28,6 +29,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Removed `utils.get_sinusoidal_encoding` (legacy) ([#200](https://github.com/neuro-galaxy/torch_brain/pull/200))
 
 ### Changed
+- `delattr` on `Data`, `ArrayDict`, `IrregularTimeSeries`, and `Interval` now raises `AttributeError` for `IrregularTimeSeries.timestamps` and `Interval.start`/`end`; deleting other registered timekeys auto-deregisters them
 - Moved collate utilities from `torch_brain.data.collate` to `torch_brain.batching`; the old module now raises a descriptive `ImportError` directing users to the new location ([#232](https://github.com/neuro-galaxy/torch_brain/pull/232))
 - Changed minimum `temporaldata` version to `v0.1.4` ([#209](https://github.com/neuro-galaxy/torch_brain/pull/209))
 - Moved `DecodingStitchEvaluator` and `MultiTaskDecodingStitchEvaluator` to `utils/callbacks.py` ([#183](https://github.com/neuro-galaxy/torch_brain/pull/183))

--- a/tests/data/test_data.py
+++ b/tests/data/test_data.py
@@ -36,8 +36,8 @@ def test_data():
         session_id="session_0",
         domain=Interval.from_list([(0, 3)]),
         spikes=IrregularTimeSeries(
-            timestamps=np.array([0.1, 0.2, 0.3, 2.1, 2.2, 2.3]),
-            unit_index=np.array([0, 0, 1, 0, 1, 2]),
+            timestamps=[0.1, 0.2, 0.3, 2.1, 2.2, 2.3],
+            unit_index=[0, 0, 1, 0, 1, 2],
             waveforms=np.zeros((6, 48)),
             domain="auto",
         ),
@@ -46,14 +46,14 @@ def test_data():
             sampling_rate=250.0,
         ),
         units=ArrayDict(
-            id=np.array(["unit_0", "unit_1", "unit_2"]),
-            brain_region=np.array(["M1", "M1", "PMd"]),
+            id=["unit_0", "unit_1", "unit_2"],
+            brain_region=["M1", "M1", "PMd"],
         ),
         trials=Interval(
-            start=np.array([0, 1, 2]),
-            end=np.array([1, 2, 3]),
-            go_cue_time=np.array([0.5, 1.5, 2.5]),
-            drifting_gratings_dir=np.array([0, 45, 90]),
+            start=[0, 1, 2],
+            end=[1, 2, 3],
+            go_cue_time=[0.5, 1.5, 2.5],
+            drifting_gratings_dir=[0, 45, 90],
         ),
         drifting_gratings_imgs=np.zeros((8, 3, 32, 32)),
     )
@@ -89,10 +89,10 @@ def test_data_copy():
     data = Data(
         session_id="session_0",
         domain=Interval.from_list([(0, 3)]),
-        some_numpy_array=np.array([1, 2, 3]),
+        some_numpy_array=[1, 2, 3],
         spikes=IrregularTimeSeries(
-            timestamps=np.array([0.1, 0.2, 0.3, 2.1, 2.2, 2.3]),
-            unit_index=np.array([0, 0, 1, 0, 1, 2]),
+            timestamps=[0.1, 0.2, 0.3, 2.1, 2.2, 2.3],
+            unit_index=[0, 0, 1, 0, 1, 2],
             waveforms=np.zeros((6, 48)),
             domain="auto",
         ),
@@ -101,14 +101,14 @@ def test_data_copy():
             sampling_rate=250.0,
         ),
         units=ArrayDict(
-            id=np.array(["unit_0", "unit_1", "unit_2"]),
-            brain_region=np.array(["M1", "M1", "PMd"]),
+            id=["unit_0", "unit_1", "unit_2"],
+            brain_region=["M1", "M1", "PMd"],
         ),
         trials=Interval(
-            start=np.array([0, 1, 2]),
-            end=np.array([1, 2, 3]),
-            go_cue_time=np.array([0.5, 1.5, 2.5]),
-            drifting_gratings_dir=np.array([0, 45, 90]),
+            start=[0, 1, 2],
+            end=[1, 2, 3],
+            go_cue_time=[0.5, 1.5, 2.5],
+            drifting_gratings_dir=[0, 45, 90],
         ),
         drifting_gratings_imgs=np.zeros((8, 3, 32, 32)),
     )
@@ -142,10 +142,10 @@ def test_lazy_data_copy(test_filepath):
     data = Data(
         session_id="session_0",
         domain=Interval.from_list([(0, 3)]),
-        some_numpy_array=np.array([1, 2, 3]),
+        some_numpy_array=[1, 2, 3],
         spikes=IrregularTimeSeries(
-            timestamps=np.array([0.1, 0.2, 0.3, 2.1, 2.2, 2.3]),
-            unit_index=np.array([0, 0, 1, 0, 1, 2]),
+            timestamps=[0.1, 0.2, 0.3, 2.1, 2.2, 2.3],
+            unit_index=[0, 0, 1, 0, 1, 2],
             waveforms=np.zeros((6, 48)),
             domain="auto",
         ),
@@ -154,14 +154,14 @@ def test_lazy_data_copy(test_filepath):
             sampling_rate=250.0,
         ),
         units=ArrayDict(
-            id=np.array(["unit_0", "unit_1", "unit_2"]),
-            brain_region=np.array(["M1", "M1", "PMd"]),
+            id=["unit_0", "unit_1", "unit_2"],
+            brain_region=["M1", "M1", "PMd"],
         ),
         trials=Interval(
-            start=np.array([0, 1, 2]),
-            end=np.array([1, 2, 3]),
-            go_cue_time=np.array([0.5, 1.5, 2.5]),
-            drifting_gratings_dir=np.array([0, 45, 90]),
+            start=[0, 1, 2],
+            end=[1, 2, 3],
+            go_cue_time=[0.5, 1.5, 2.5],
+            drifting_gratings_dir=[0, 45, 90],
         ),
         drifting_gratings_imgs=np.zeros((8, 3, 32, 32)),
     )
@@ -210,10 +210,10 @@ def test_data_absolute_start(test_filepath):
     data = Data(
         session_id="session_0",
         domain=Interval.from_list([(0, 3)]),
-        some_numpy_array=np.array([1, 2, 3]),
+        some_numpy_array=[1, 2, 3],
         spikes=IrregularTimeSeries(
-            timestamps=np.array([0.1, 0.2, 0.3, 2.1, 2.2, 2.3]),
-            unit_index=np.array([0, 0, 1, 0, 1, 2]),
+            timestamps=[0.1, 0.2, 0.3, 2.1, 2.2, 2.3],
+            unit_index=[0, 0, 1, 0, 1, 2],
             waveforms=np.zeros((6, 48)),
             domain="auto",
         ),
@@ -222,14 +222,14 @@ def test_data_absolute_start(test_filepath):
             sampling_rate=250.0,
         ),
         units=ArrayDict(
-            id=np.array(["unit_0", "unit_1", "unit_2"]),
-            brain_region=np.array(["M1", "M1", "PMd"]),
+            id=["unit_0", "unit_1", "unit_2"],
+            brain_region=["M1", "M1", "PMd"],
         ),
         trials=Interval(
-            start=np.array([0, 1, 2]),
-            end=np.array([1, 2, 3]),
-            go_cue_time=np.array([0.5, 1.5, 2.5]),
-            drifting_gratings_dir=np.array([0, 45, 90]),
+            start=[0, 1, 2],
+            end=[1, 2, 3],
+            go_cue_time=[0.5, 1.5, 2.5],
+            drifting_gratings_dir=[0, 45, 90],
         ),
         drifting_gratings_imgs=np.zeros((8, 3, 32, 32)),
     )
@@ -279,8 +279,8 @@ def test_timeless_data(test_filepath):
     data = Data(
         subject=subject,
         spikes=IrregularTimeSeries(
-            timestamps=np.array([0.1, 0.2, 0.3, 2.1, 2.2, 2.3]),
-            unit_index=np.array([0, 0, 1, 0, 1, 2]),
+            timestamps=[0.1, 0.2, 0.3, 2.1, 2.2, 2.3],
+            unit_index=[0, 0, 1, 0, 1, 2],
             waveforms=np.zeros((6, 48)),
             domain="auto",
         ),
@@ -309,7 +309,7 @@ def test_precision(caplog):
     with caplog.at_level(logging.WARNING):
         spikes = IrregularTimeSeries(
             timestamps=np.array([0.1, 0.2, 0.3, 2.1, 2.2, 2.3], dtype=np.float64),
-            unit_index=np.array([0, 0, 1, 0, 1, 2]),
+            unit_index=[0, 0, 1, 0, 1, 2],
             waveforms=np.zeros((6, 48)),
             domain="auto",
         )
@@ -318,7 +318,7 @@ def test_precision(caplog):
     with caplog.at_level(logging.WARNING):
         spikes = IrregularTimeSeries(
             timestamps=np.array([0.1, 0.2, 0.3, 2.1, 2.2, 2.3], dtype=np.float16),
-            unit_index=np.array([0, 0, 1, 0, 1, 2]),
+            unit_index=[0, 0, 1, 0, 1, 2],
             waveforms=np.zeros((6, 48)),
             domain="auto",
         )
@@ -329,10 +329,10 @@ def test_precision(caplog):
 
     with caplog.at_level(logging.WARNING):
         trials = Interval(
-            start=np.array([0, 1, 2]),
-            end=np.array([1, 2, 3]),
-            go_cue_time=np.array([0.5, 1.5, 2.5]),
-            drifting_gratings_dir=np.array([0, 45, 90]),
+            start=[0, 1, 2],
+            end=[1, 2, 3],
+            go_cue_time=[0.5, 1.5, 2.5],
+            drifting_gratings_dir=[0, 45, 90],
         )
         assert (
             f"start is of type {trials.start.dtype} not of type float64." in caplog.text
@@ -350,13 +350,13 @@ def test_nested_attributes():
         session_id="session_0",
         domain=Interval.from_list([(0, 3)]),
         spikes=IrregularTimeSeries(
-            timestamps=np.array([0.1, 0.2, 0.3, 2.1, 2.2, 2.3]),
+            timestamps=[0.1, 0.2, 0.3, 2.1, 2.2, 2.3],
             waveforms=np.zeros((6, 48)),
             domain="auto",
         ),
         units=ArrayDict(
-            id=np.array(["unit_0", "unit_1", "unit_2"]),
-            brain_region=np.array(["M1", "M1", "PMd"]),
+            id=["unit_0", "unit_1", "unit_2"],
+            brain_region=["M1", "M1", "PMd"],
         ),
     )
 
@@ -390,13 +390,13 @@ class TestSetNestedAttribute:
             session=Data(id="session_0"),
             domain=Interval.from_list([(0, 3)]),
             spikes=IrregularTimeSeries(
-                timestamps=np.array([0.1, 0.2, 0.3, 2.1, 2.2, 2.3]),
+                timestamps=[0.1, 0.2, 0.3, 2.1, 2.2, 2.3],
                 waveforms=np.zeros((6, 48)),
                 domain="auto",
             ),
             units=ArrayDict(
-                id=np.array(["unit_0", "unit_1", "unit_2"]),
-                brain_region=np.array(["M1", "M1", "PMd"]),
+                id=["unit_0", "unit_1", "unit_2"],
+                brain_region=["M1", "M1", "PMd"],
             ),
         )
 
@@ -448,15 +448,15 @@ def test_data_has_nested_attribute_lazy(test_filepath):
     """Tests the Data.has_nested_attribute method with lazily loaded objects."""
     data_to_save = Data(
         session_id="session_lazy_hsna_test",
-        some_numpy_array=np.array([10, 20, 30]),
+        some_numpy_array=[10, 20, 30],
         spikes=IrregularTimeSeries(
-            timestamps=np.array([0.1, 0.2, 0.3, 2.1, 2.2, 2.3]),
-            unit_index=np.array([0, 0, 1, 0, 1, 2]),
+            timestamps=[0.1, 0.2, 0.3, 2.1, 2.2, 2.3],
+            unit_index=[0, 0, 1, 0, 1, 2],
             domain="auto",
         ),
         units=ArrayDict(
-            id=np.array(["u0_hsna", "u1_hsna"]),
-            type=np.array(["typeA_hsna", "typeB_hsna"]),
+            id=["u0_hsna", "u1_hsna"],
+            type=["typeA_hsna", "typeB_hsna"],
         ),
         nested_data=Data(
             level2_attr="hello_nested_hsna",
@@ -537,12 +537,137 @@ def test_data_has_nested_attribute_lazy(test_filepath):
             lazy_data.has_nested_attribute("nested_data.level2_primitive.foo")
 
 
+class TestDeleteNestedAttribute:
+    @pytest.fixture
+    def data(self):
+        return Data(
+            session_id="session_0",
+            domain=Interval(0.0, 3.0),
+            spikes=IrregularTimeSeries(
+                timestamps=[0.1, 0.2, 0.3, 2.1, 2.2, 2.3],
+                unit_index=[0, 0, 1, 0, 1, 2],
+                waveforms=np.zeros((6, 48)),
+                # offset_time is a secondary time attribute registered as a timekey
+                offset_time=[0.05, 0.05, 0.05, 0.05, 0.05, 0.05],
+                timekeys=["offset_time"],
+                domain="auto",
+            ),
+            trials=Interval(
+                start=[0.0, 1.0, 2.0],
+                end=[1.0, 2.0, 3.0],
+                go_cue_time=[0.5, 1.5, 2.5],
+                condition=[0, 1, 2],
+                timekeys=["go_cue_time"],
+            ),
+            units=ArrayDict(
+                id=["unit_0", "unit_1", "unit_2"],
+                brain_region=["M1", "M1", "PMd"],
+            ),
+        )
+
+    # --- basic deletion ---
+
+    def test_delete_top_level(self, data):
+        data.delete_nested_attribute("session_id")
+        with pytest.raises(AttributeError):
+            data.session_id  # noqa: B018
+
+    def test_delete_nested_column_irregular_ts(self, data):
+        data.delete_nested_attribute("spikes.waveforms")
+        assert "waveforms" not in data.spikes.keys()
+        with pytest.raises(AttributeError):
+            data.spikes.waveforms  # noqa: B018
+        assert "timestamps" in data.spikes.keys()
+        assert "unit_index" in data.spikes.keys()
+
+    def test_delete_nested_column_arraydict(self, data):
+        data.delete_nested_attribute("units.brain_region")
+        assert "brain_region" not in data.units.keys()
+        with pytest.raises(AttributeError):
+            data.units.brain_region  # noqa: B018
+        assert "id" in data.units.keys()
+
+    def test_delete_non_timekey_interval_column(self, data):
+        data.delete_nested_attribute("trials.condition")
+        assert "condition" not in data.trials.keys()
+        with pytest.raises(AttributeError):
+            data.trials.condition  # noqa: B018
+        assert "start" in data.trials.keys()
+        assert "end" in data.trials.keys()
+
+    # --- timekey deregistration ---
+
+    def test_delete_timekey_irregular_ts_deregisters(self, data):
+        assert "offset_time" in data.spikes.timekeys()
+        data.delete_nested_attribute("spikes.offset_time")
+        assert "offset_time" not in data.spikes.keys()
+        assert "offset_time" not in data.spikes.timekeys()
+
+    def test_delete_timekey_irregular_ts_slice_still_works(self, data):
+        data.delete_nested_attribute("spikes.offset_time")
+        sliced = data.slice(1.0, 3.0)
+        assert len(sliced.spikes) == 3
+
+    def test_delete_timekey_interval_deregisters(self, data):
+        assert "go_cue_time" in data.trials.timekeys()
+        data.delete_nested_attribute("trials.go_cue_time")
+        assert "go_cue_time" not in data.trials.keys()
+        assert "go_cue_time" not in data.trials.timekeys()
+
+    def test_delete_timekey_interval_slice_still_works(self, data):
+        data.delete_nested_attribute("trials.go_cue_time")
+        sliced = data.slice(0.0, 2.0)
+        assert len(sliced.trials) == 2
+
+    # --- protected attributes raise ---
+
+    def test_raises_on_irregular_ts_timestamps(self, data):
+        with pytest.raises(AttributeError, match="timestamps"):
+            data.delete_nested_attribute("spikes.timestamps")
+
+    def test_raises_on_interval_start(self, data):
+        with pytest.raises(AttributeError, match="start"):
+            data.delete_nested_attribute("trials.start")
+
+    def test_raises_on_interval_end(self, data):
+        with pytest.raises(AttributeError, match="end"):
+            data.delete_nested_attribute("trials.end")
+
+    # --- nonexistent paths raise ---
+
+    def test_raises_on_nonexistent_intermediate(self, data):
+        with pytest.raises(AttributeError):
+            data.delete_nested_attribute("nonexistent.attr")
+
+    def test_raises_on_nonexistent_leaf(self, data):
+        with pytest.raises(AttributeError):
+            data.delete_nested_attribute("spikes.nonexistent")
+
+    # --- __delattr__ guard applies outside delete_nested_attribute too ---
+
+    def test_direct_delattr_timestamps_raises(self, data):
+        with pytest.raises(AttributeError):
+            delattr(data.spikes, "timestamps")
+
+    def test_direct_delattr_interval_start_raises(self, data):
+        with pytest.raises(AttributeError):
+            delattr(data.trials, "start")
+
+    def test_direct_delattr_interval_end_raises(self, data):
+        with pytest.raises(AttributeError):
+            delattr(data.trials, "end")
+
+    def test_direct_delattr_private_interval_raises(self, data):
+        with pytest.raises(AttributeError):
+            delattr(data.trials, "_timekeys")
+
+
 def test_data_auto_domain():
     data = Data(
         session_id="session_0",
         spikes=IrregularTimeSeries(
-            timestamps=np.array([0.1, 0.2, 0.3, 2.1, 2.2, 2.3]),
-            unit_index=np.array([0, 0, 1, 0, 1, 2]),
+            timestamps=[0.1, 0.2, 0.3, 2.1, 2.2, 2.3],
+            unit_index=[0, 0, 1, 0, 1, 2],
             waveforms=np.zeros((6, 48)),
             domain="auto",
         ),
@@ -551,14 +676,14 @@ def test_data_auto_domain():
             sampling_rate=250.0,
         ),
         units=ArrayDict(
-            id=np.array(["unit_0", "unit_1", "unit_2"]),
-            brain_region=np.array(["M1", "M1", "PMd"]),
+            id=["unit_0", "unit_1", "unit_2"],
+            brain_region=["M1", "M1", "PMd"],
         ),
         trials=Interval(
-            start=np.array([0, 1, 5]),
-            end=np.array([1, 2, 6]),
-            go_cue_time=np.array([0.5, 1.5, 2.5]),
-            drifting_gratings_dir=np.array([0, 45, 90]),
+            start=[0, 1, 5],
+            end=[1, 2, 6],
+            go_cue_time=[0.5, 1.5, 2.5],
+            drifting_gratings_dir=[0, 45, 90],
         ),
         drifting_gratings_imgs=np.zeros((8, 3, 32, 32)),
         domain="auto",
@@ -571,15 +696,15 @@ def test_data_auto_domain():
 def test_data_save(tmp_path):
     data_to_save = Data(
         session_id="session_lazy_hsna_test",
-        some_numpy_array=np.array([10, 20, 30]),
+        some_numpy_array=[10, 20, 30],
         spikes=IrregularTimeSeries(
-            timestamps=np.array([0.1, 0.2, 0.3, 2.1, 2.2, 2.3]),
-            unit_index=np.array([0, 0, 1, 0, 1, 2]),
+            timestamps=[0.1, 0.2, 0.3, 2.1, 2.2, 2.3],
+            unit_index=[0, 0, 1, 0, 1, 2],
             domain="auto",
         ),
         units=ArrayDict(
-            id=np.array(["u0_hsna", "u1_hsna"]),
-            type=np.array(["typeA_hsna", "typeB_hsna"]),
+            id=["u0_hsna", "u1_hsna"],
+            type=["typeA_hsna", "typeB_hsna"],
         ),
         domain=Interval(0.0, 3.0),
     )

--- a/torch_brain/data/data.py
+++ b/torch_brain/data/data.py
@@ -313,9 +313,9 @@ class Data:
         Args:
             file: HDF5 file.
 
-        Examples:
-            >>> import h5py  # doctest: +SKIP
-            >>> from torch_brain.data import Data  # doctest: +SKIP
+        Examples::
+            >>> import h5py
+            >>> from torch_brain.data import Data
             >>> data = Data(...)  # doctest: +SKIP
             >>> with h5py.File("data.h5", "w") as f:  # doctest: +SKIP
             ...     data.to_hdf5(f)
@@ -355,7 +355,7 @@ class Data:
         Args:
             file: HDF5 file.
 
-        Examples:
+        Examples::
             >>> import h5py  # doctest: +SKIP
             >>> from torch_brain.data import Data  # doctest: +SKIP
             >>> with h5py.File("data.h5", "r") as f:  # doctest: +SKIP
@@ -424,7 +424,7 @@ class Data:
         Returns:
             Data: The loaded :class:`Data` object from the HDF5 file.
 
-        Examples:
+        Examples::
             >>> from torch_brain.data import Data
             >>> # lazy with context manager (recommended)
             >>> with Data.load("data.h5") as data:  # doctest: +SKIP
@@ -473,7 +473,7 @@ class Data:
         Args:
             path: Destination file path
 
-        Examples:
+        Examples::
             >>> from torch_brain.data import Data  # doctest: +SKIP
             >>> data = Data(...)  # doctest: +SKIP
             >>> data.save("data.h5")  # doctest: +SKIP
@@ -572,7 +572,7 @@ class Data:
         Raises:
             AttributeError: If any component of the path cannot be resolved.
 
-        Examples:
+        Examples::
             >>> import numpy as np
             >>> from torch_brain.data import Data, IrregularTimeSeries, Interval
             >>> data = Data(
@@ -626,7 +626,7 @@ class Data:
     def has_nested_attribute(self, path: str) -> bool:
         """Return :obj:`True` if the dot-separated path resolves to an existing attribute.
 
-        Examples:
+        Examples::
             >>> if data.has_nested_attribute("spikes.waveforms"):  # doctest: +SKIP
             ...     process(data.spikes.waveforms)
 
@@ -665,7 +665,7 @@ class Data:
         r"""Delete a nested attribute specified by its dot-separated path, modifying
         the object in-place.
 
-        Examples:
+        Examples::
             >>> for path in ["spikes.waveforms", "lfp.raw"]:  # doctest: +SKIP
             ...     if data.has_nested_attribute(path):
             ...         data.delete_nested_attribute(path)

--- a/torch_brain/data/data.py
+++ b/torch_brain/data/data.py
@@ -429,12 +429,12 @@ class Data:
             >>> # lazy with context manager (recommended)
             >>> with Data.load("data.h5") as data:  # doctest: +SKIP
             ...     ...
-            >>>
+
             >>> # lazy with explicit close
             >>> data = Data.load("data.h5")  # doctest: +SKIP
             >>> ...  # doctest: +SKIP
             >>> data.close()  # doctest: +SKIP
-            >>>
+
             >>> # non-lazy (no close needed)
             >>> data = Data.load("data.h5", lazy=False)  # doctest: +SKIP
         """
@@ -584,6 +584,7 @@ class Data:
             ...     ),
             ...     domain=Interval(0., 1.),
             ... )
+
             >>> for attr in ["timestamps", "unit_index", "waveforms"]:
             ...     print(attr, data.get_nested_attribute(f"spikes.{attr}"))
             timestamps [0.1 0.2 0.3]

--- a/torch_brain/data/data.py
+++ b/torch_brain/data/data.py
@@ -313,7 +313,7 @@ class Data:
         Args:
             file: HDF5 file.
 
-        Examples::
+        Example ::
             >>> import h5py
             >>> from torch_brain.data import Data
             >>> data = Data(...)  # doctest: +SKIP
@@ -355,7 +355,7 @@ class Data:
         Args:
             file: HDF5 file.
 
-        Examples::
+        Example ::
             >>> import h5py  # doctest: +SKIP
             >>> from torch_brain.data import Data  # doctest: +SKIP
             >>> with h5py.File("data.h5", "r") as f:  # doctest: +SKIP
@@ -424,7 +424,7 @@ class Data:
         Returns:
             Data: The loaded :class:`Data` object from the HDF5 file.
 
-        Examples::
+        Example ::
             >>> from torch_brain.data import Data
             >>> # lazy with context manager (recommended)
             >>> with Data.load("data.h5") as data:  # doctest: +SKIP
@@ -473,7 +473,7 @@ class Data:
         Args:
             path: Destination file path
 
-        Examples::
+        Example ::
             >>> from torch_brain.data import Data  # doctest: +SKIP
             >>> data = Data(...)  # doctest: +SKIP
             >>> data.save("data.h5")  # doctest: +SKIP
@@ -572,7 +572,7 @@ class Data:
         Raises:
             AttributeError: If any component of the path cannot be resolved.
 
-        Examples::
+        Example ::
             >>> import numpy as np
             >>> from torch_brain.data import Data, IrregularTimeSeries, Interval
             >>> data = Data(
@@ -626,7 +626,7 @@ class Data:
     def has_nested_attribute(self, path: str) -> bool:
         """Return :obj:`True` if the dot-separated path resolves to an existing attribute.
 
-        Examples::
+        Example ::
             >>> if data.has_nested_attribute("spikes.waveforms"):  # doctest: +SKIP
             ...     process(data.spikes.waveforms)
 
@@ -665,7 +665,7 @@ class Data:
         r"""Delete a nested attribute specified by its dot-separated path, modifying
         the object in-place.
 
-        Examples::
+        Example ::
             >>> for path in ["spikes.waveforms", "lfp.raw"]:  # doctest: +SKIP
             ...     if data.has_nested_attribute(path):
             ...         data.delete_nested_attribute(path)

--- a/torch_brain/data/data.py
+++ b/torch_brain/data/data.py
@@ -313,15 +313,12 @@ class Data:
         Args:
             file: HDF5 file.
 
-        .. code-block:: python
-
-                import h5py
-                from torch_brain.data import Data
-
-                data = Data(...)
-
-                with h5py.File("data.h5", "w") as f:
-                    data.to_hdf5(f)
+        Examples:
+            >>> import h5py  # doctest: +SKIP
+            >>> from torch_brain.data import Data  # doctest: +SKIP
+            >>> data = Data(...)  # doctest: +SKIP
+            >>> with h5py.File("data.h5", "w") as f:  # doctest: +SKIP
+            ...     data.to_hdf5(f)
         """
         for key in self.keys():
             value = getattr(self, key)
@@ -358,14 +355,11 @@ class Data:
         Args:
             file: HDF5 file.
 
-
-        .. code-block:: python
-
-            import h5py
-            from torch_brain.data import Data
-
-            with h5py.File("data.h5", "r") as f:
-                data = Data.from_hdf5(f)
+        Examples:
+            >>> import h5py  # doctest: +SKIP
+            >>> from torch_brain.data import Data  # doctest: +SKIP
+            >>> with h5py.File("data.h5", "r") as f:  # doctest: +SKIP
+            ...     data = Data.from_hdf5(f)
         """
         # check that the file is read-only
         if isinstance(file, h5py.File):
@@ -430,21 +424,19 @@ class Data:
         Returns:
             Data: The loaded :class:`Data` object from the HDF5 file.
 
-        .. code-block:: python
+        Examples:
+            >>> from torch_brain.data import Data
+            >>> # lazy with context manager (recommended)
+            >>> with Data.load("data.h5") as data:  # doctest: +SKIP
+            ...     ...
 
-            from torch_brain.data import Data
+            >>> # lazy with context manager (recommended)
+            >>> data = Data.load("data.h5")  # doctest: +SKIP
+            >>> ...  # doctest: +SKIP
+            >>> data.close()  # doctest: +SKIP
 
-            # lazy with context manager (recommended)
-            with Data.load("data.h5") as data:
-                ...
-
-            # lazy with explicit close
-            data = Data.load("data.h5")
-            ...
-            data.close()
-
-            # non-lazy (no close needed)
-            data = Data.load("data.h5", lazy=False)
+            >>> # non-lazy (no close needed)
+            >>> data = Data.load("data.h5", lazy=False)  # doctest: +SKIP
         """
         file = h5py.File(path)
         try:
@@ -481,12 +473,10 @@ class Data:
         Args:
             path: Destination file path
 
-        .. code-block:: python
-
-                from torch_brain.data import Data
-
-                data = Data(...)
-                data.save("data.h5")
+        Examples:
+            >>> from torch_brain.data import Data  # doctest: +SKIP
+            >>> data = Data(...)  # doctest: +SKIP
+            >>> data.save("data.h5")  # doctest: +SKIP
         """
         with h5py.File(path, "w") as f:
             self.to_hdf5(f)
@@ -550,43 +540,15 @@ class Data:
         data."""
         return key in self.keys()
 
-    def get_nested_attribute(self, path: str) -> Any:
-        r"""Returns the attribute specified by the path. The path can be nested using
-        dots. For example, if the path is "spikes.timestamps", this method will return
-        the timestamps attribute of the spikes object.
-
-        Args:
-            path: Nested attribute path.
-        """
-        # Split key by dots, resolve using getattr
-        components = path.split(".")
-        out = self
-        for c in components:
-            try:
-                out = getattr(out, c)
-            except AttributeError as err:
-                raise AttributeError(
-                    f"Could not resolve {path} in data (specifically, at level {c})"
-                ) from err
-        return out
-
-    def set_nested_attribute(self, path: str, value: Any) -> Data:
-        r"""Set a nested attribute specified by its path. The path can be nested
-        using dots. For example, if the path is "session.id", this method will
-        set the value of the ``id`` attribute of the ``session`` object.
-        The attribute is modified in an in-place manner.
-
-        Args:
-            path: Nested attribute path (can be dot-separated, e.g. "session.id").
-            value: The value to set for the attribute.
+    def _resolve_to_parent(self, path: str):
+        """Walk all but the last component of a dot-separated path.
 
         Returns:
-            Data: self with the updated nested attribute.
+            tuple: ``(parent_object, last_attribute_name)``
 
         Raises:
-            AttributeError: If any component of the path cannot be resolved.
+            AttributeError: If any intermediate component cannot be resolved.
         """
-        # Split key by dots, resolve using getattr
         components = path.split(".")
         obj = self
         for c in components[:-1]:
@@ -596,12 +558,94 @@ class Data:
                 raise AttributeError(
                     f"Could not resolve {path} in data (specifically, at level {c})"
                 ) from err
+        return obj, components[-1]
 
-        setattr(obj, components[-1], value)
+    def get_nested_attribute(self, path: str) -> Any:
+        r"""Return the value of a nested attribute specified by its dot-separated path.
+
+        Args:
+            path: Nested attribute path (dot-separated).
+
+        Returns:
+            The value of the attribute at the end of the path.
+
+        Raises:
+            AttributeError: If any component of the path cannot be resolved.
+
+        Examples:
+            >>> import numpy as np
+            >>> from torch_brain.data import Data, IrregularTimeSeries, Interval
+            >>> data = Data(
+            ...     spikes=IrregularTimeSeries(
+            ...         timestamps=[0.1, 0.2, 0.3],
+            ...         unit_index=[0, 0, 1],
+            ...         waveforms=np.zeros((3, 2)),
+            ...         domain=Interval(0., 1.),
+            ...     ),
+            ...     domain=Interval(0., 1.),
+            ... )
+            >>> for attr in ["timestamps", "unit_index", "waveforms"]:
+            ...     print(attr, data.get_nested_attribute(f"spikes.{attr}"))
+            timestamps [0.1 0.2 0.3]
+            unit_index [0 0 1]
+            waveforms [[0. 0.]
+             [0. 0.]
+             [0. 0.]]
+        """
+        obj, attr = self._resolve_to_parent(path)
+        try:
+            return getattr(obj, attr)
+        except AttributeError as err:
+            raise AttributeError(
+                f"Could not resolve {path} in data (specifically, at level {attr})"
+            ) from err
+
+    def set_nested_attribute(self, path: str, value: Any) -> Data:
+        r"""Set a nested attribute specified by its dot-separated path, modifying
+        the object in-place.
+
+        Examples:
+            >>> data.set_nested_attribute("session.subject.age", 5)  # doctest: +SKIP
+            >>> data.set_nested_attribute("spikes.unit_index", remapped_units)  # doctest: +SKIP
+
+        Args:
+            path: Nested attribute path (dot-separated).
+            value: The value to set for the attribute.
+
+        Returns:
+            Data: self with the updated nested attribute.
+
+        Raises:
+            AttributeError: If any component of the path cannot be resolved.
+        """
+        obj, attr = self._resolve_to_parent(path)
+        setattr(obj, attr, value)
         return self
 
     def has_nested_attribute(self, path: str) -> bool:
-        """Check if the attribute specified by the path exists in the Data object."""
+        """Return :obj:`True` if the dot-separated path resolves to an existing attribute.
+
+        Examples:
+            >>> if data.has_nested_attribute("spikes.waveforms"):  # doctest: +SKIP
+            ...     process(data.spikes.waveforms)
+
+        .. note::
+            Uses ``__dict__`` rather than ``getattr`` at each level of the path
+            traversal to avoid two side-effects:
+
+            - ``getattr`` on a lazy object (e.g. :obj:`LazyIrregularTimeSeries`)
+              would materialise the underlying h5py dataset into a NumPy array as
+              a side-effect of the existence check.
+            - ``getattr`` would invoke computed properties such as
+              :attr:`RegularTimeSeries.timestamps`, incorrectly reporting them as
+              stored attributes when they are not.
+
+        Args:
+            path: Nested attribute path (dot-separated).
+
+        Returns:
+            bool: :obj:`True` if the attribute exists, :obj:`False` otherwise.
+        """
         if not path:
             return False
 
@@ -615,6 +659,30 @@ class Data:
                 return False
 
         return True
+
+    def delete_nested_attribute(self, path: str):
+        r"""Delete a nested attribute specified by its dot-separated path, modifying
+        the object in-place.
+
+        Examples:
+            >>> for path in ["spikes.waveforms", "lfp.raw"]:  # doctest: +SKIP
+            ...     if data.has_nested_attribute(path):
+            ...         data.delete_nested_attribute(path)
+
+        Args:
+            path: Nested attribute path (dot-separated).
+
+        Raises:
+            AttributeError: If any component of the path cannot be resolved, or
+                if the target attribute is protected.
+        """
+        obj, attr = self._resolve_to_parent(path)
+        try:
+            delattr(obj, attr)
+        except AttributeError as err:
+            raise AttributeError(
+                f"Could not resolve {path} in data (specifically, at level {attr})"
+            ) from err
 
     def __copy__(self):
         # create a shallow copy of the object

--- a/torch_brain/data/data.py
+++ b/torch_brain/data/data.py
@@ -605,7 +605,8 @@ class Data:
         r"""Set a nested attribute specified by its dot-separated path, modifying
         the object in-place.
 
-        Examples:
+        Example ::
+
             >>> data.set_nested_attribute("session.subject.age", 5)  # doctest: +SKIP
             >>> data.set_nested_attribute("spikes.unit_index", remapped_units)  # doctest: +SKIP
 

--- a/torch_brain/data/data.py
+++ b/torch_brain/data/data.py
@@ -429,12 +429,12 @@ class Data:
             >>> # lazy with context manager (recommended)
             >>> with Data.load("data.h5") as data:  # doctest: +SKIP
             ...     ...
-
-            >>> # lazy with context manager (recommended)
+            >>>
+            >>> # lazy with explicit close
             >>> data = Data.load("data.h5")  # doctest: +SKIP
             >>> ...  # doctest: +SKIP
             >>> data.close()  # doctest: +SKIP
-
+            >>>
             >>> # non-lazy (no close needed)
             >>> data = Data.load("data.h5", lazy=False)  # doctest: +SKIP
         """

--- a/torch_brain/data/interval.py
+++ b/torch_brain/data/interval.py
@@ -120,6 +120,15 @@ class Interval(ArrayDict):
         if timekey not in self._timekeys:
             self._timekeys.append(timekey)
 
+    def __delattr__(self, name):
+        if name in ("start", "end"):
+            raise AttributeError(
+                f"Cannot delete '{name}' from {self.__class__.__name__}."
+            )
+        super().__delattr__(name)
+        if name in self._timekeys:
+            self._timekeys.remove(name)
+
     def __setattr__(self, name, value):
         super().__setattr__(name, value)
 

--- a/torch_brain/data/irregular_ts.py
+++ b/torch_brain/data/irregular_ts.py
@@ -136,6 +136,16 @@ class IrregularTimeSeries(ArrayDict):
         if timekey not in self._timekeys:
             self._timekeys.append(timekey)
 
+    def __delattr__(self, name):
+        if name == "timestamps":
+            raise AttributeError(
+                f"Cannot delete 'timestamps' from {self.__class__.__name__}."
+            )
+
+        super().__delattr__(name)
+        if name in self._timekeys:
+            self._timekeys.remove(name)
+
     def __setattr__(self, name, value):
         if name == "domain":
             if not isinstance(value, Interval):


### PR DESCRIPTION
## Summary

- Adds `Data.delete_nested_attribute(path)` symmetric with the existing `get`/`set`/`has` methods
- Deletion guards live on `__delattr__` of each class (`Data`, `ArrayDict`, `IrregularTimeSeries`, `Interval`), not on the API method, so protection applies regardless of how `delattr` is called:
  - `IrregularTimeSeries.timestamps` and `Interval.start`/`end` always blocked
  - Other registered timekeys can be deleted and are auto-deregistered from `_timekeys`
- `_resolve_to_parent` helper refactors shared path-walking logic from `get`/`set`/`delete`
- Fixes latent bug: `LazyIrregularTimeSeries` was not explicitly imported in `data.py`

See docs [here](https://torch-brain--299.org.readthedocs.build/en/299/generated/api/autosummary/torch_brain.data.Data.html#torch_brain.data.Data)
