### PR TITLE
chore: Split benchmark script by subpackage; rename data_benchmarks → benchmarks

### DIFF
--- a/.github/workflows/benchmarks-data.yml
+++ b/.github/workflows/benchmarks-data.yml
@@ -24,6 +24,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/benchmarks-data.yml
+++ b/.github/workflows/benchmarks-data.yml
@@ -1,0 +1,107 @@
+name: Benchmarks (data)
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+    paths:
+      - torch_brain/data/**
+      - pyproject.toml
+      - scripts/benchmarks/**
+      - .github/workflows/benchmarks-data.yml
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+jobs:
+  compare-with-base:
+    runs-on: ubuntu-latest
+    env:
+      BASE_REF: ${{ github.event.pull_request.base.ref }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Install package and dependencies
+        run: uv pip install --system -e ".[dev]"
+
+      - name: Fetch base branch
+        run: git fetch origin "$BASE_REF"
+
+      - name: Run benchmark comparison (base vs PR HEAD)
+        id: benchmark
+        run: |
+          set -o pipefail
+          uv run python scripts/benchmarks/compare.py --suite data "origin/$BASE_REF" HEAD | tee benchmark-report.txt
+
+      - name: Upsert PR benchmark comment
+        if: ${{ !cancelled() && hashFiles('benchmark-report.txt') != '' }}
+        uses: actions/github-script@v7
+        env:
+          BENCHMARK_REPORT_PATH: benchmark-report.txt
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+        with:
+          script: |
+            const fs = require("fs");
+            const marker = "<!-- benchmark-ci-report:data -->";
+            const reportPath = process.env.BENCHMARK_REPORT_PATH;
+            const baseRef = process.env.BASE_REF;
+            const report = fs.readFileSync(reportPath, "utf8");
+
+            const body = `${marker}
+            ## Benchmark comparison vs ${baseRef} (torch_brain.data)
+
+            Baseline: \`origin/${baseRef}\`
+            Target: \`HEAD\`
+
+            \`\`\`text
+            ${report}
+            \`\`\`
+            `;
+
+            const { owner, repo } = context.repo;
+            const issue_number = context.issue.number;
+
+            const comments = await github.paginate(
+              github.rest.issues.listComments,
+              {
+                owner,
+                repo,
+                issue_number,
+                per_page: 100,
+              }
+            );
+
+            const existing = comments.find(
+              (comment) =>
+                comment.user.type === "Bot" &&
+                comment.body &&
+                comment.body.includes(marker)
+            );
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner,
+                repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number,
+                body,
+              });
+            }

--- a/.github/workflows/benchmarks-utils.yml
+++ b/.github/workflows/benchmarks-utils.yml
@@ -24,6 +24,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/benchmarks-utils.yml
+++ b/.github/workflows/benchmarks-utils.yml
@@ -1,13 +1,13 @@
-name: Benchmarks
+name: Benchmarks (utils)
 
 on:
   pull_request:
     types: [opened, reopened, synchronize]
     paths:
-      - torch_brain/data/**
+      - torch_brain/utils/**
       - pyproject.toml
-      - scripts/data_benchmarks/**
-      - .github/workflows/benchmarks.yml
+      - scripts/benchmarks/**
+      - .github/workflows/benchmarks-utils.yml
 
 permissions:
   contents: read
@@ -43,7 +43,7 @@ jobs:
         id: benchmark
         run: |
           set -o pipefail
-          uv run python scripts/data_benchmarks/compare.py "origin/$BASE_REF" HEAD | tee benchmark-report.txt
+          uv run python scripts/benchmarks/compare.py --suite utils "origin/$BASE_REF" HEAD | tee benchmark-report.txt
 
       - name: Upsert PR benchmark comment
         if: ${{ !cancelled() && hashFiles('benchmark-report.txt') != '' }}
@@ -54,13 +54,13 @@ jobs:
         with:
           script: |
             const fs = require("fs");
-            const marker = "<!-- benchmark-ci-report -->";
+            const marker = "<!-- benchmark-ci-report:utils -->";
             const reportPath = process.env.BENCHMARK_REPORT_PATH;
             const baseRef = process.env.BASE_REF;
             const report = fs.readFileSync(reportPath, "utf8");
 
             const body = `${marker}
-            ## Benchmark comparison vs ${baseRef}
+            ## Benchmark comparison vs ${baseRef} (torch_brain.utils)
 
             Baseline: \`origin/${baseRef}\`
             Target: \`HEAD\`

--- a/scripts/benchmarks/bench_data.py
+++ b/scripts/benchmarks/bench_data.py
@@ -1,38 +1,25 @@
-"""Benchmark suite for torch_brain.data.
+"""torch_brain.data benchmarks.
 
-Benchmarks are modeled on real torch_brain workloads: Data.slice() on
-realistic lazy-loaded recording objects, IrregularTimeSeries/Interval
-inner-loop slicing, and Interval set operations at production-typical sizes.
+Data.slice() on realistic lazy/in-memory recordings, IrregularTimeSeries /
+RegularTimeSeries / Interval inner-loop slicing, Interval set operations, and
+ArrayDict / LazyInterval access, all at production-typical sizes. The fixtures
+that build the synthetic recordings live here alongside the benchmarks.
 
-Usage:
-    uv run python scripts/data_benchmarks/benchmark.py
-    uv run python scripts/data_benchmarks/benchmark.py --json
-    uv run python scripts/data_benchmarks/benchmark.py --save results.jsonl
-
-Set TORCH_BRAIN_SOURCE to override where torch_brain.data is imported from
-(used by compare.py to benchmark code from arbitrary commits).
+The sys.path shim that resolves ``torch_brain`` lives in benchmark.py and runs
+before this module is imported, so the imports below pick up the code under
+test (see TORCH_BRAIN_SOURCE).
 """
 
 from __future__ import annotations
 
-import argparse
-import json
 import os
-import sys
 import tempfile
-import time
-import timeit
-import traceback
 
-_source = os.environ.get(
-    "TORCH_BRAIN_SOURCE", os.path.join(os.path.dirname(__file__), "..", "..")
-)
-sys.path.insert(0, _source)
+import h5py
+import numpy as np
+from harness import bench
 
-import h5py  # noqa: E402
-import numpy as np  # noqa: E402
-
-from torch_brain.data import (  # noqa: E402
+from torch_brain.data import (
     ArrayDict,
     Data,
     Interval,
@@ -41,11 +28,9 @@ from torch_brain.data import (  # noqa: E402
     RegularTimeSeries,
 )
 
-
-def _bench(label: str, stmt, number: int) -> dict:
-    times = timeit.repeat(stmt, number=number, repeat=5)
-    mean_us = np.mean(times) / number * 1e6
-    return {"label": label, "number": number, "mean_us": round(mean_us, 3)}
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
 
 
 def _make_disjoint_intervals(n, min_gap=1.0, min_dur=0.5, max_dur=2.0, seed=42):
@@ -197,7 +182,7 @@ def bench_data_slice_lazy():
             def go():
                 lazy_data.slice(300.0, 301.0)
 
-            return _bench("Data.slice() (lazy, realistic)", go, number=200)
+            return bench("Data.slice() (lazy, realistic)", go, number=200)
     finally:
         os.unlink(path)
 
@@ -209,7 +194,7 @@ def bench_data_slice_inmemory():
     def go():
         data.slice(300.0, 301.0)
 
-    return _bench("Data.slice() (in-memory)", go, number=500)
+    return bench("Data.slice() (in-memory)", go, number=500)
 
 
 def bench_its_slice():
@@ -227,7 +212,7 @@ def bench_its_slice():
     def go():
         its.slice(500.0, 501.0)
 
-    return _bench("IrregularTimeSeries.slice()", go, number=1_000)
+    return bench("IrregularTimeSeries.slice()", go, number=1_000)
 
 
 def bench_rts_slice():
@@ -243,7 +228,7 @@ def bench_rts_slice():
     def go():
         rts.slice(500.0, 501.0)
 
-    return _bench("RegularTimeSeries.slice()", go, number=1_000)
+    return bench("RegularTimeSeries.slice()", go, number=1_000)
 
 
 def bench_interval_slice():
@@ -255,7 +240,7 @@ def bench_interval_slice():
     def go():
         iv.slice(500.0, 501.0)
 
-    return _bench("Interval.slice()", go, number=2_000)
+    return bench("Interval.slice()", go, number=2_000)
 
 
 def bench_interval_and_single():
@@ -266,7 +251,7 @@ def bench_interval_and_single():
     def go():
         d1 & single
 
-    return _bench("Interval.__and__ (1k&single)", go, number=1_000)
+    return bench("Interval.__and__ (1k&single)", go, number=1_000)
 
 
 def bench_interval_and_multi():
@@ -277,7 +262,7 @@ def bench_interval_and_multi():
     def go():
         d1 & d2
 
-    return _bench("Interval.__and__ (1k&100)", go, number=200)
+    return bench("Interval.__and__ (1k&100)", go, number=200)
 
 
 def bench_interval_or():
@@ -288,7 +273,7 @@ def bench_interval_or():
     def go():
         d1 | d2
 
-    return _bench("Interval.__or__ (1k|100)", go, number=200)
+    return bench("Interval.__or__ (1k|100)", go, number=200)
 
 
 def bench_interval_difference():
@@ -299,7 +284,7 @@ def bench_interval_difference():
     def go():
         d1.difference(d2)
 
-    return _bench("Interval.difference (1k-100)", go, number=200)
+    return bench("Interval.difference (1k-100)", go, number=200)
 
 
 def bench_arraydict_keys():
@@ -309,7 +294,7 @@ def bench_arraydict_keys():
     def go():
         ad.keys()
 
-    return _bench("ArrayDict.keys() x100k", go, number=100_000)
+    return bench("ArrayDict.keys() x100k", go, number=100_000)
 
 
 def bench_lazy_interval_access():
@@ -356,15 +341,11 @@ def bench_lazy_interval_access():
                 _ = lazy.target_pos_x
                 _ = lazy.target_pos_y
 
-            return _bench("LazyInterval access (10 attrs)", go, number=2_000)
+            return bench("LazyInterval access (10 attrs)", go, number=2_000)
     finally:
         if os.path.exists(path):
             os.unlink(path)
 
-
-# ---------------------------------------------------------------------------
-# Runner
-# ---------------------------------------------------------------------------
 
 BENCHMARKS = [
     bench_data_slice_lazy,
@@ -379,46 +360,3 @@ BENCHMARKS = [
     bench_arraydict_keys,
     bench_lazy_interval_access,
 ]
-
-
-def main():
-    parser = argparse.ArgumentParser(description="Run torch_brain.data benchmarks.")
-    parser.add_argument("--json", action="store_true", help="Output results as JSON")
-    parser.add_argument(
-        "--save", type=str, default=None, help="Append results to a JSONL file"
-    )
-    args = parser.parse_args()
-
-    results = []
-    if not args.json:
-        print(f"{'Benchmark':<42} {'Iters':>8} {'Mean (µs)':>12}")
-        print("-" * 65)
-
-    for bench_fn in BENCHMARKS:
-        try:
-            r = bench_fn()
-        except Exception:
-            r = {"label": bench_fn.__name__, "error": traceback.format_exc()}
-        results.append(r)
-        if not args.json:
-            if "error" in r:
-                print(f"{r['label']:<42} {'ERROR':>8} {'---':>12}")
-            else:
-                print(f"{r['label']:<42} {r['number']:>8} {r['mean_us']:>12.3f}")
-
-    if args.json:
-        print(json.dumps({"results": results}))
-
-    if args.save:
-        record = {
-            "timestamp": time.strftime("%Y-%m-%d %H:%M:%S"),
-            "results": results,
-        }
-        with open(args.save, "a") as f:
-            f.write(json.dumps(record) + "\n")
-        if not args.json:
-            print(f"\nResults saved to {args.save}")
-
-
-if __name__ == "__main__":
-    main()

--- a/scripts/benchmarks/bench_utils.py
+++ b/scripts/benchmarks/bench_utils.py
@@ -1,0 +1,97 @@
+"""torch_brain.utils benchmarks.
+
+bin_spikes over spike windows at production-typical sizes. bin_spikes is
+imported lazily inside the driver (not at module scope) so importing this
+module never requires torch_brain.utils to exist -- the rest of the suite then
+still runs against commits/sources predating the module, where only the
+bin_spikes benchmarks error out in isolation.
+
+The sys.path shim that resolves ``torch_brain`` lives in benchmark.py and runs
+before this module is imported (see TORCH_BRAIN_SOURCE).
+"""
+
+from __future__ import annotations
+
+import numpy as np
+from harness import bench
+
+from torch_brain.data import Interval, IrregularTimeSeries
+
+
+def _run_bin_spikes(label, n_units, n_bins, n_spikes, duration, number):
+    """Shared driver: build one spike window and time bin_spikes over it.
+
+    bin_spikes is imported lazily so the rest of the suite still runs against
+    commits/sources where torch_brain.utils is unavailable.
+    """
+    from torch_brain.utils.binning import bin_spikes
+
+    rng = np.random.RandomState(42)
+    bin_size = duration / n_bins
+    ts = np.sort(rng.uniform(0.0, duration, n_spikes))
+    spikes = IrregularTimeSeries(
+        timestamps=ts,
+        unit_index=rng.randint(0, n_units, n_spikes),
+        domain=Interval(0.0, duration),
+    )
+
+    def go():
+        bin_spikes(spikes, num_units=n_units, bin_size=bin_size)
+
+    return bench(label, go, number=number)
+
+
+def bench_bin_spikes_realistic():
+    """Real per-__getitem__ session window: 1s, 358 units, 20 bins (~3.5k)."""
+    return _run_bin_spikes(
+        "bin_spikes (1s, 358u, 20 bins)",
+        n_units=358,
+        n_bins=20,
+        n_spikes=3_538,
+        duration=1.0,
+        number=2_000,
+    )
+
+
+def bench_bin_spikes_many_units():
+    """Large population, coarse bins: 1s, 1024 units, 20 bins (~10k)."""
+    return _run_bin_spikes(
+        "bin_spikes (1s, 1024u, 20 bins)",
+        n_units=1024,
+        n_bins=20,
+        n_spikes=10_000,
+        duration=1.0,
+        number=2_000,
+    )
+
+
+def bench_bin_spikes_fine_bins():
+    """Fine time resolution: 1s, 358 units, 200 bins (5ms bins, ~3.5k)."""
+    return _run_bin_spikes(
+        "bin_spikes (1s, 358u, 200 bins)",
+        n_units=358,
+        n_bins=200,
+        n_spikes=3_538,
+        duration=1.0,
+        number=2_000,
+    )
+
+
+def bench_bin_spikes_large():
+    """Long window + large population: 10s, 1024 units, 500 bins (~50k)."""
+    return _run_bin_spikes(
+        "bin_spikes (10s, 1024u, 500 bins)",
+        n_units=1024,
+        n_bins=500,
+        n_spikes=50_000,
+        duration=10.0,
+        number=500,
+    )
+
+
+BENCHMARKS = [
+    bench_bin_spikes_realistic,
+    bench_bin_spikes_many_units,
+    bench_bin_spikes_fine_bins,
+    bench_bin_spikes_large,
+]

--- a/scripts/benchmarks/benchmark.py
+++ b/scripts/benchmarks/benchmark.py
@@ -1,0 +1,85 @@
+"""Benchmark suite for torch_brain.
+
+Benchmarks are modeled on real torch_brain workloads: Data.slice() on
+realistic lazy-loaded recording objects, IrregularTimeSeries/Interval
+inner-loop slicing, Interval set operations, and bin_spikes, all at
+production-typical sizes. Benchmarks are grouped by subpackage:
+bench_data.py (torch_brain.data) and bench_utils.py (torch_brain.utils);
+the shared timing helper lives in harness.py.
+
+Usage:
+    uv run python scripts/benchmarks/benchmark.py
+    uv run python scripts/benchmarks/benchmark.py --json
+    uv run python scripts/benchmarks/benchmark.py --save results.jsonl
+
+Set TORCH_BRAIN_SOURCE to override where torch_brain is imported from (used by
+compare.py to benchmark code from arbitrary commits).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+import traceback
+
+_source = os.environ.get(
+    "TORCH_BRAIN_SOURCE", os.path.join(os.path.dirname(__file__), "..", "..")
+)
+sys.path.insert(0, _source)
+
+# Imported after the sys.path shim above so their top-level torch_brain imports
+# resolve to the code under test.
+import bench_data  # noqa: E402
+import bench_utils  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Runner
+# ---------------------------------------------------------------------------
+
+BENCHMARKS = bench_data.BENCHMARKS + bench_utils.BENCHMARKS
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Run torch_brain benchmarks.")
+    parser.add_argument("--json", action="store_true", help="Output results as JSON")
+    parser.add_argument(
+        "--save", type=str, default=None, help="Append results to a JSONL file"
+    )
+    args = parser.parse_args()
+
+    results = []
+    if not args.json:
+        print(f"{'Benchmark':<42} {'Iters':>8} {'Mean (µs)':>12}")
+        print("-" * 65)
+
+    for bench_fn in BENCHMARKS:
+        try:
+            r = bench_fn()
+        except Exception:
+            r = {"label": bench_fn.__name__, "error": traceback.format_exc()}
+        results.append(r)
+        if not args.json:
+            if "error" in r:
+                print(f"{r['label']:<42} {'ERROR':>8} {'---':>12}")
+            else:
+                print(f"{r['label']:<42} {r['number']:>8} {r['mean_us']:>12.3f}")
+
+    if args.json:
+        print(json.dumps({"results": results}))
+
+    if args.save:
+        record = {
+            "timestamp": time.strftime("%Y-%m-%d %H:%M:%S"),
+            "results": results,
+        }
+        with open(args.save, "a") as f:
+            f.write(json.dumps(record) + "\n")
+        if not args.json:
+            print(f"\nResults saved to {args.save}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/benchmarks/benchmark.py
+++ b/scripts/benchmarks/benchmark.py
@@ -11,6 +11,7 @@ Usage:
     uv run python scripts/benchmarks/benchmark.py
     uv run python scripts/benchmarks/benchmark.py --json
     uv run python scripts/benchmarks/benchmark.py --save results.jsonl
+    uv run python scripts/benchmarks/benchmark.py --suite data
 
 Set TORCH_BRAIN_SOURCE to override where torch_brain is imported from (used by
 compare.py to benchmark code from arbitrary commits).
@@ -39,7 +40,11 @@ import bench_utils  # noqa: E402
 # Runner
 # ---------------------------------------------------------------------------
 
-BENCHMARKS = bench_data.BENCHMARKS + bench_utils.BENCHMARKS
+SUITES = {
+    "data": bench_data.BENCHMARKS,
+    "utils": bench_utils.BENCHMARKS,
+    "all": bench_data.BENCHMARKS + bench_utils.BENCHMARKS,
+}
 
 
 def main():
@@ -48,6 +53,12 @@ def main():
     parser.add_argument(
         "--save", type=str, default=None, help="Append results to a JSONL file"
     )
+    parser.add_argument(
+        "--suite",
+        choices=sorted(SUITES),
+        default="all",
+        help="Which benchmark suite to run (default: all)",
+    )
     args = parser.parse_args()
 
     results = []
@@ -55,7 +66,7 @@ def main():
         print(f"{'Benchmark':<42} {'Iters':>8} {'Mean (µs)':>12}")
         print("-" * 65)
 
-    for bench_fn in BENCHMARKS:
+    for bench_fn in SUITES[args.suite]:
         try:
             r = bench_fn()
         except Exception:

--- a/scripts/benchmarks/compare.py
+++ b/scripts/benchmarks/compare.py
@@ -1,13 +1,13 @@
-"""Compare torch_brain.data benchmarks across git commits.
+"""Compare torch_brain benchmarks across git commits.
 
-Extracts torch_brain.data source from arbitrary commits via `git archive` and
+Extracts torch_brain source from arbitrary commits via `git archive` and
 runs the current benchmark.py against each, then displays a side-by-side
 comparison table.
 
 Usage:
-    uv run python scripts/data_benchmarks/compare.py                      # benchmark working tree
-    uv run python scripts/data_benchmarks/compare.py <commit>              # <commit> vs working tree
-    uv run python scripts/data_benchmarks/compare.py <commitA> <commitB>   # commitA vs commitB
+    uv run python scripts/benchmarks/compare.py                      # benchmark working tree
+    uv run python scripts/benchmarks/compare.py <commit>              # <commit> vs working tree
+    uv run python scripts/benchmarks/compare.py <commitA> <commitB>   # commitA vs commitB
 
 Options:
     --save PATH   Append comparison results as JSONL to PATH.
@@ -48,30 +48,20 @@ def short_hash(full_hash: str) -> str:
     return full_hash[:10]
 
 
-def extract_source(commit: str) -> str:
-    """Extract torch_brain/data/ from a commit into a temp directory.
+def _archive_pathspec(commit: str, pathspec: str, tmpdir: str) -> str | None:
+    """Extract a single pathspec from a commit into tmpdir.
 
-    Only the data subpackage is extracted, and a stub torch_brain/__init__.py
-    is written so that ``from torch_brain.data import ...`` resolves to the
-    extracted code without triggering the full package's imports (which may
-    pull in heavy dependencies like torch).
+    Returns None on success, or an error string on failure (so callers can
+    decide whether the failure is fatal).
     """
-    tmpdir = tempfile.mkdtemp(prefix="tdbench_")
     git_proc = subprocess.run(
-        ["git", "archive", commit, "--", "torch_brain/data/"],
+        ["git", "archive", commit, "--", pathspec],
         cwd=REPO_ROOT,
         capture_output=True,
         check=False,
     )
     if git_proc.returncode != 0:
-        shutil.rmtree(tmpdir, ignore_errors=True)
-        print(
-            (
-                f"Error: git archive failed for {short_hash(commit)}: "
-                f"{git_proc.stderr.decode(errors='replace').strip()}"
-            ),
-        )
-        sys.exit(1)
+        return f"git archive: {git_proc.stderr.decode(errors='replace').strip()}"
 
     tar_proc = subprocess.run(
         ["tar", "xf", "-", "-C", tmpdir],
@@ -80,14 +70,38 @@ def extract_source(commit: str) -> str:
         check=False,
     )
     if tar_proc.returncode != 0:
+        return f"tar: {tar_proc.stderr.decode(errors='replace').strip()}"
+
+    return None
+
+
+def extract_source(commit: str) -> str:
+    """Extract torch_brain source needed by the benchmarks into a temp dir.
+
+    torch_brain/data/ is required; torch_brain/utils/ is extracted best-effort
+    so the bin_spikes benchmark can import (older commits without it simply
+    skip that one benchmark). A stub torch_brain/__init__.py is written so
+    that ``from torch_brain.data import ...`` resolves to the extracted code
+    without triggering the full package's imports (which may pull in heavy
+    dependencies like torch).
+    """
+    tmpdir = tempfile.mkdtemp(prefix="tdbench_")
+
+    err = _archive_pathspec(commit, "torch_brain/data/", tmpdir)
+    if err is not None:
         shutil.rmtree(tmpdir, ignore_errors=True)
-        print(
-            (
-                f"Error: tar extraction failed for {short_hash(commit)}: "
-                f"{tar_proc.stderr.decode(errors='replace').strip()}"
-            ),
-        )
+        print(f"Error: extracting torch_brain/data/ for {short_hash(commit)}: {err}")
         sys.exit(1)
+
+    # Best-effort: absent on commits predating the module; the bin_spikes
+    # benchmark then errors in isolation instead of breaking the whole run.
+    utils_err = _archive_pathspec(commit, "torch_brain/utils/", tmpdir)
+    if utils_err is not None:
+        print(
+            f"Note: torch_brain/utils/ unavailable for {short_hash(commit)} "
+            f"({utils_err}); bin_spikes benchmark will be skipped.",
+            file=sys.stderr,
+        )
 
     # Write a minimal stub so `import torch_brain` succeeds without
     # pulling in the real package's __init__.py and its heavy deps.
@@ -182,11 +196,11 @@ def print_comparison(
 
 def main():
     parser = argparse.ArgumentParser(
-        description="Compare torch_brain.data benchmarks across git commits.",
+        description="Compare torch_brain benchmarks across git commits.",
         epilog="Examples:\n"
-        "  uv run python scripts/data_benchmarks/compare.py\n"
-        "  uv run python scripts/data_benchmarks/compare.py abc123\n"
-        "  uv run python scripts/data_benchmarks/compare.py abc123 def456\n",
+        "  uv run python scripts/benchmarks/compare.py\n"
+        "  uv run python scripts/benchmarks/compare.py abc123\n"
+        "  uv run python scripts/benchmarks/compare.py abc123 def456\n",
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     parser.add_argument(

--- a/scripts/benchmarks/compare.py
+++ b/scripts/benchmarks/compare.py
@@ -10,7 +10,8 @@ Usage:
     uv run python scripts/benchmarks/compare.py <commitA> <commitB>   # commitA vs commitB
 
 Options:
-    --save PATH   Append comparison results as JSONL to PATH.
+    --save PATH    Append comparison results as JSONL to PATH.
+    --suite NAME   Which benchmark suite to run: data, utils, or all (default: all).
 """
 
 from __future__ import annotations
@@ -112,7 +113,9 @@ def extract_source(commit: str) -> str:
     return tmpdir
 
 
-def run_benchmark(source_dir: str | None, label: str) -> list[dict] | None:
+def run_benchmark(
+    source_dir: str | None, label: str, suite: str = "all"
+) -> list[dict] | None:
     """Run benchmark.py, optionally overriding the import source.
 
     Returns the results list, or ``None`` if the benchmark subprocess failed
@@ -124,7 +127,7 @@ def run_benchmark(source_dir: str | None, label: str) -> list[dict] | None:
 
     print(f"Running benchmarks for {label}...", file=sys.stderr)
     result = subprocess.run(
-        [sys.executable, BENCH_SCRIPT, "--json"],
+        [sys.executable, BENCH_SCRIPT, "--json", "--suite", suite],
         capture_output=True,
         text=True,
         env=env,
@@ -209,6 +212,12 @@ def main():
     parser.add_argument(
         "--save", type=str, default=None, help="Append results to a JSONL file"
     )
+    parser.add_argument(
+        "--suite",
+        choices=["data", "utils", "all"],
+        default="all",
+        help="Which benchmark suite to run (default: all)",
+    )
     args = parser.parse_args()
 
     if len(args.commits) > 2:
@@ -218,7 +227,7 @@ def main():
     had_failures = False
     try:
         if len(args.commits) == 0:
-            results = run_benchmark(None, "working tree")
+            results = run_benchmark(None, "working tree", args.suite)
             if results is None:
                 had_failures = True
             else:
@@ -237,8 +246,8 @@ def main():
             tmpdir = extract_source(commit)
             tmpdirs.append(tmpdir)
 
-            results_a = run_benchmark(tmpdir, label_a)
-            results_b = run_benchmark(None, "working tree")
+            results_a = run_benchmark(tmpdir, label_a, args.suite)
+            results_b = run_benchmark(None, "working tree", args.suite)
 
             if results_a is None or results_b is None:
                 had_failures = True
@@ -269,8 +278,8 @@ def main():
             tmpdir_b = extract_source(commit_b)
             tmpdirs.append(tmpdir_b)
 
-            results_a = run_benchmark(tmpdir_a, label_a)
-            results_b = run_benchmark(tmpdir_b, label_b)
+            results_a = run_benchmark(tmpdir_a, label_a, args.suite)
+            results_b = run_benchmark(tmpdir_b, label_b, args.suite)
 
             if results_a is None or results_b is None:
                 had_failures = True

--- a/scripts/benchmarks/harness.py
+++ b/scripts/benchmarks/harness.py
@@ -1,0 +1,19 @@
+"""Shared benchmark harness: the timeit-based timing helper.
+
+Kept in its own module so both bench_data and bench_utils can import it without
+depending on benchmark.py (the entry point), which would create an import
+cycle. The TORCH_BRAIN_SOURCE / sys.path shim lives in benchmark.py and runs
+before either benchmark module is imported.
+"""
+
+from __future__ import annotations
+
+import timeit
+
+import numpy as np
+
+
+def bench(label: str, stmt, number: int) -> dict:
+    times = timeit.repeat(stmt, number=number, repeat=5)
+    mean_us = np.mean(times) / number * 1e6
+    return {"label": label, "number": number, "mean_us": round(mean_us, 3)}

--- a/scripts/benchmarks/harness.py
+++ b/scripts/benchmarks/harness.py
@@ -6,8 +6,6 @@ cycle. The TORCH_BRAIN_SOURCE / sys.path shim lives in benchmark.py and runs
 before either benchmark module is imported.
 """
 
-from __future__ import annotations
-
 import timeit
 
 import numpy as np


### PR DESCRIPTION
## Summary
- Added benchmarks for utils (binning for now).
- Split benchmark CI into two path-scoped workflows: `benchmarks-data.yml` (triggers on `torch_brain/data/**`) and `benchmarks-utils.yml` (triggers on `torch_brain/utils/**`), each posting its own PR comment.
- Added `--suite {data,utils,all}` to `benchmark.py`/`compare.py` so each workflow runs only the relevant suite.
- Fixed stale `scripts/data_benchmarks/**` path filter left over from the `scripts/benchmarks/` rename.
