### PR TITLE
feat: Add utils for OpenNeuro participants metadata

### DIFF
--- a/tests/utils/test_openneuro.py
+++ b/tests/utils/test_openneuro.py
@@ -1,5 +1,6 @@
 """Unit tests for OpenNeuro S3 utility functions."""
 
+from io import BytesIO
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -18,11 +19,13 @@ from torch_brain.utils.openneuro import (  # noqa: E402
     _graphql_query_openneuro,
     construct_s3_url_from_path,
     download_dataset_description,
+    download_participants_tsv,
     download_recording,
     fetch_all_filenames,
     fetch_latest_snapshot_tag,
     fetch_participants_tsv,
     fetch_species,
+    parse_participants_tsv,
 )
 
 # ============================================================================
@@ -402,6 +405,148 @@ class TestDownloadDatasetDescription:
 
         with pytest.raises(RuntimeError, match="Failed to download"):
             download_dataset_description("ds005085", tmp_path)
+
+
+# ============================================================================
+# Tests for parse_participants_tsv
+# ============================================================================
+
+
+class TestParseParticipantsTsv:
+    """Tests for the shared participants.tsv parser."""
+
+    def test_returns_indexed_dataframe(self, participants_tsv_bytes):
+        """Returns DataFrame indexed by participant_id when column exists."""
+        result = parse_participants_tsv(
+            BytesIO(participants_tsv_bytes(has_participant_id=True))
+        )
+
+        assert isinstance(result, pd.DataFrame)
+        assert result.index.name == "participant_id"
+        assert list(result.index) == ["participant_01", "participant_02"]
+
+    def test_returns_none_when_participant_id_column_missing(
+        self, participants_tsv_bytes
+    ):
+        """Returns None when participant_id column is absent."""
+        result = parse_participants_tsv(
+            BytesIO(participants_tsv_bytes(has_participant_id=False))
+        )
+
+        assert result is None
+
+    def test_parses_na_values(self):
+        """``n/a`` and ``N/A`` are parsed as NaN."""
+        tsv_content = b"participant_id\tage\npart_01\tn/a\npart_02\tN/A"
+
+        result = parse_participants_tsv(BytesIO(tsv_content))
+
+        assert result is not None
+        assert result["age"].isna().all()
+
+
+# ============================================================================
+# Tests for download_participants_tsv
+# ============================================================================
+
+
+class TestDownloadParticipantsTsv:
+    """Tests for participants.tsv download and caching."""
+
+    @patch("torch_brain.utils.openneuro.get_cached_s3_client")
+    def test_short_circuits_when_file_exists(self, mock_get_client, tmp_path):
+        """Returns existing file without downloading if already present."""
+        target_file = tmp_path / "participants.tsv"
+        target_file.write_text("participant_id\tage\npart_01\t25")
+
+        result = download_participants_tsv("ds005085", tmp_path)
+
+        assert result == target_file
+        mock_get_client.assert_not_called()
+
+    @patch("torch_brain.utils.openneuro.get_cached_s3_client")
+    def test_redownloads_when_redownload_set(self, mock_get_client, tmp_path):
+        """Re-downloads and overwrites an existing file when redownload=True."""
+        target_file = tmp_path / "participants.tsv"
+        target_file.write_bytes(b"stale")
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+        mock_client.get_object.return_value = {
+            "Body": MagicMock(read=lambda: b"participant_id\tage\npart_01\t25")
+        }
+
+        result = download_participants_tsv("ds005085", tmp_path, redownload=True)
+
+        assert result == target_file
+        assert result.read_bytes() == b"participant_id\tage\npart_01\t25"
+        mock_client.get_object.assert_called_once()
+
+    @patch("torch_brain.utils.openneuro.get_cached_s3_client")
+    def test_downloads_and_writes_raw_bytes_on_success(self, mock_get_client, tmp_path):
+        """Downloads and writes raw file bytes when not already present."""
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+        mock_client.get_object.return_value = {
+            "Body": MagicMock(read=lambda: b"participant_id\tage\npart_01\t25")
+        }
+
+        result = download_participants_tsv("ds005085", tmp_path)
+
+        assert result == tmp_path / "participants.tsv"
+        assert result.exists()
+        assert result.read_bytes() == b"participant_id\tage\npart_01\t25"
+
+    @patch("torch_brain.utils.openneuro.get_cached_s3_client")
+    def test_creates_parent_directories(self, mock_get_client, tmp_path):
+        """Creates parent directories if they don't exist."""
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+        mock_client.get_object.return_value = {
+            "Body": MagicMock(read=lambda: b"participant_id\tage")
+        }
+        nested_target = tmp_path / "a" / "b" / "c"
+
+        result = download_participants_tsv("ds005085", nested_target)
+
+        assert result.parent.exists()
+        assert result.exists()
+
+    @patch("torch_brain.utils.openneuro.get_cached_s3_client")
+    def test_returns_none_on_no_such_key(self, mock_get_client, tmp_path):
+        """Returns None when participants.tsv does not exist on S3 (NoSuchKey)."""
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+        mock_client.get_object.side_effect = make_client_error("NoSuchKey")
+
+        result = download_participants_tsv("ds005085", tmp_path)
+
+        assert result is None
+        assert not (tmp_path / "participants.tsv").exists()
+
+    @patch("torch_brain.utils.openneuro.get_cached_s3_client")
+    def test_returns_none_on_404(self, mock_get_client, tmp_path):
+        """Returns None on 404 error."""
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+        mock_client.get_object.side_effect = make_client_error("404")
+
+        result = download_participants_tsv("ds005085", tmp_path)
+
+        assert result is None
+
+    @patch("torch_brain.utils.openneuro.get_cached_s3_client")
+    def test_raises_runtime_error_on_other_client_error(
+        self, mock_get_client, tmp_path
+    ):
+        """RuntimeError is raised for other ClientErrors."""
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+        mock_client.get_object.side_effect = make_client_error(
+            "AccessDenied", "Access Denied"
+        )
+
+        with pytest.raises(RuntimeError, match="Failed to download"):
+            download_participants_tsv("ds005085", tmp_path)
 
 
 # ============================================================================

--- a/torch_brain/utils/openneuro.py
+++ b/torch_brain/utils/openneuro.py
@@ -320,6 +320,8 @@ def download_participants_tsv(
         if BOTO_AVAILABLE:
             error_code = e.response.get("Error", {}).get("Code", "")
         if error_code in ("NoSuchKey", "404"):
+            if redownload and target_path.exists() and target_path.is_file():
+                target_path.unlink()
             return None
         raise RuntimeError(
             f"Failed to download participants.tsv for {dataset_id}: {e}"

--- a/torch_brain/utils/openneuro.py
+++ b/torch_brain/utils/openneuro.py
@@ -8,11 +8,13 @@ __all__ = [
     "OPENNEURO_S3_BUCKET",
     "construct_s3_url_from_path",
     "download_dataset_description",
+    "download_participants_tsv",
     "download_recording",
     "fetch_latest_snapshot_tag",
     "fetch_all_filenames",
     "fetch_participants_tsv",
     "fetch_species",
+    "parse_participants_tsv",
 ]
 
 __api_ref__ = {
@@ -132,21 +134,15 @@ def fetch_participants_tsv(dataset_id: str) -> pd.DataFrame | None:
         response = s3_client.get_object(Bucket=OPENNEURO_S3_BUCKET, Key=key)
         content = response["Body"].read()
 
-        df = pd.read_csv(
-            BytesIO(content),
-            sep="\t",
-            na_values=["n/a", "N/A"],
-            keep_default_na=True,
-        )
+        df = parse_participants_tsv(BytesIO(content))
 
-        if "participant_id" not in df.columns:
+        if df is None:
             logging.warning(
                 f"No participant_id column found in participants.tsv file in OpenNeuro dataset {dataset_id}. "
                 "Returning None."
             )
             return None
 
-        df = df.set_index("participant_id")
         return df
 
     except ClientError as e:
@@ -278,6 +274,58 @@ def download_dataset_description(dataset_id: str, target_dir: Path) -> Path:
         ) from e
 
 
+def download_participants_tsv(
+    dataset_id: str,
+    target_dir: Path,
+    *,
+    redownload: bool = False,
+) -> Path | None:
+    """Download participants.tsv from OpenNeuro S3.
+
+    Args:
+        dataset_id: The OpenNeuro dataset identifier
+        target_dir: Local directory to download to
+        redownload: If ``True``, re-download and overwrite any existing local file.
+            If ``False`` (default), an existing local file is returned as-is.
+
+    Returns:
+        Path to the downloaded or existing participants.tsv file, or ``None`` if
+        the dataset has no participants.tsv on OpenNeuro S3.
+
+    Raises:
+        RuntimeError: If the download fails for a reason other than the file being
+            absent.
+    """
+    target_dir = Path(target_dir)
+    target_path = target_dir / "participants.tsv"
+
+    if target_path.exists() and not redownload:
+        return target_path
+
+    s3_client = get_cached_s3_client()
+    key = f"{dataset_id}/participants.tsv"
+
+    try:
+        response = s3_client.get_object(Bucket=OPENNEURO_S3_BUCKET, Key=key)
+        content = response["Body"].read()
+
+        target_dir.mkdir(parents=True, exist_ok=True)
+        with open(target_path, "wb") as f:
+            f.write(content)
+
+        return target_path
+
+    except ClientError as e:
+        error_code = ""
+        if BOTO_AVAILABLE:
+            error_code = e.response.get("Error", {}).get("Code", "")
+        if error_code in ("NoSuchKey", "404"):
+            return None
+        raise RuntimeError(
+            f"Failed to download participants.tsv for {dataset_id}: {e}"
+        ) from e
+
+
 def _graphql_query_openneuro(query: str, variables: dict | None = None) -> dict:
     """Execute an OpenNeuro GraphQL query with retry.
 
@@ -332,3 +380,27 @@ def _graphql_query_openneuro(query: str, variables: dict | None = None) -> dict:
             raise Exception(f"Query failed with status code {response.status_code}")
 
     return _graphql_query(query, variables)
+
+
+def parse_participants_tsv(buffer) -> pd.DataFrame | None:
+    """Parse a participants.tsv source into a DataFrame indexed by participant_id.
+
+    Args:
+        buffer: Any source accepted by :func:`pandas.read_csv` (e.g. a
+            :class:`io.BytesIO` of the file contents or a local path).
+
+    Returns:
+        DataFrame indexed by ``participant_id``, or ``None`` if the file has no
+        ``participant_id`` column.
+    """
+    df = pd.read_csv(
+        buffer,
+        sep="\t",
+        na_values=["n/a", "N/A"],
+        keep_default_na=True,
+    )
+
+    if "participant_id" not in df.columns:
+        return None
+
+    return df.set_index("participant_id")


### PR DESCRIPTION
### Summary 

Adds OpenNeuro utils for `participants.tsv` containing participants metadata in OpenNeuro datasets
- `download_participants_tsv` to locally download the file
- `parse_participants_tsv` for standard parsing of the file
- tests for both utils

This will be useful for brainsets using `openneuro.py` utils.