### PR TITLE
chore: Fix doc build warning

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -111,6 +111,10 @@ plot_html_show_formats = False
 plot_formats = [("png", 110)]
 
 
+exclude_patterns = [
+    "notebooks/nlb_maze_minimal_example/nlb_maze_minimal_example.ipynb",
+]
+
 # Compile scss files into css files using sphinxcontrib-sass
 sass_src_dir, sass_out_dir = "scss", "generated/css/styles"
 sass_targets = {


### PR DESCRIPTION
This notebook is first preprocessed and copied to another file, which is included in the docs. So, sphinx shows warning that the original notebook is not included anywhere.

Closes #315
