### PR TITLE
feat: Hide serialize_fn_map; add get_default_serialize_fn_map()

### DIFF
--- a/docs/source/guides/pipeline/create_pipeline.rst
+++ b/docs/source/guides/pipeline/create_pipeline.rst
@@ -209,7 +209,7 @@ it into processed :obj:`torch_brain.data.Data` object(s), and stores these insid
         # save data to disk
         self.update_status("Storing")
         with h5py.File(output_file_path, "w") as file:
-            data.to_hdf5(file, serialize_fn_map=serialize_fn_map)
+            data.to_hdf5(file)
 
 
 Most of the logic for implementing the |process| method will follow the tutorial

--- a/docs/source/guides/pipeline/openneuro_pipeline.rst
+++ b/docs/source/guides/pipeline/openneuro_pipeline.rst
@@ -376,9 +376,8 @@ Add custom processing beyond the default:
         
         # Save the result
         import h5py
-        from brainsets import serialize_fn_map
         with h5py.File(store_path, "w") as file:
-            data.to_hdf5(file, serialize_fn_map=serialize_fn_map)
+            data.to_hdf5(file)
 
 
 What's Next?

--- a/docs/source/guides/pipeline/prepare_data.rst
+++ b/docs/source/guides/pipeline/prepare_data.rst
@@ -29,7 +29,6 @@ The following is an example ``prepare_data.py`` script that can serve as a templ
     import h5py
 
     from torch_brain.data  import Data
-    from brainsets import serialize_fn_map
 
     def main():
         parser = argparse.ArgumentParser()
@@ -47,7 +46,7 @@ The following is an example ``prepare_data.py`` script that can serve as a templ
         # save data to disk
         path = os.path.join(args.output_dir, f"{session_id}.h5")
         with h5py.File(path, "w") as file:
-            data.to_hdf5(file, serialize_fn_map=serialize_fn_map)
+            data.to_hdf5(file)
 
 
     if __name__ == "__main__":

--- a/howto/MIGRATE_TO_v0.2.md
+++ b/howto/MIGRATE_TO_v0.2.md
@@ -52,6 +52,7 @@ See below for re-organization of modules in v0.2.0:
 | `from brainsets.utils.bids_utils import XYZ`              | `from torch_brain.utils.bids import XYZ`                       |
 | `from brainsets.processing.signal import XYZ`             | `from torch_brain.utils.signal import XYZ`                     |
 | `from brainsets.datasets import XYZ`                      | `from torch_brain.datasets import XYZ`                         |
+| `from brainsets import serialize_fn_map`                  | Deprecated; `Data.to_hdf5` now applies the default serialization automatically, so it no longer needs to be passed. Importable as `torch_brain.data.serialize_fn_map` for now (with a `DeprecationWarning`). |
 
 
 `brainsets` CLI remains the same as before.

--- a/howto/MIGRATE_TO_v0.2.md
+++ b/howto/MIGRATE_TO_v0.2.md
@@ -52,7 +52,7 @@ See below for re-organization of modules in v0.2.0:
 | `from brainsets.utils.bids_utils import XYZ`              | `from torch_brain.utils.bids import XYZ`                       |
 | `from brainsets.processing.signal import XYZ`             | `from torch_brain.utils.signal import XYZ`                     |
 | `from brainsets.datasets import XYZ`                      | `from torch_brain.datasets import XYZ`                         |
-| `from brainsets import serialize_fn_map`                  | Deprecated; `Data.to_hdf5` now applies the default serialization automatically, so it no longer needs to be passed. Importable as `torch_brain.data.serialize_fn_map` for now (with a `DeprecationWarning`). |
+| `from brainsets import serialize_fn_map`                  | Deprecated; `Data.to_hdf5` now applies the default serialization automatically, so it no longer needs to be passed. To extend the defaults, use `from torch_brain.data import get_default_serialize_fn_map` and pass the result to `Data.to_hdf5`. Still importable as `torch_brain.data.serialize_fn_map` for now (with a `DeprecationWarning`). |
 
 
 `brainsets` CLI remains the same as before.

--- a/tests/data/test_serialize.py
+++ b/tests/data/test_serialize.py
@@ -6,7 +6,8 @@ from enum import Enum
 import h5py
 import pytest
 
-from torch_brain.data import Data
+from torch_brain.data import Data, get_default_serialize_fn_map
+from torch_brain.data.serialization import _DEFAULT_SERIALIZE_FN_MAP
 
 
 @pytest.fixture
@@ -85,3 +86,17 @@ def test_default_datetime_serialize(test_filepath):
 
         assert d.recording_date == str(timestamp)
         assert d.nested.recording_date == str(timestamp)
+
+
+def test_get_default_serialize_fn_map_returns_copy():
+    # Test public extension path for adding more serialization functions.
+    # Adding a new serialize fn should not change the module's own dict.
+    serialize_fn_map = get_default_serialize_fn_map()
+
+    assert id(serialize_fn_map) != id(_DEFAULT_SERIALIZE_FN_MAP)
+    assert serialize_fn_map is not _DEFAULT_SERIALIZE_FN_MAP
+    assert serialize_fn_map == _DEFAULT_SERIALIZE_FN_MAP
+
+    serialize_fn_map[Enum] = lambda obj, serialize_fn_map=None: obj.name
+
+    assert Enum not in _DEFAULT_SERIALIZE_FN_MAP

--- a/tests/data/test_serialize.py
+++ b/tests/data/test_serialize.py
@@ -1,3 +1,4 @@
+import datetime
 import os
 import tempfile
 from enum import Enum
@@ -61,3 +62,26 @@ def test_serialize(test_filepath):
         assert d.nested_special_objects.special_item == "B"
         assert all(d.nested_special_objects.special_list == ["B", "A"])
         assert all(d.nested_special_objects.special_tuple == ("B", "A"))
+
+
+def test_default_datetime_serialize(test_filepath):
+    # When no serialize_fn_map is passed, to_hdf5 should fall back to the default
+    # map, which serializes datetime.datetime objects to their string form.
+    timestamp = datetime.datetime(2021, 1, 2, 3, 4, 5)
+
+    d = Data(
+        id="test",
+        recording_date=timestamp,
+        nested=Data(recording_date=timestamp),
+    )
+
+    with h5py.File(test_filepath, "w") as file:
+        d.to_hdf5(file)
+
+    del d
+
+    with h5py.File(test_filepath, "r") as file:
+        d = Data.from_hdf5(file)
+
+        assert d.recording_date == str(timestamp)
+        assert d.nested.recording_date == str(timestamp)

--- a/tests/test_new_dataset.py
+++ b/tests/test_new_dataset.py
@@ -14,7 +14,6 @@ from torch_brain.data import (
     RegularTimeSeries,
     SessionDescription,
     SubjectDescription,
-    serialize_fn_map,
 )
 from torch_brain.datasets import (
     Dataset,
@@ -92,19 +91,19 @@ def dummy_spiking_brainset(tmp_path):
 
     data = create_spiking_data(BRAINSET_ID, "alice", "session1", 1.0)
     with h5py.File(store_path / f"{data.session.id}.h5", "w") as f:
-        data.to_hdf5(f, serialize_fn_map=serialize_fn_map)
+        data.to_hdf5(f)
 
     data = create_spiking_data(BRAINSET_ID, "bob", "session2", 1.5)
     with h5py.File(store_path / f"{data.session.id}.h5", "w") as f:
-        data.to_hdf5(f, serialize_fn_map=serialize_fn_map)
+        data.to_hdf5(f)
 
     data = create_spiking_data(BRAINSET_ID, "bob", "session3", 0.9)
     with h5py.File(store_path / f"{data.session.id}.h5", "w") as f:
-        data.to_hdf5(f, serialize_fn_map=serialize_fn_map)
+        data.to_hdf5(f)
 
     data = create_spiking_data(BRAINSET_ID, "charlie", "session4", 2.0)
     with h5py.File(store_path / f"{data.session.id}.h5", "w") as f:
-        data.to_hdf5(f, serialize_fn_map=serialize_fn_map)
+        data.to_hdf5(f)
 
     return store_path
 
@@ -117,11 +116,11 @@ def dummy_multichannel_brainset(tmp_path):
 
     data = create_multichannel_data(BRAINSET_ID, "alice", "session1", 1.0)
     with h5py.File(store_path / f"{data.session.id}.h5", "w") as f:
-        data.to_hdf5(f, serialize_fn_map=serialize_fn_map)
+        data.to_hdf5(f)
 
     data = create_multichannel_data(BRAINSET_ID, "bob", "session2", 1.2)
     with h5py.File(store_path / f"{data.session.id}.h5", "w") as f:
-        data.to_hdf5(f, serialize_fn_map=serialize_fn_map)
+        data.to_hdf5(f)
 
     return store_path
 

--- a/torch_brain/data/__init__.py
+++ b/torch_brain/data/__init__.py
@@ -16,6 +16,28 @@ from .interval import Interval, LazyInterval
 from .irregular_ts import IrregularTimeSeries, LazyIrregularTimeSeries
 from .regular_ts import LazyRegularTimeSeries, RegularTimeSeries
 
+
+def __getattr__(name):
+    # `serialize_fn_map` was renamed to the private `_DEFAULT_SERIALIZE_FN_MAP`.
+    # Keep the old public name importable but deprecated; `Data.to_hdf5` now
+    # applies this default map automatically, so passing it explicitly is no
+    # longer necessary.
+    if name == "serialize_fn_map":
+        import warnings
+
+        from .serialization import _DEFAULT_SERIALIZE_FN_MAP
+
+        warnings.warn(
+            "torch_brain.data.serialize_fn_map is deprecated and will be removed "
+            "in a future version. Data.to_hdf5 now uses this default serialization "
+            "map automatically, so it no longer needs to be passed explicitly.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return _DEFAULT_SERIALIZE_FN_MAP
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
 __all__ = [
     "ArrayDict",
     "LazyArrayDict",

--- a/torch_brain/data/__init__.py
+++ b/torch_brain/data/__init__.py
@@ -15,26 +15,25 @@ from .descriptions import (
 from .interval import Interval, LazyInterval
 from .irregular_ts import IrregularTimeSeries, LazyIrregularTimeSeries
 from .regular_ts import LazyRegularTimeSeries, RegularTimeSeries
+from .serialization import get_default_serialize_fn_map
 
 
 def __getattr__(name):
-    # `serialize_fn_map` was renamed to the private `_DEFAULT_SERIALIZE_FN_MAP`.
-    # Keep the old public name importable but deprecated; `Data.to_hdf5` now
-    # applies this default map automatically, so passing it explicitly is no
-    # longer necessary.
+    # `serialize_fn_map` is deprecated: `Data.to_hdf5` now applies the default
+    # serialization map automatically, so passing it explicitly is no longer
+    # necessary. To extend the defaults, use `get_default_serialize_fn_map()`,
+    # which returns a fresh, safe-to-mutate copy.
     if name == "serialize_fn_map":
         import warnings
 
-        from .serialization import _DEFAULT_SERIALIZE_FN_MAP
-
         warnings.warn(
             "torch_brain.data.serialize_fn_map is deprecated and will be removed "
-            "in a future version. Data.to_hdf5 now uses this default serialization "
-            "map automatically, so it no longer needs to be passed explicitly.",
+            "in a future version. Data.to_hdf5 now uses the default serialization "
+            "map automatically; to extend it, use get_default_serialize_fn_map().",
             DeprecationWarning,
             stacklevel=2,
         )
-        return _DEFAULT_SERIALIZE_FN_MAP
+        return get_default_serialize_fn_map()
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
@@ -53,6 +52,7 @@ __all__ = [
     "SessionDescription",
     "SubjectDescription",
     "concat",
+    "get_default_serialize_fn_map",
 ]
 
 # Drives the generated API reference; see docs/source/api_reference.py.
@@ -91,7 +91,10 @@ __api_ref__ = {
         },
         {
             "title": "Utility Functions",
-            "autosummary": ["concat"],
+            "autosummary": [
+                "concat",
+                "get_default_serialize_fn_map",
+            ],
         },
     ],
 }

--- a/torch_brain/data/__init__.py
+++ b/torch_brain/data/__init__.py
@@ -15,7 +15,6 @@ from .descriptions import (
 from .interval import Interval, LazyInterval
 from .irregular_ts import IrregularTimeSeries, LazyIrregularTimeSeries
 from .regular_ts import LazyRegularTimeSeries, RegularTimeSeries
-from .serialization import serialize_fn_map
 
 __all__ = [
     "ArrayDict",
@@ -32,7 +31,6 @@ __all__ = [
     "SessionDescription",
     "SubjectDescription",
     "concat",
-    "serialize_fn_map",
 ]
 
 # Drives the generated API reference; see docs/source/api_reference.py.
@@ -72,10 +70,6 @@ __api_ref__ = {
         {
             "title": "Utility Functions",
             "autosummary": ["concat"],
-        },
-        {
-            "title": "Constants",
-            "autosummary": ["serialize_fn_map"],
         },
     ],
 }

--- a/torch_brain/data/data.py
+++ b/torch_brain/data/data.py
@@ -13,6 +13,7 @@ from .arraydict import ArrayDict, LazyArrayDict  # noqa: F401
 from .interval import Interval, LazyInterval  # noqa: F401
 from .irregular_ts import IrregularTimeSeries, LazyIrregularTimeSeries  # noqa: F401
 from .regular_ts import LazyRegularTimeSeries, RegularTimeSeries  # noqa: F401
+from .serialization import _DEFAULT_SERIALIZE_FN_MAP
 from .utils import _size_repr
 
 
@@ -304,14 +305,28 @@ class Data:
         out_dict = {k: v for k, v in self.__dict__.items() if k != "_file"}
         return copy.deepcopy(out_dict)
 
-    def to_hdf5(self, file, serialize_fn_map=None):
+    def to_hdf5(
+        self,
+        file: h5py.File | h5py.Group,
+        serialize_fn_map: dict[type, Callable] | None = None,
+    ):
         r"""Saves the data object to an HDF5 file. This method will also call the
-        `to_hdf5` method of all contained data objects, so that the entire data object
-        is saved to the HDF5 file, i.e. no need to call `to_hdf5` for each contained
-        data object.
+        ``to_hdf5`` method of all contained data objects, so that the entire data
+        object is saved to the HDF5 file, i.e. no need to call ``to_hdf5`` for each
+        contained data object.
 
         Args:
-            file: HDF5 file.
+            file: An open :class:`h5py.File` (or :class:`h5py.Group`) to write into.
+            serialize_fn_map: Optional dictionary mapping a Python type to a callable
+                that serializes values of that type into an `HDF5-compatible object
+                <https://docs.h5py.org/en/latest/faq.html#what-datatypes-are-supported>`_.
+                Use this for attributes whose types are not natively supported by
+                HDF5. If :obj:`None`, a default map is used that performs the
+                following serialization:
+
+                - :obj:`datetime.datetime` objects are converted to :obj:`str`
+
+                Defaults to :obj:`None`.
 
         Example ::
             >>> import h5py
@@ -320,6 +335,9 @@ class Data:
             >>> with h5py.File("data.h5", "w") as f:  # doctest: +SKIP
             ...     data.to_hdf5(f)
         """
+        if serialize_fn_map is None:
+            serialize_fn_map = _DEFAULT_SERIALIZE_FN_MAP
+
         for key in self.keys():
             value = getattr(self, key)
             if isinstance(value, (Data, ArrayDict)):
@@ -731,7 +749,7 @@ class Data:
 
 def _serialize(
     elem,
-    serialize_fn_map: dict[type | tuple[type, ...], Callable] | None = None,
+    serialize_fn_map: dict[type, Callable] | None = None,
 ):
     r"""
     General serialization function that handles object types that are not supported

--- a/torch_brain/data/data.py
+++ b/torch_brain/data/data.py
@@ -321,11 +321,8 @@ class Data:
                 that serializes values of that type into an `HDF5-compatible object
                 <https://docs.h5py.org/en/latest/faq.html#what-datatypes-are-supported>`_.
                 Use this for attributes whose types are not natively supported by
-                HDF5. If :obj:`None`, a default map is used that performs the
-                following serialization:
-
-                - :obj:`datetime.datetime` objects are converted to :obj:`str`
-
+                HDF5. If :obj:`None`, the map returned by
+                :func:`~torch_brain.data.get_default_serialize_fn_map` is used.
                 Defaults to :obj:`None`.
 
         Example ::

--- a/torch_brain/data/serialization.py
+++ b/torch_brain/data/serialization.py
@@ -10,3 +10,28 @@ def datetime_serialize_fn(obj, serialize_fn_map=None):
 _DEFAULT_SERIALIZE_FN_MAP: dict[type, Callable] = {
     datetime.datetime: datetime_serialize_fn,
 }
+
+
+def get_default_serialize_fn_map() -> dict[type, Callable]:
+    r"""Returns the default serialization map used when saving :class:`Data` to HDF5.
+
+    :meth:`torch_brain.data.Data.to_hdf5` uses this map to serialize attribute
+    values whose types HDF5 cannot store natively. By default it maps:
+
+    - :obj:`datetime.datetime` to :obj:`str`
+
+    A fresh copy is returned on every call, so mutating the result never
+    affects the global default. You can extend the returned map to support
+    additional types:
+
+    .. code:: python
+
+        serialize_fn_map = get_default_serialize_fn_map()
+        serialize_fn_map[MyType] = my_serialize_fn
+        data.to_hdf5(file, serialize_fn_map=serialize_fn_map)
+
+
+    Returns:
+        A copy of the default mapping from type to serialization function.
+    """
+    return dict(_DEFAULT_SERIALIZE_FN_MAP)

--- a/torch_brain/data/serialization.py
+++ b/torch_brain/data/serialization.py
@@ -7,7 +7,6 @@ def datetime_serialize_fn(obj, serialize_fn_map=None):
     return str(obj)
 
 
-serialize_fn_map: dict[type, Callable] = {
+_DEFAULT_SERIALIZE_FN_MAP: dict[type, Callable] = {
     datetime.datetime: datetime_serialize_fn,
 }
-r"""A dict that maps classes to their serialization functions"""

--- a/torch_brain/pipeline/brainsets-pipelines/allen_visual_coding_ophys_2016/pipeline.py
+++ b/torch_brain/pipeline/brainsets-pipelines/allen_visual_coding_ophys_2016/pipeline.py
@@ -36,7 +36,6 @@ from torch_brain.data import (
     RegularTimeSeries,
     SessionDescription,
     SubjectDescription,
-    serialize_fn_map,
 )
 from torch_brain.pipeline import BrainsetPipeline
 
@@ -200,7 +199,7 @@ class Pipeline(BrainsetPipeline):
         # save data to disk
         self.update_status("Storing")
         with h5py.File(store_path, "w") as file:
-            data.to_hdf5(file, serialize_fn_map=serialize_fn_map)
+            data.to_hdf5(file)
 
 
 def extract_behavior(nwb_dataset: BrainObservatoryNwbDataSet):

--- a/torch_brain/pipeline/brainsets-pipelines/churchland_shenoy_neural_2012/pipeline.py
+++ b/torch_brain/pipeline/brainsets-pipelines/churchland_shenoy_neural_2012/pipeline.py
@@ -24,7 +24,6 @@ from torch_brain.data import (
     Interval,
     IrregularTimeSeries,
     SessionDescription,
-    serialize_fn_map,
 )
 from torch_brain.pipeline import BrainsetPipeline
 from torch_brain.utils.dandi import (
@@ -178,7 +177,7 @@ class Pipeline(BrainsetPipeline):
 
         self.update_status("Storing")
         with h5py.File(store_path, "w") as file:
-            data.to_hdf5(file, serialize_fn_map=serialize_fn_map)
+            data.to_hdf5(file)
 
 
 def extract_trials(nwbfile, session_id):

--- a/torch_brain/pipeline/brainsets-pipelines/flint_slutzky_accurate_2012/pipeline.py
+++ b/torch_brain/pipeline/brainsets-pipelines/flint_slutzky_accurate_2012/pipeline.py
@@ -22,7 +22,6 @@ from torch_brain.data import (
     IrregularTimeSeries,
     SessionDescription,
     SubjectDescription,
-    serialize_fn_map,
 )
 from torch_brain.pipeline import BrainsetPipeline
 
@@ -170,7 +169,7 @@ class Pipeline(BrainsetPipeline):
 
         # save data to disk
         with h5py.File(store_path, "w") as file:
-            data.to_hdf5(file, serialize_fn_map=serialize_fn_map)
+            data.to_hdf5(file)
 
 
 def extract_units(mat):

--- a/torch_brain/pipeline/brainsets-pipelines/kemp_sleep_edf_2013/pipeline.py
+++ b/torch_brain/pipeline/brainsets-pipelines/kemp_sleep_edf_2013/pipeline.py
@@ -23,7 +23,6 @@ from torch_brain.data import (
     Interval,
     SessionDescription,
     SubjectDescription,
-    serialize_fn_map,
 )
 from torch_brain.pipeline import BrainsetPipeline
 from torch_brain.utils.mne import (
@@ -256,7 +255,7 @@ class Pipeline(BrainsetPipeline):
 
         self.update_status("Storing")
         with h5py.File(output_path, "w") as file:
-            data.to_hdf5(file, serialize_fn_map=serialize_fn_map)
+            data.to_hdf5(file)
 
         logging.info(f"Saved processed data to: {output_path}")
 

--- a/torch_brain/pipeline/brainsets-pipelines/neuroprobe_2025/pipeline.py
+++ b/torch_brain/pipeline/brainsets-pipelines/neuroprobe_2025/pipeline.py
@@ -31,7 +31,6 @@ from torch_brain.data import (
     Interval,
     RegularTimeSeries,
     SubjectDescription,
-    serialize_fn_map,
 )
 from torch_brain.pipeline import BrainsetPipeline
 
@@ -245,7 +244,7 @@ class Pipeline(BrainsetPipeline):
         self.update_status("Storing")
         path = self.processed_dir / download_output.path.name
         with h5py.File(path, "w") as file:
-            data.to_hdf5(file, serialize_fn_map=serialize_fn_map)
+            data.to_hdf5(file)
         logging.info(f"Saved data to {path}")
 
     def iterate_extract_splits(

--- a/torch_brain/pipeline/brainsets-pipelines/odoherty_sabes_nonhuman_2017/pipeline.py
+++ b/torch_brain/pipeline/brainsets-pipelines/odoherty_sabes_nonhuman_2017/pipeline.py
@@ -24,7 +24,6 @@ from torch_brain.data import (
     RegularTimeSeries,
     SessionDescription,
     SubjectDescription,
-    serialize_fn_map,
 )
 from torch_brain.pipeline import BrainsetPipeline
 from torch_brain.utils import calculate_sampling_rate
@@ -209,7 +208,7 @@ class Pipeline(BrainsetPipeline):
         # save data to disk
         self.update_status("Storing")
         with h5py.File(store_path, "w") as file:
-            data.to_hdf5(file, serialize_fn_map=serialize_fn_map)
+            data.to_hdf5(file)
 
 
 def extract_behavior(h5file):

--- a/torch_brain/pipeline/brainsets-pipelines/pei_pandarinath_nlb_2021/pipeline.py
+++ b/torch_brain/pipeline/brainsets-pipelines/pei_pandarinath_nlb_2021/pipeline.py
@@ -18,7 +18,6 @@ from torch_brain.data import (
     Interval,
     RegularTimeSeries,
     SessionDescription,
-    serialize_fn_map,
 )
 from torch_brain.pipeline import BrainsetPipeline
 from torch_brain.utils.dandi import (
@@ -164,7 +163,7 @@ class Pipeline(BrainsetPipeline):
 
         # save data to disk
         with h5py.File(store_path, "w") as file:
-            data.to_hdf5(file, serialize_fn_map=serialize_fn_map)
+            data.to_hdf5(file)
 
 
 def extract_trials(nwbfile):

--- a/torch_brain/pipeline/brainsets-pipelines/perich_miller_population_2018/pipeline.py
+++ b/torch_brain/pipeline/brainsets-pipelines/perich_miller_population_2018/pipeline.py
@@ -23,7 +23,6 @@ from torch_brain.data import (
     Interval,
     IrregularTimeSeries,
     SessionDescription,
-    serialize_fn_map,
 )
 from torch_brain.pipeline import BrainsetPipeline
 from torch_brain.utils.dandi import (
@@ -207,7 +206,7 @@ class Pipeline(BrainsetPipeline):
 
         self.update_status("Storing")
         with h5py.File(store_path, "w") as file:
-            data.to_hdf5(file, serialize_fn_map=serialize_fn_map)
+            data.to_hdf5(file)
 
 
 def extract_behavior(nwbfile):

--- a/torch_brain/pipeline/brainsets-pipelines/vollan_moser_alternating_2025/pipeline.py
+++ b/torch_brain/pipeline/brainsets-pipelines/vollan_moser_alternating_2025/pipeline.py
@@ -22,7 +22,6 @@ from torch_brain.data import (
     IrregularTimeSeries,
     SessionDescription,
     SubjectDescription,
-    serialize_fn_map,
 )
 from torch_brain.pipeline import BrainsetPipeline
 
@@ -314,7 +313,7 @@ class Pipeline(BrainsetPipeline):
 
         self.update_status("Storing")
         with h5py.File(store_path, "w") as file:
-            data.to_hdf5(file, serialize_fn_map=serialize_fn_map)
+            data.to_hdf5(file)
 
     def _process_sleep(self, fpath, session_id):
         """Process a sleep session from ``Dsleep``.
@@ -386,7 +385,7 @@ class Pipeline(BrainsetPipeline):
 
         self.update_status("Storing")
         with h5py.File(store_path, "w") as file:
-            data.to_hdf5(file, serialize_fn_map=serialize_fn_map)
+            data.to_hdf5(file)
 
 
 # ---------------------------------------------------------------------------

--- a/torch_brain/pipeline/openneuro.py
+++ b/torch_brain/pipeline/openneuro.py
@@ -34,7 +34,6 @@ from torch_brain.data import (
     DeviceDescription,
     SessionDescription,
     SubjectDescription,
-    serialize_fn_map,
 )
 from torch_brain.utils.bids import (
     build_bids_path,
@@ -536,7 +535,7 @@ class OpenNeuroPipeline(BrainsetPipeline, ABC):
 
         self.update_status("Storing")
         with h5py.File(store_path, "w") as file:
-            data.to_hdf5(file, serialize_fn_map=serialize_fn_map)
+            data.to_hdf5(file)
 
     def get_channel_name_remapping(
         self,


### PR DESCRIPTION
Previously, `torch_brain.data.serialize_fn_map` was a public constant that callers had to pass into `Data.to_hdf5`. This PR hides it behind a private default and makes `Data.to_hdf5` apply it automatically, so users no longer need to interact with `serialize_fn_map` unless they want custom serialization.

The default map now lives in the private constant `torch_brain.data.serialization._DEFAULT_SERIALIZE_FN_MAP`. For users who *do* want to extend it, we expose a public getter `get_default_serialize_fn_map()` which returns a fresh copy each call so mutating the result can never corrupt the global default (a very painful Python footgun):

```python
from torch_brain.data import get_default_serialize_fn_map

serialize_fn_map = get_default_serialize_fn_map()
serialize_fn_map[MyType] = my_serialize_fn
data.to_hdf5(file, serialize_fn_map=serialize_fn_map)
```

**Changes**

- `Data.to_hdf5` uses `_DEFAULT_SERIALIZE_FN_MAP` as its default (`serialize_fn_map=None`).
- Public extension point: `get_default_serialize_fn_map()` returns a safe-to-mutate copy of the defaults.
- Backwards compatibility: `torch_brain.data.serialize_fn_map` is still importable but emits `DeprecationWarning`.
- Updated Pipelines that passed `serialize_fn_map` explicitly, and previous tests.
- Tests added.
- Migration doc updated with info about this change.

Closes #286