### PR TITLE
docs: Final migration instructions update

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ models.
 pip install torch torch_brain
 ```
 
-> [!NOTE]
+> [!CAUTION]
 > Until we release `v0.2.0` on PyPI, you will have to install from GitHub
 > itself. See the [releases page](https://github.com/neuro-galaxy/torch_brain/releases)
 > for updates on releases.

--- a/README.md
+++ b/README.md
@@ -44,6 +44,14 @@ models.
 pip install torch torch_brain
 ```
 
+> [!NOTE]
+> Until we release `v0.2.0` on PyPI, you will have to install from GitHub
+> itself. See the [releases page](https://github.com/neuro-galaxy/torch_brain/releases)
+> for updates on releases.
+> ```bash
+> pip install torch git+https://github.com/neuro-galaxy/torch_brain
+> ```
+
 > [!TIP]
 > If you only need `torch_brain.data` and the data-preparation pipelines, you
 > can skip installing `torch`.

--- a/howto/MIGRATE_TO_v0.2.md
+++ b/howto/MIGRATE_TO_v0.2.md
@@ -13,11 +13,17 @@ See [README.md](../README.md) for updated installation instructions.
 A couple of things to note when coming from v0.1.x:
 
 - Uninstall the old packages first so their stale top-level `temporaldata` /
-  `brainsets` modules don't shadow the new ones: `pip uninstall temporaldata brainsets`.
+`brainsets` modules don't shadow the new ones: 
+```bash
+pip uninstall temporaldata brainsets
+```
 - `torch` is **not** a base dependency anymore, and the `data` and `pipeline`
-  modules are designed to work without it. Install `torch` directly from `pip` when needed:
-  `pip install torch git+https://github.com/neuro-galaxy/torch_brain`.
-
+modules are designed to work without it. You will need to manage the `torch` 
+installation independently within your project environment. For example, install 
+it alongside `torch_brain` with:
+```bash
+pip install torch git+https://github.com/neuro-galaxy/torch_brain
+```
 
 ## Module renames
 
@@ -25,36 +31,41 @@ See below for re-organization of modules in v0.2.0:
 
 ### Temporaldata
 
-| Before | After |
-|--------|-------|
-| `from temporaldata import XYZ` | `from torch_brain.data import XYZ`|
-| `from temporaldata.descriptions import XYZ` | `from torch_brain.data import XYZ`|
+
+| Before                                      | After                              |
+| ------------------------------------------- | ---------------------------------- |
+| `from temporaldata import XYZ`              | `from torch_brain.data import XYZ` |
+| `from temporaldata.descriptions import XYZ` | `from torch_brain.data import XYZ` |
+
 
 ### Brainsets
 
-| Before | After |
-|--------|-------|
-| `from brainsets.pipeline import BrainsetPipeline` | `from torch_brain.pipeline import BrainsetPipeline` |
+
+| Before                                                    | After                                                          |
+| --------------------------------------------------------- | -------------------------------------------------------------- |
+| `from brainsets.pipeline import BrainsetPipeline`         | `from torch_brain.pipeline import BrainsetPipeline`            |
 | `from brainsets.utils.openneuro import OpenNeuroPipeline` | `from torch_brain.pipeline.openneuro import OpenNeuroPipeline` |
-| `from brainsets.utils.s3_utils import XYZ` | `from torch_brain.utils.s3 import XYZ` |
-| `from brainsets.utils.split import XYZ` | `from torch_brain.utils.split import XYZ` |
-| `from brainsets.utils.dandi_utils import XYZ` | `from torch_brain.utils.dandi import XYZ` |
-| `from brainsets.utils.mne_utils import XYZ` | `from torch_brain.utils.mne import XYZ` |
-| `from brainsets.utils.bids_utils import XYZ` | `from torch_brain.utils.bids import XYZ` |
-| `from brainsets.processing.signal import XYZ` | `from torch_brain.utils.signal import XYZ` |
-| `from brainsets.datasets import XYZ` | `from torch_brain.datasets import XYZ` |
+| `from brainsets.utils.s3_utils import XYZ`                | `from torch_brain.utils.s3 import XYZ`                         |
+| `from brainsets.utils.split import XYZ`                   | `from torch_brain.utils.split import XYZ`                      |
+| `from brainsets.utils.dandi_utils import XYZ`             | `from torch_brain.utils.dandi import XYZ`                      |
+| `from brainsets.utils.mne_utils import XYZ`               | `from torch_brain.utils.mne import XYZ`                        |
+| `from brainsets.utils.bids_utils import XYZ`              | `from torch_brain.utils.bids import XYZ`                       |
+| `from brainsets.processing.signal import XYZ`             | `from torch_brain.utils.signal import XYZ`                     |
+| `from brainsets.datasets import XYZ`                      | `from torch_brain.datasets import XYZ`                         |
+
 
 `brainsets` CLI remains the same as before.
 
 ### TorchBrain
 
-| Before | After |
-|--------|-------|
-| `from torch_brain.data.sampler import XYZ` |  `from torch_brain.samplers import XYZ` |
-| `from torch_brain.data.collate import XYZ` | `from torch_brain.batching import XYZ` |
-| `from torch_brain.dataset import XYZ` | `from torch_brain.datasets import XYZ` |
-| `from torch_brain.utils import stitch` | `from torch_brain.utils.stitcher import stitch` |
-| `from torch_brain.utils import create_start_end_unit_tokens` | `from torch_brain.models.poyo import create_start_end_unit_tokens` |
+
+| Before                                                        | After                                                               |
+| ------------------------------------------------------------- | ------------------------------------------------------------------- |
+| `from torch_brain.data.sampler import XYZ`                    | `from torch_brain.samplers import XYZ`                              |
+| `from torch_brain.data.collate import XYZ`                    | `from torch_brain.batching import XYZ`                              |
+| `from torch_brain.dataset import XYZ`                         | `from torch_brain.datasets import XYZ`                              |
+| `from torch_brain.utils import stitch`                        | `from torch_brain.utils.stitcher import stitch`                     |
+| `from torch_brain.utils import create_start_end_unit_tokens`  | `from torch_brain.models.poyo import create_start_end_unit_tokens`  |
 | `from torch_brain.utils import create_linspace_latent_tokens` | `from torch_brain.models.poyo import create_linspace_latent_tokens` |
 
 
@@ -63,23 +74,25 @@ See below for re-organization of modules in v0.2.0:
 Additionally, a number of modules/functions were removed because they were not
 general enough to keep supporting. The table lists a replacement where one exists.
 
-| Removed | Replacement / status |
-|---------|----------------------|
-| `torch_brain.data.Dataset` | Deprecated and replaced with `torch_brain.dataset.Dataset` |
-| `torch_brain.utils.get_sinusoidal_encoding` | Use `torch_brain.nn.SinusoidalTimeEmbedding` |
-| `torch_brain.utils.seed_everything` | Reference implementation in `examples/poyo/utils.py` |
-| `torch_brain.optim` | Removed; `SparseLamb` implementation can be found in `examples/poyo` |
-| `torch_brain.registry` | Removed, no replacement |
-| `torch_brain.nn.loss` | Removed, no replacement |
-| `torch_brain.nn.MultitaskReadout` | Removed, no replacement |
-| `torch_brain.nn.FeedForwad` | Removed, no replacement |
-| `torch_brain.utils.gradient_rescale` | Removed, no replacement |
-| `torch_brain.utils.prepare_for_readout` | Removed, no replacement |
-| `DecodingStitchEvaluator`, `MultiTaskDecodingStitchEvaluator` | Removed; see `examples/poyo` for an alternate |
-| `POYOPlus`, `CalciumPOYOPlus` models | Removed; POYO+ code moved to [[github.com/nerdslab/poyo_plus]] |
+
+| Removed                                                       | Replacement / status                                                 |
+| ------------------------------------------------------------- | -------------------------------------------------------------------- |
+| `torch_brain.data.Dataset`                                    | Deprecated and replaced with `torch_brain.dataset.Dataset`           |
+| `torch_brain.utils.get_sinusoidal_encoding`                   | Use `torch_brain.nn.SinusoidalTimeEmbedding`                         |
+| `torch_brain.utils.seed_everything`                           | Reference implementation in `examples/poyo/utils.py`                 |
+| `torch_brain.optim`                                           | Removed; `SparseLamb` implementation can be found in `examples/poyo` |
+| `torch_brain.registry`                                        | Removed, no replacement                                              |
+| `torch_brain.nn.loss`                                         | Removed, no replacement                                              |
+| `torch_brain.nn.MultitaskReadout`                             | Removed, no replacement                                              |
+| `torch_brain.nn.FeedForwad`                                   | Removed, no replacement                                              |
+| `torch_brain.utils.gradient_rescale`                          | Removed, no replacement                                              |
+| `torch_brain.utils.prepare_for_readout`                       | Removed, no replacement                                              |
+| `DecodingStitchEvaluator`, `MultiTaskDecodingStitchEvaluator` | Removed; see `examples/poyo` for an alternate                        |
+| `POYOPlus`, `CalciumPOYOPlus` models                          | Removed; POYO+ code moved to [[github.com/nerdslab/poyo_plus]]       |
+
 
 ## Data files (HDF5)
 
 Although the on-disk HDF5 format is unchanged by the merger, and datasets you
-preprocessed with `brainsets`/`temporaldata` v0.1.x _should_ continue to load
+preprocessed with `brainsets`/`temporaldata` v0.1.x *should* continue to load
 with v0.2.0, we suggest re-running `brainsets prepare` if feasible.

--- a/howto/MIGRATE_TO_v0.2.md
+++ b/howto/MIGRATE_TO_v0.2.md
@@ -6,21 +6,17 @@ If you pull `torch_brain` from GitHub, we suggest you start with a fresh clone.
 
 ## Installation
 
-See [README.md](../README.md) for updated installation instructions.
 Until we release `v0.2.0` on PyPI, you will have to install from GitHub itself.
 See [releases page](https://github.com/neuro-galaxy/torch_brain/releases) for updates on releases.
+See [README.md](../README.md) for updated installation instructions.
 
-A couple of things to know when coming from v0.1.x:
+A couple of things to note when coming from v0.1.x:
 
 - Uninstall the old packages first so their stale top-level `temporaldata` /
   `brainsets` modules don't shadow the new ones: `pip uninstall temporaldata brainsets`.
 - `torch` is **not** a base dependency anymore, and the `data` and `pipeline`
-  modules are designed to work without it. Install `torch` directly from `pip` for other
-  modules: `pip install torch git+https://github.com/neuro-galaxy/torch_brain`.
-
-> Renamed imports are not silently aliased to their old location: they raise
-> `ImportError`/`AttributeError` pointing at the new path, so every import below
-> must be updated.
+  modules are designed to work without it. Install `torch` directly from `pip` when needed:
+  `pip install torch git+https://github.com/neuro-galaxy/torch_brain`.
 
 
 ## Module renames
@@ -58,15 +54,9 @@ See below for re-organization of modules in v0.2.0:
 | `from torch_brain.data.collate import XYZ` | `from torch_brain.batching import XYZ` |
 | `from torch_brain.dataset import XYZ` | `from torch_brain.datasets import XYZ` |
 | `from torch_brain.utils import stitch` | `from torch_brain.utils.stitcher import stitch` |
-
-Old `torch_brain.data.Dataset` has not been completely deprecated. Please switch to `torch_brain.datasets.Dataset`.
-
-These POYO-specific utilities were moved:
-
-| Before | After |
-|--------|-------|
 | `from torch_brain.utils import create_start_end_unit_tokens` | `from torch_brain.models.poyo import create_start_end_unit_tokens` |
 | `from torch_brain.utils import create_linspace_latent_tokens` | `from torch_brain.models.poyo import create_linspace_latent_tokens` |
+
 
 ## Removed APIs
 
@@ -75,6 +65,7 @@ general enough to keep supporting. The table lists a replacement where one exist
 
 | Removed | Replacement / status |
 |---------|----------------------|
+| `torch_brain.data.Dataset` | Deprecated and replaced with `torch_brain.dataset.Dataset` |
 | `torch_brain.utils.get_sinusoidal_encoding` | Use `torch_brain.nn.SinusoidalTimeEmbedding` |
 | `torch_brain.utils.seed_everything` | Reference implementation in `examples/poyo/utils.py` |
 | `torch_brain.optim` | Removed; `SparseLamb` implementation can be found in `examples/poyo` |
@@ -84,12 +75,11 @@ general enough to keep supporting. The table lists a replacement where one exist
 | `torch_brain.nn.FeedForwad` | Removed, no replacement |
 | `torch_brain.utils.gradient_rescale` | Removed, no replacement |
 | `torch_brain.utils.prepare_for_readout` | Removed, no replacement |
-| `DecodingStitchEvaluator`, `MultiTaskDecodingStitchEvaluator` (from `torch_brain.utils.callbacks`) | Removed; see `examples/poyo` for an alternate implementation of `DecodingStitchEvaluator` |
-| `POYOPlus`, `CalciumPOYOPlus` models | Removed; relied on previously removed modules |
+| `DecodingStitchEvaluator`, `MultiTaskDecodingStitchEvaluator` | Removed; see `examples/poyo` for an alternate |
+| `POYOPlus`, `CalciumPOYOPlus` models | Removed; POYO+ code moved to [[github.com/nerdslab/poyo_plus]] |
 
 ## Data files (HDF5)
 
-The on-disk HDF5 format is unchanged by the merger, so datasets you preprocessed
-with `brainsets`/`temporaldata` v0.1.x continue to load with v0.2.0. No
-re-processing _should_ be required. Although it might be better to just re-run
-`brainsets prepare` if possible.
+Although the on-disk HDF5 format is unchanged by the merger, and datasets you
+preprocessed with `brainsets`/`temporaldata` v0.1.x _should_ continue to load
+with v0.2.0, we suggest re-running `brainsets prepare` if feasible.

--- a/howto/MIGRATE_TO_v0.2.md
+++ b/howto/MIGRATE_TO_v0.2.md
@@ -4,6 +4,24 @@ The biggest change from v0.1.x to v0.2.0 is the merger of `temporaldata`
 and `brainsets` into `torch_brain`.
 If you pull `torch_brain` from GitHub, we suggest you start with a fresh clone.
 
+## Installation
+
+See [README.md](../README.md) for updated installation instructions.
+Until we release `v0.2.0` on PyPI, you will have to install from GitHub itself.
+See [releases page](https://github.com/neuro-galaxy/torch_brain/releases) for updates on releases.
+
+A couple of things to know when coming from v0.1.x:
+
+- Uninstall the old packages first so their stale top-level `temporaldata` /
+  `brainsets` modules don't shadow the new ones: `pip uninstall temporaldata brainsets`.
+- `torch` is **not** a base dependency anymore, and the `data` and `pipeline`
+  modules are designed to work without it. Install `torch` directly from `pip` for other
+  modules: `pip install torch git+https://github.com/neuro-galaxy/torch_brain`.
+
+> Renamed imports are not silently aliased to their old location: they raise
+> `ImportError`/`AttributeError` pointing at the new path, so every import below
+> must be updated.
+
 
 ## Module renames
 
@@ -30,22 +48,48 @@ See below for re-organization of modules in v0.2.0:
 | `from brainsets.processing.signal import XYZ` | `from torch_brain.utils.signal import XYZ` |
 | `from brainsets.datasets import XYZ` | `from torch_brain.datasets import XYZ` |
 
+`brainsets` CLI remains the same as before.
+
 ### TorchBrain
 
 | Before | After |
 |--------|-------|
-| `torch_brain.data.sampler` |  `torch_brain.samplers` |
-| `torch_brain.data.collate` | `torch_brain.batching` |
+| `from torch_brain.data.sampler import XYZ` |  `from torch_brain.samplers import XYZ` |
+| `from torch_brain.data.collate import XYZ` | `from torch_brain.batching import XYZ` |
+| `from torch_brain.dataset import XYZ` | `from torch_brain.datasets import XYZ` |
+| `from torch_brain.utils import stitch` | `from torch_brain.utils.stitcher import stitch` |
 
-Additionally, a bunch of modules/functions were removed:
-- `torch_brain.utils.get_sinusoidal_encoding` (use `torch_brain.nn.SinusoidalTimeEmbedding` instead)
-- `torch_brain.utils.seed_everything`; a reference implementation can still be found in `examples/poyo/utils.py`
-- `torch_brain.registry`
-- `torch_brain.nn.loss`
-- `torch_brain.nn.MultitaskReadout`
-- `DecodingStitchEvaluator` and `MultiTaskDecodingStitchEvaluator` from `torch_brain.utils.callbacks`
-- `torch_brain.utils.prepare_for_readout`
-- `torch_brain.nn.FeedForwad`
-- `torch_brain.optim`
-- `torch_brain.utils.gradient_rescale`
-- `POYOPlus` and `CalciumPOYOPlus` models (because of their reliance on previously removed modules)
+Old `torch_brain.data.Dataset` has not been completely deprecated. Please switch to `torch_brain.datasets.Dataset`.
+
+These POYO-specific utilities were moved:
+
+| Before | After |
+|--------|-------|
+| `from torch_brain.utils import create_start_end_unit_tokens` | `from torch_brain.models.poyo import create_start_end_unit_tokens` |
+| `from torch_brain.utils import create_linspace_latent_tokens` | `from torch_brain.models.poyo import create_linspace_latent_tokens` |
+
+## Removed APIs
+
+Additionally, a number of modules/functions were removed because they were not
+general enough to keep supporting. The table lists a replacement where one exists.
+
+| Removed | Replacement / status |
+|---------|----------------------|
+| `torch_brain.utils.get_sinusoidal_encoding` | Use `torch_brain.nn.SinusoidalTimeEmbedding` |
+| `torch_brain.utils.seed_everything` | Reference implementation in `examples/poyo/utils.py` |
+| `torch_brain.optim` | Removed; `SparseLamb` implementation can be found in `examples/poyo` |
+| `torch_brain.registry` | Removed, no replacement |
+| `torch_brain.nn.loss` | Removed, no replacement |
+| `torch_brain.nn.MultitaskReadout` | Removed, no replacement |
+| `torch_brain.nn.FeedForwad` | Removed, no replacement |
+| `torch_brain.utils.gradient_rescale` | Removed, no replacement |
+| `torch_brain.utils.prepare_for_readout` | Removed, no replacement |
+| `DecodingStitchEvaluator`, `MultiTaskDecodingStitchEvaluator` (from `torch_brain.utils.callbacks`) | Removed; see `examples/poyo` for an alternate implementation of `DecodingStitchEvaluator` |
+| `POYOPlus`, `CalciumPOYOPlus` models | Removed; relied on previously removed modules |
+
+## Data files (HDF5)
+
+The on-disk HDF5 format is unchanged by the merger, so datasets you preprocessed
+with `brainsets`/`temporaldata` v0.1.x continue to load with v0.2.0. No
+re-processing _should_ be required. Although it might be better to just re-run
+`brainsets prepare` if possible.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,7 +92,7 @@ ignore = ["E501"]
 python-version = "3.10"
 
 [tool.ty.src]
-include = ["torch_brain/data", "tests/data", "torch_brain/models"]
+include = ["torch_brain/data", "tests/data"]
 
 [tool.ty.rules]
 # Change these to "error" over time

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,7 +92,7 @@ ignore = ["E501"]
 python-version = "3.10"
 
 [tool.ty.src]
-include = ["torch_brain/data", "tests/data"]
+include = ["torch_brain/data", "tests/data", "torch_brain/models"]
 
 [tool.ty.rules]
 # Change these to "error" over time

--- a/torch_brain/utils/stitcher.py
+++ b/torch_brain/utils/stitcher.py
@@ -99,6 +99,7 @@ def _removed_import_error(name):
         "and `howto/MIGRATE_TO_v0.2.md` for the full list of removed APIs."
     )
 
+
 class DecodingStitchEvaluator:
     def __init__(self, *args, **kwargs):
         _removed_import_error("DecodingStitchEvaluator")

--- a/torch_brain/utils/stitcher.py
+++ b/torch_brain/utils/stitcher.py
@@ -95,7 +95,7 @@ def _removed_import_error(name):
     raise ImportError(
         f"`{name}` was removed in v0.2.0. It relied on modules that are no longer "
         "supported (`torch_brain.nn.MultitaskReadout`, `torch_brain.nn.loss`). "
-        "See `examples/poyo/` for a current end-to-end training and evaluation setup, "
+        "See `examples/poyo/` for a reference end-to-end training and evaluation setup, "
         "and `howto/MIGRATE_TO_v0.2.md` for the full list of removed APIs."
     )
 

--- a/torch_brain/utils/stitcher.py
+++ b/torch_brain/utils/stitcher.py
@@ -91,28 +91,29 @@ def stitch(
         )
 
 
-def _deprecated_import_error(name):
+def _removed_import_error(name):
     raise ImportError(
-        f"`{name}` has been moved to `torch_brain.utils.callbacks`. "
-        f"Please update your import to: `from torch_brain.utils.callbacks import {name}`"
+        f"`{name}` was removed in v0.2.0. It relied on modules that are no longer "
+        "supported (`torch_brain.nn.MultitaskReadout`, `torch_brain.nn.loss`). "
+        "See `examples/poyo/` for a current end-to-end training and evaluation setup, "
+        "and `howto/MIGRATE_TO_v0.2.md` for the full list of removed APIs."
     )
-
 
 class DecodingStitchEvaluator:
     def __init__(self, *args, **kwargs):
-        _deprecated_import_error("DecodingStitchEvaluator")
+        _removed_import_error("DecodingStitchEvaluator")
 
 
 class DataForDecodingStitchEvaluator:
     def __init__(self, *args, **kwargs):
-        _deprecated_import_error("DataForDecodingStitchEvaluator")
+        _removed_import_error("DataForDecodingStitchEvaluator")
 
 
 class MultiTaskDecodingStitchEvaluator:
     def __init__(self, *args, **kwargs):
-        _deprecated_import_error("MultiTaskDecodingStitchEvaluator")
+        _removed_import_error("MultiTaskDecodingStitchEvaluator")
 
 
 class DataForMultiTaskDecodingStitchEvaluator:
     def __init__(self, *args, **kwargs):
-        _deprecated_import_error("DataForMultiTaskDecodingStitchEvaluator")
+        _removed_import_error("DataForMultiTaskDecodingStitchEvaluator")


### PR DESCRIPTION
Final major updates to migration docs. Also updated README with the info that currently, people have to install directly from GitHub. We should remember to update this instruction once we release alpha version on PyPI.

Closes #242 