### PR TITLE
tests: changing pipeline_testing so that they install from a REF

### DIFF
--- a/.github/workflows/pipeline_testing.yml
+++ b/.github/workflows/pipeline_testing.yml
@@ -66,7 +66,6 @@ jobs:
     - name: Download kemp_sleep_edf_2013
       id: kemp_sleep_edf_2013
       continue-on-error: true
-      if: matrix.python-version != '3.9'
       run: brainsets prepare kemp_sleep_edf_2013 -s sleep_cassette_SC4002E0-PSG
 
     # TODO: SSL cert issue with data-proxy.ebrains.eu, re-enable when fixed

--- a/.github/workflows/pipeline_testing.yml
+++ b/.github/workflows/pipeline_testing.yml
@@ -36,7 +36,7 @@ jobs:
           REPO_URL="${{ github.server_url }}/${{ github.repository }}.git"
           REF="${{ github.sha }}"
         fi
-        uv pip install --system "torch_brain[dev] @ git+${REPO_URL}@${REF}"
+        uv pip install --system "torch_brain @ git+${REPO_URL}@${REF}"
 
     - name: Configure brainsets
       run: brainsets config set --raw-dir data/raw --processed-dir data/processed

--- a/.github/workflows/pipeline_testing.yml
+++ b/.github/workflows/pipeline_testing.yml
@@ -25,6 +25,9 @@ jobs:
         python-version: "3.10"
 
     - name: Install the project from git ref
+      # For PRs, we use the head repo URL and SHA to support fork PRs where the
+      # commit doesn't exist in the base repo. For pushes, we use the base repo
+      # URL and the pushed SHA directly.
       run: |
         if [ "${{ github.event_name }}" = "pull_request" ]; then
           REPO_URL="${{ github.event.pull_request.head.repo.clone_url }}"

--- a/.github/workflows/pipeline_testing.yml
+++ b/.github/workflows/pipeline_testing.yml
@@ -14,8 +14,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
-
     - name: Install uv
       uses: astral-sh/setup-uv@v5
       with:
@@ -26,69 +24,76 @@ jobs:
       with:
         python-version: "3.10"
 
-    - name: Install the project
-      run: uv sync --all-extras
+    - name: Install the project from git ref
+      run: |
+        if [ "${{ github.event_name }}" = "pull_request" ]; then
+          REPO_URL="${{ github.event.pull_request.head.repo.clone_url }}"
+          REF="${{ github.event.pull_request.head.sha }}"
+        else
+          REPO_URL="${{ github.server_url }}/${{ github.repository }}.git"
+          REF="${{ github.sha }}"
+        fi
+        uv pip install --system "torch_brain[dev] @ git+${REPO_URL}@${REF}"
 
     - name: Configure brainsets
-      run: uv run brainsets config set --raw-dir data/raw --processed-dir data/processed
+      run: brainsets config set --raw-dir data/raw --processed-dir data/processed
 
     - name: Download pei_pandarinath_nlb_2021
       id: pei_pandarinath_nlb_2021
       continue-on-error: true
-      run: uv run brainsets prepare pei_pandarinath_nlb_2021
+      run: brainsets prepare pei_pandarinath_nlb_2021
 
     - name: Download perich_miller_population_2018
       id: perich_miller_population_2018
       continue-on-error: true
-      run: uv run brainsets prepare perich_miller_population_2018 -s c_20131219_center_out_reaching
+      run: brainsets prepare perich_miller_population_2018 -s c_20131219_center_out_reaching
 
     - name: Download allen_visual_coding_ophys_2016
       id: allen_visual_coding_ophys_2016
       continue-on-error: true
-      run: uv run brainsets prepare allen_visual_coding_ophys_2016 -s 717913184
+      run: brainsets prepare allen_visual_coding_ophys_2016 -s 717913184
 
     - name: Download churchland_shenoy_neural_2012
       id: churchland_shenoy_neural_2012
       continue-on-error: true
-      run: uv run brainsets prepare churchland_shenoy_neural_2012 -s jenkins_20090912
+      run: brainsets prepare churchland_shenoy_neural_2012 -s jenkins_20090912
 
     - name: Download flint_slutzky_accurate_2012
       id: flint_slutzky_accurate_2012
       continue-on-error: true
-      run: uv run brainsets prepare flint_slutzky_accurate_2012 -s flint_2012_e1
+      run: brainsets prepare flint_slutzky_accurate_2012 -s flint_2012_e1
 
     - name: Download kemp_sleep_edf_2013
       id: kemp_sleep_edf_2013
       continue-on-error: true
       if: matrix.python-version != '3.9'
-      # scikit-learn>=1.7.2 is not compatible with python3.9
-      run: uv run brainsets prepare kemp_sleep_edf_2013 -s sleep_cassette_SC4002E0-PSG
+      run: brainsets prepare kemp_sleep_edf_2013 -s sleep_cassette_SC4002E0-PSG
 
     # TODO: SSL cert issue with data-proxy.ebrains.eu, re-enable when fixed
     - name: Download vollan_moser_alternating_2025 (navigation)
       id: vollan_moser_alternating_2025_navigation
       continue-on-error: true
-      run: uv run brainsets prepare vollan_moser_alternating_2025 -s of_24365_2
+      run: brainsets prepare vollan_moser_alternating_2025 -s of_24365_2
 
     - name: Download vollan_moser_alternating_2025 (sleep)
       id: vollan_moser_alternating_2025_sleep
       continue-on-error: true
-      run: uv run brainsets prepare vollan_moser_alternating_2025 -s sleep_25691_1
+      run: brainsets prepare vollan_moser_alternating_2025 -s sleep_25691_1
 
     - name: Download klinzing_sleep_ds005555
       id: klinzing_sleep_ds005555
       continue-on-error: true
-      run: uv run brainsets prepare klinzing_sleep_ds005555 -s sub-10_task-Sleep_acq-headband --on-version-mismatch continue
+      run: brainsets prepare klinzing_sleep_ds005555 -s sub-10_task-Sleep_acq-headband --on-version-mismatch continue
 
     - name: Download kochi_visualnaming_ds006914
       id: kochi_visualnaming_ds006914
       continue-on-error: true
-      run: uv run brainsets prepare kochi_visualnaming_ds006914 -s sub-023_ses-2_task-picture --on-version-mismatch continue
+      run: brainsets prepare kochi_visualnaming_ds006914 -s sub-023_ses-2_task-picture --on-version-mismatch continue
 
     - name: Download shirazi_hbnr1_ds005505
       id: shirazi_hbnr1_ds005505
       continue-on-error: true
-      run: uv run brainsets prepare shirazi_hbnr1_ds005505 -s sub-NDARAC904DMU_task-DespicableMe --on-version-mismatch continue
+      run: brainsets prepare shirazi_hbnr1_ds005505 -s sub-NDARAC904DMU_task-DespicableMe --on-version-mismatch continue
 
     - name: Check all pipelines passed
       if: always()

--- a/.github/workflows/pipeline_testing_matrix.yml
+++ b/.github/workflows/pipeline_testing_matrix.yml
@@ -29,6 +29,9 @@ jobs:
         python-version: ${{ matrix.python-version }}
 
     - name: Install the project from git ref
+      # For PRs, we use the head repo URL and SHA to support fork PRs where the
+      # commit doesn't exist in the base repo. For pushes, we use the base repo
+      # URL and the pushed SHA directly.
       run: |
         if [ "${{ github.event_name }}" = "pull_request" ]; then
           REPO_URL="${{ github.event.pull_request.head.repo.clone_url }}"

--- a/.github/workflows/pipeline_testing_matrix.yml
+++ b/.github/workflows/pipeline_testing_matrix.yml
@@ -18,8 +18,6 @@ jobs:
         python-version: ["3.10", "3.11", "3.12", "3.13"]
 
     steps:
-    - uses: actions/checkout@v4
-
     - name: Install uv
       uses: astral-sh/setup-uv@v5
       with:
@@ -30,10 +28,18 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
-    - name: Install the project
-      run: uv sync --all-extras
+    - name: Install the project from git ref
+      run: |
+        if [ "${{ github.event_name }}" = "pull_request" ]; then
+          REPO_URL="${{ github.event.pull_request.head.repo.clone_url }}"
+          REF="${{ github.event.pull_request.head.sha }}"
+        else
+          REPO_URL="${{ github.server_url }}/${{ github.repository }}.git"
+          REF="${{ github.sha }}"
+        fi
+        uv pip install --system "torch_brain[dev] @ git+${REPO_URL}@${REF}"
 
     - name: Download pei_pandarinath_nlb_2021
       run: |
-        uv run brainsets config set --raw-dir data/raw --processed-dir data/processed
-        uv run brainsets prepare pei_pandarinath_nlb_2021
+        brainsets config set --raw-dir data/raw --processed-dir data/processed
+        brainsets prepare pei_pandarinath_nlb_2021

--- a/.github/workflows/pipeline_testing_matrix.yml
+++ b/.github/workflows/pipeline_testing_matrix.yml
@@ -40,7 +40,7 @@ jobs:
           REPO_URL="${{ github.server_url }}/${{ github.repository }}.git"
           REF="${{ github.sha }}"
         fi
-        uv pip install --system "torch_brain[dev] @ git+${REPO_URL}@${REF}"
+        uv pip install --system "torch_brain @ git+${REPO_URL}@${REF}"
 
     - name: Download pei_pandarinath_nlb_2021
       run: |


### PR DESCRIPTION
Removed the checkout step and updated the project installation command to use the appropriate git reference based on the event type. Given that we no longer checkout, I also simplified the brainsets preparation commands by removing the `uv run` prefix as we now install in the system python directly.

Closes #276 