### PR TITLE
fix: rebind logging handlers to each pipeline item's log file

### DIFF
--- a/tests/pipeline/test_pipeline_logging.py
+++ b/tests/pipeline/test_pipeline_logging.py
@@ -16,7 +16,8 @@ from torch_brain.pipeline.pipeline import BrainsetPipeline
 
 
 class _LoggingPipeline(BrainsetPipeline):
-    """Minimal pipeline whose download() emits a log record."""
+    """Minimal pipeline whose download() emits a log record and whose
+    process() prints to stdout."""
 
     brainset_id = "logging_test"
 
@@ -29,7 +30,7 @@ class _LoggingPipeline(BrainsetPipeline):
         return None
 
     def process(self, download_output):
-        pass
+        print("hello from process")
 
 
 @pytest.fixture(autouse=True)
@@ -68,6 +69,16 @@ def test_logging_lands_in_per_item_log_file(pipeline, tmp_path):
 
     log_file = tmp_path / "processed" / "pipeline_logs" / "item0.err"
     assert "hello from download" in log_file.read_text()
+
+
+def test_print_output_lands_in_per_item_out_file(pipeline, tmp_path):
+    # print() goes through plain sys.stdout redirection (no logging handler
+    # involved), so this isn't exercising the bug above — it just confirms
+    # _redirect_stdio's other half, the .out file, behaves as expected.
+    pipeline._run_item_on_parallel_worker(pd.Series({"Index": "item0"}))
+
+    log_file = tmp_path / "processed" / "pipeline_logs" / "item0.out"
+    assert "hello from process" in log_file.read_text()
 
 
 def test_restores_logging_handlers_after_item_runs(pipeline, tmp_path):

--- a/tests/pipeline/test_pipeline_logging.py
+++ b/tests/pipeline/test_pipeline_logging.py
@@ -1,0 +1,81 @@
+"""Tests for the per-item logging/stdio redirection in BrainsetPipeline.
+
+Regression coverage for a bug where a pipeline calling `logging.basicConfig()`
+at import time (several brainsets pipelines do) would bind its log handler to
+the stream that was current *then*, rather than the one `_redirect_stdio`
+later swaps in for each manifest item. Log records would then bypass the
+per-item `pipeline_logs/<id>.err` file entirely.
+"""
+
+import logging
+
+import pandas as pd
+import pytest
+
+from torch_brain.pipeline.pipeline import BrainsetPipeline
+
+
+class _LoggingPipeline(BrainsetPipeline):
+    """Minimal pipeline whose download() emits a log record."""
+
+    brainset_id = "logging_test"
+
+    @classmethod
+    def get_manifest(cls, raw_dir, args):
+        return pd.DataFrame({"file": ["a"]})
+
+    def download(self, manifest_item):
+        logging.info("hello from download")
+        return None
+
+    def process(self, download_output):
+        pass
+
+
+@pytest.fixture(autouse=True)
+def _restore_logging_state():
+    """Prevent basicConfig(force=True) calls in these tests from leaking
+    into other test files."""
+    root_logger = logging.getLogger()
+    handlers_before = root_logger.handlers[:]
+    level_before = root_logger.level
+    yield
+    root_logger.handlers[:] = handlers_before
+    root_logger.setLevel(level_before)
+
+
+@pytest.fixture
+def pipeline(tmp_path):
+    return _LoggingPipeline(
+        raw_dir=tmp_path / "raw",
+        processed_dir=tmp_path / "processed",
+        args=None,
+    )
+
+
+def test_logging_lands_in_per_item_log_file(pipeline, tmp_path):
+    # Simulate a pipeline module that already called `logging.basicConfig()`
+    # at import time, binding a handler to whatever stream was current then
+    # (here: the test process's real stderr, captured before any redirect).
+    # A plain StreamHandler is added instead of calling
+    # `logging.basicConfig(force=True)`, which would tear down pytest's own
+    # log-capture handler on the root logger.
+    root_logger = logging.getLogger()
+    root_logger.setLevel(logging.INFO)
+    root_logger.addHandler(logging.StreamHandler())
+
+    pipeline._run_item_on_parallel_worker(pd.Series({"Index": "item0"}))
+
+    log_file = tmp_path / "processed" / "pipeline_logs" / "item0.err"
+    assert "hello from download" in log_file.read_text()
+
+
+def test_restores_logging_handlers_after_item_runs(pipeline, tmp_path):
+    root_logger = logging.getLogger()
+    handlers_before = root_logger.handlers[:]
+    level_before = root_logger.level
+
+    pipeline._run_item_on_parallel_worker(pd.Series({"Index": "item0"}))
+
+    assert root_logger.handlers == handlers_before
+    assert root_logger.level == level_before

--- a/torch_brain/pipeline/brainsets-pipelines/allen_visual_coding_ophys_2016/pipeline.py
+++ b/torch_brain/pipeline/brainsets-pipelines/allen_visual_coding_ophys_2016/pipeline.py
@@ -8,7 +8,6 @@
 # ///
 
 
-import logging
 import os
 from argparse import ArgumentParser
 from pathlib import Path
@@ -38,8 +37,6 @@ from torch_brain.data import (
     SubjectDescription,
 )
 from torch_brain.pipeline import BrainsetPipeline
-
-logging.basicConfig(level=logging.INFO)
 
 parser = ArgumentParser()
 parser.add_argument("--redownload", action="store_true")

--- a/torch_brain/pipeline/brainsets-pipelines/kemp_sleep_edf_2013/pipeline.py
+++ b/torch_brain/pipeline/brainsets-pipelines/kemp_sleep_edf_2013/pipeline.py
@@ -36,8 +36,6 @@ from torch_brain.utils.split import (
     generate_string_kfold_assignment,
 )
 
-logging.basicConfig(level=logging.INFO)
-
 CHANNEL_TYPE_REMAPPING = {
     "EEG": ["EEG Fpz-Cz", "EEG Pz-Oz"],
     "EOG": ["EOG horizontal"],

--- a/torch_brain/pipeline/brainsets-pipelines/neuroprobe_2025/pipeline.py
+++ b/torch_brain/pipeline/brainsets-pipelines/neuroprobe_2025/pipeline.py
@@ -34,9 +34,6 @@ from torch_brain.data import (
 )
 from torch_brain.pipeline import BrainsetPipeline
 
-logging.basicConfig(level=logging.INFO)
-
-
 BASE_URL = "https://braintreebank.dev"
 DOWNLOAD_TIMEOUT_SECONDS = 60
 DOWNLOAD_MAX_RETRIES = 2

--- a/torch_brain/pipeline/brainsets-pipelines/odoherty_sabes_nonhuman_2017/pipeline.py
+++ b/torch_brain/pipeline/brainsets-pipelines/odoherty_sabes_nonhuman_2017/pipeline.py
@@ -28,8 +28,6 @@ from torch_brain.data import (
 from torch_brain.pipeline import BrainsetPipeline
 from torch_brain.utils import calculate_sampling_rate
 
-logging.basicConfig(level=logging.INFO)
-
 parser = ArgumentParser()
 parser.add_argument("--redownload", action="store_true")
 parser.add_argument("--reprocess", action="store_true")

--- a/torch_brain/pipeline/pipeline.py
+++ b/torch_brain/pipeline/pipeline.py
@@ -193,6 +193,10 @@ def _redirect_stdio(log_out_path, log_err_path):
     This is useful when running pipelines in parallel."""
     stdout_prev = sys.stdout
     stderr_prev = sys.stderr
+    # `_run_item` reconfigures the root logger via `logging.basicConfig(force=True, ...)`,
+    # which only ever mutates `handlers` and `level` on the root logger (see
+    # https://docs.python.org/3/library/logging.html#logging.basicConfig), so those are
+    # the only two attributes that need to be saved/restored here.
     root_logger = logging.getLogger()
     handlers_prev = root_logger.handlers[:]
     level_prev = root_logger.level

--- a/torch_brain/pipeline/pipeline.py
+++ b/torch_brain/pipeline/pipeline.py
@@ -1,3 +1,4 @@
+import logging
 import sys
 import traceback
 from abc import ABC, abstractmethod
@@ -164,6 +165,7 @@ class BrainsetPipeline(ABC):
     def _run_item(self, manifest_item):
         """Run download and process for a manifest item."""
         self._asset_id = manifest_item.Index
+        logging.basicConfig(stream=sys.stderr, level=logging.INFO, force=True)
         output = self.download(manifest_item)
         if not self._download_only:
             self.process(output)
@@ -191,6 +193,9 @@ def _redirect_stdio(log_out_path, log_err_path):
     This is useful when running pipelines in parallel."""
     stdout_prev = sys.stdout
     stderr_prev = sys.stderr
+    root_logger = logging.getLogger()
+    handlers_prev = root_logger.handlers[:]
+    level_prev = root_logger.level
     with (
         open(log_out_path, "w", encoding="utf-8") as log_out,
         open(log_err_path, "w", encoding="utf-8") as log_err,
@@ -202,3 +207,5 @@ def _redirect_stdio(log_out_path, log_err_path):
         finally:
             sys.stdout = stdout_prev
             sys.stderr = stderr_prev
+            root_logger.handlers[:] = handlers_prev
+            root_logger.setLevel(level_prev)


### PR DESCRIPTION
## Summary
- Several brainsets pipelines call `logging.basicConfig()` at import time, binding a log handler to whatever `stdout`/`stderr` was current at that moment.
- `_redirect_stdio` only reassigns `sys.stdout`/`sys.stderr` per manifest item afterwards, so those already-bound handlers kept writing to the pre-redirect stream — log records bypassed the per-item `pipeline_logs/<id>.err` file entirely.
- `BrainsetPipeline._run_item` now rebinds logging (`logging.basicConfig(stream=sys.stderr, level=logging.INFO, force=True)`) against the current stream at the start of every item, covering both the parallel-worker path (redirected) and the `--single` path (real stderr). `_redirect_stdio` saves/restores the root logger's handlers and level so this doesn't leak between items.
- Removed the now-redundant `logging.basicConfig(level=logging.INFO)` calls from the 4 pipelines that had them (`odoherty_sabes_nonhuman_2017`, `kemp_sleep_edf_2013`, `allen_visual_coding_ophys_2016`, `neuroprobe_2025`).

## Test plan
- Added `tests/pipeline/test_pipeline_logging.py`: a minimal pipeline whose `download()` logs and `process()` prints; asserts the log record lands in `pipeline_logs/<id>.err`, the print output lands in `pipeline_logs/<id>.out`, and that root logger handlers/level are restored after the item finishes.
- Verified the logging test fails without the fix (message leaks to the real stderr instead of the log file) and passes with it.