### PR TITLE
chore: Prep for v0.2.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,16 +41,8 @@ models.
 **torch_brain** requires Python >= 3.10. To install a stable release:
 
 ```bash
-pip install torch torch_brain
+pip install torch torch_brain>=0.2
 ```
-
-> [!CAUTION]
-> Until we release `v0.2.0` on PyPI, you will have to install from GitHub
-> itself. See the [releases page](https://github.com/neuro-galaxy/torch_brain/releases)
-> for updates on releases.
-> ```bash
-> pip install torch git+https://github.com/neuro-galaxy/torch_brain
-> ```
 
 > [!TIP]
 > If you only need `torch_brain.data` and the data-preparation pipelines, you

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ models.
 **torch_brain** requires Python >= 3.10. To install a stable release:
 
 ```bash
-pip install torch torch_brain>=0.2
+pip install torch torch_brain
 ```
 
 > [!TIP]

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -31,6 +31,12 @@ If you encounter any bugs or have feature requests, please submit them to our
    :alt: Discord
 
 
+.. note::
+   We have merged `temporaldata` and `brainsets` into `torch_brain`.
+   If you are migrating from v0.1.x, please see this
+   `migration guide <https://github.com/neuro-galaxy/torch_brain/blob/main/howto/MIGRATE_TO_v0.2.md>`_.
+
+
 ----
 
 .. toctree::

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -32,7 +32,7 @@ If you encounter any bugs or have feature requests, please submit them to our
 
 
 .. note::
-   We have merged `temporaldata` and `brainsets` into `torch_brain`.
+   We have merged ``temporaldata`` and ``brainsets`` into ``torch_brain``.
    If you are migrating from v0.1.x, please see this
    `migration guide <https://github.com/neuro-galaxy/torch_brain/blob/main/howto/MIGRATE_TO_v0.2.md>`_.
 


### PR DESCRIPTION
Doc updates to prepare for `v0.2.0` release. Merge this just before publishing on PyPI.