### PR TITLE
feat: Add SessionBatchSampler for grouping samples into per-session batches

### DIFF
--- a/tests/test_sampler.py
+++ b/tests/test_sampler.py
@@ -7,7 +7,7 @@ from torch_brain.datasets import DatasetIndex
 from torch_brain.samplers import (
     RandomFixedWindowSampler,
     SequentialFixedWindowSampler,
-    SessionBatchSampler,
+    SessionWiseBatchSampler,
     TrialSampler,
 )
 
@@ -231,11 +231,13 @@ def test_session_batch_sampler():
 
     # batch_size must be positive
     with pytest.raises(ValueError):
-        SessionBatchSampler(_FakeSampler(indices), batch_size=0)
+        SessionWiseBatchSampler(_FakeSampler(indices), batch_size=0)
 
     # drop_last=True: session1 (4 items) -> 2 batches of 2; session2 (3 items)
     # -> 1 batch of 2, remainder of 1 dropped.
-    sampler = SessionBatchSampler(_FakeSampler(indices), batch_size=2, drop_last=True)
+    sampler = SessionWiseBatchSampler(
+        _FakeSampler(indices), batch_size=2, drop_last=True
+    )
     assert len(sampler) == 3
 
     batches = list(sampler)
@@ -252,7 +254,9 @@ def test_session_batch_sampler():
 
     # drop_last=False: session1 -> 2 batches of 2; session2 -> 1 batch of 2
     # and 1 batch of 1 (the remainder is kept).
-    sampler = SessionBatchSampler(_FakeSampler(indices), batch_size=2, drop_last=False)
+    sampler = SessionWiseBatchSampler(
+        _FakeSampler(indices), batch_size=2, drop_last=False
+    )
     assert len(sampler) == 4
 
     batches = list(sampler)

--- a/tests/test_sampler.py
+++ b/tests/test_sampler.py
@@ -13,7 +13,7 @@ from torch_brain.samplers import (
 
 
 # helper
-class _FakeSampler(torch.utils.data.Sampler):
+class _FakeSampler(torch.utils.data.Sampler[DatasetIndex]):
     """Yields a fixed, pre-defined list of DatasetIndex objects, in order."""
 
     def __init__(self, indices):

--- a/tests/test_sampler.py
+++ b/tests/test_sampler.py
@@ -27,6 +27,27 @@ class _FakeSampler(torch.utils.data.Sampler[DatasetIndex]):
 
 
 # helper
+class _CountingSampler(torch.utils.data.Sampler[DatasetIndex]):
+    """Yields indices shifted by an offset that increments on every __iter__
+    call, to simulate a stateful/random inner sampler for cache tests."""
+
+    def __init__(self, indices):
+        self.indices = indices
+        self.call_count = 0
+
+    def __iter__(self):
+        offset = self.call_count
+        self.call_count += 1
+        return iter(
+            DatasetIndex(idx.recording_id, idx.start + offset, idx.end + offset)
+            for idx in self.indices
+        )
+
+    def __len__(self):
+        return len(self.indices)
+
+
+# helper
 def compare_slice_indices(a, b):
     return (
         (a.recording_id == b.recording_id)
@@ -271,5 +292,72 @@ def test_session_batch_sampler():
     assert sorted(batch_sizes_by_session["session2"]) == [1, 2]
 
     # len() should stay consistent with a second pass over the sampler
-    # (the internal batch cache is rebuilt on every new __iter__ call).
+    # (cache_batches defaults to True, so both calls see the same batches).
     assert len(sampler) == len(list(sampler))
+
+
+def test_session_batch_sampler_shuffle():
+    torch.manual_seed(0)
+    indices = [
+        DatasetIndex(f"session{s}", float(i), float(i) + 1.0)
+        for s in range(3)
+        for i in range(4)
+    ]
+
+    def batch_signature(batches):
+        return [
+            tuple((idx.recording_id, idx.start, idx.end) for idx in batch)
+            for batch in batches
+        ]
+
+    # shuffle=False (default): batches are always yielded in build order.
+    batch_sampler = SessionWiseBatchSampler(
+        _FakeSampler(indices), batch_size=2, shuffle=False
+    )
+    order1 = batch_signature(list(batch_sampler))
+    order2 = batch_signature(list(batch_sampler))
+    assert order1 == order2
+
+    # shuffle=True: the batch order changes across successive epochs.
+    batch_sampler = SessionWiseBatchSampler(
+        _FakeSampler(indices), batch_size=2, shuffle=True
+    )
+    shuffled1 = batch_signature(list(batch_sampler))
+    shuffled2 = batch_signature(list(batch_sampler))
+    assert sorted(shuffled1) == sorted(shuffled2)  # same set of batches
+    assert shuffled1 != shuffled2  # different order
+
+
+def test_session_batch_sampler_cache_batches():
+    indices = [
+        DatasetIndex("session1", 0.0, 1.0),
+        DatasetIndex("session2", 0.0, 1.0),
+        DatasetIndex("session1", 1.0, 2.0),
+        DatasetIndex("session2", 1.0, 2.0),
+    ]
+
+    # NOTE: we deliberately iterate via `list(iter(batch_sampler))` rather than
+    # `list(batch_sampler)`. The latter triggers CPython's length_hint
+    # optimization, which calls len(batch_sampler) (and therefore
+    # _prepare_cache()) before __iter__ is consumed, causing a spurious extra
+    # rebuild when cache_batches=False. Iterating an explicit iterator avoids
+    # that.
+
+    # cache_batches=True (default): batches are built once from the inner
+    # sampler and reused verbatim across epochs, even if the inner sampler
+    # is stateful and would otherwise yield different indices each time.
+    inner = _CountingSampler(indices)
+    batch_sampler = SessionWiseBatchSampler(inner, batch_size=2, cache_batches=True)
+    batches1 = list(iter(batch_sampler))
+    batches2 = list(iter(batch_sampler))
+    assert batches1 == batches2
+    assert inner.call_count == 1
+
+    # cache_batches=False: batches are rebuilt on every __iter__ call, so a
+    # stateful inner sampler produces different batches each epoch.
+    inner = _CountingSampler(indices)
+    batch_sampler = SessionWiseBatchSampler(inner, batch_size=2, cache_batches=False)
+    batches1 = list(iter(batch_sampler))
+    batches2 = list(iter(batch_sampler))
+    assert batches1 != batches2
+    assert inner.call_count == 2

--- a/tests/test_sampler.py
+++ b/tests/test_sampler.py
@@ -7,8 +7,23 @@ from torch_brain.datasets import DatasetIndex
 from torch_brain.samplers import (
     RandomFixedWindowSampler,
     SequentialFixedWindowSampler,
+    SessionBatchSampler,
     TrialSampler,
 )
+
+
+# helper
+class _FakeSampler(torch.utils.data.Sampler):
+    """Yields a fixed, pre-defined list of DatasetIndex objects, in order."""
+
+    def __init__(self, indices):
+        self.indices = indices
+
+    def __iter__(self):
+        return iter(self.indices)
+
+    def __len__(self):
+        return len(self.indices)
 
 
 # helper
@@ -199,3 +214,58 @@ def test_trial_sampler():
     sampler1 = TrialSampler(sampling_intervals=sampling_intervals, shuffle=False)
     samples1 = list(sampler1)
     assert compare_slice_indices(samples1[0], DatasetIndex("session1", 0.0, 2.0))
+
+
+def test_session_batch_sampler():
+    # 4 indices for session1, 3 for session2, interleaved to check that the
+    # batch sampler groups them correctly regardless of the inner sampler's order.
+    indices = [
+        DatasetIndex("session1", 0.0, 1.0),
+        DatasetIndex("session2", 0.0, 1.0),
+        DatasetIndex("session1", 1.0, 2.0),
+        DatasetIndex("session2", 1.0, 2.0),
+        DatasetIndex("session1", 2.0, 3.0),
+        DatasetIndex("session2", 2.0, 3.0),
+        DatasetIndex("session1", 3.0, 4.0),
+    ]
+
+    # batch_size must be positive
+    with pytest.raises(ValueError):
+        SessionBatchSampler(_FakeSampler(indices), batch_size=0)
+
+    # drop_last=True: session1 (4 items) -> 2 batches of 2; session2 (3 items)
+    # -> 1 batch of 2, remainder of 1 dropped.
+    sampler = SessionBatchSampler(_FakeSampler(indices), batch_size=2, drop_last=True)
+    assert len(sampler) == 3
+
+    batches = list(sampler)
+    assert len(batches) == 3
+    for batch in batches:
+        assert len(batch) == 2
+        # every index in a batch must belong to the same session
+        assert len({idx.recording_id for idx in batch}) == 1
+
+    session_batch_counts = {"session1": 0, "session2": 0}
+    for batch in batches:
+        session_batch_counts[batch[0].recording_id] += 1
+    assert session_batch_counts == {"session1": 2, "session2": 1}
+
+    # drop_last=False: session1 -> 2 batches of 2; session2 -> 1 batch of 2
+    # and 1 batch of 1 (the remainder is kept).
+    sampler = SessionBatchSampler(_FakeSampler(indices), batch_size=2, drop_last=False)
+    assert len(sampler) == 4
+
+    batches = list(sampler)
+    assert len(batches) == 4
+    for batch in batches:
+        assert len({idx.recording_id for idx in batch}) == 1
+
+    batch_sizes_by_session = {"session1": [], "session2": []}
+    for batch in batches:
+        batch_sizes_by_session[batch[0].recording_id].append(len(batch))
+    assert sorted(batch_sizes_by_session["session1"]) == [2, 2]
+    assert sorted(batch_sizes_by_session["session2"]) == [1, 2]
+
+    # len() should stay consistent with a second pass over the sampler
+    # (the internal batch cache is rebuilt on every new __iter__ call).
+    assert len(sampler) == len(list(sampler))

--- a/torch_brain/samplers/__init__.py
+++ b/torch_brain/samplers/__init__.py
@@ -2,12 +2,14 @@ from .distributed_evaluation_sampler import DistributedEvaluationSamplerWrapper
 from .distributed_stitching_fixed_window import DistributedStitchingFixedWindowSampler
 from .random_fixed_window import RandomFixedWindowSampler
 from .sequential_fixed_window import SequentialFixedWindowSampler
+from .session_batch_sampler import SessionBatchSampler
 from .trial_sampler import TrialSampler
 
 __all__ = [
     "RandomFixedWindowSampler",
     "SequentialFixedWindowSampler",
     "TrialSampler",
+    "SessionBatchSampler",
     "DistributedEvaluationSamplerWrapper",
     "DistributedStitchingFixedWindowSampler",
 ]

--- a/torch_brain/samplers/__init__.py
+++ b/torch_brain/samplers/__init__.py
@@ -2,14 +2,14 @@ from .distributed_evaluation_sampler import DistributedEvaluationSamplerWrapper
 from .distributed_stitching_fixed_window import DistributedStitchingFixedWindowSampler
 from .random_fixed_window import RandomFixedWindowSampler
 from .sequential_fixed_window import SequentialFixedWindowSampler
-from .session_batch_sampler import SessionBatchSampler
+from .session_batch_sampler import SessionWiseBatchSampler
 from .trial_sampler import TrialSampler
 
 __all__ = [
     "RandomFixedWindowSampler",
     "SequentialFixedWindowSampler",
     "TrialSampler",
-    "SessionBatchSampler",
+    "SessionWiseBatchSampler",
     "DistributedEvaluationSamplerWrapper",
     "DistributedStitchingFixedWindowSampler",
 ]

--- a/torch_brain/samplers/session_batch_sampler.py
+++ b/torch_brain/samplers/session_batch_sampler.py
@@ -49,6 +49,8 @@ class SessionBatchSampler(torch.utils.data.Sampler[list[DatasetIndex]]):
         generator: torch.Generator | None = None,
         drop_last: bool = True,
     ):
+        if isinstance(batch_size, bool) or not isinstance(batch_size, int):
+            raise TypeError("batch_size must be an integer.")
         if batch_size <= 0:
             raise ValueError("batch_size must be positive.")
         self.sampler = sampler
@@ -88,11 +90,16 @@ class SessionBatchSampler(torch.utils.data.Sampler[list[DatasetIndex]]):
         return len(self._batches_cache)
 
     def __iter__(self) -> Iterator[list[DatasetIndex]]:
-        r"""Yields per-session batches of :class:`~torch_brain.datasets.DatasetIndex`."""
+        r"""Returns an iterator over per-session batches of
+        :class:`~torch_brain.datasets.DatasetIndex`."""
         self._prepare_cache()
         batches = self._batches_cache
         self._batches_cache = None  # reset so next epoch rebuilds
+        return self._yield_batches(batches)
 
+    def _yield_batches(
+        self, batches: list[list[DatasetIndex]]
+    ) -> Iterator[list[DatasetIndex]]:
         if self.shuffle_batches and batches:
             for idx in torch.randperm(len(batches), generator=self.generator).tolist():
                 yield batches[idx]

--- a/torch_brain/samplers/session_batch_sampler.py
+++ b/torch_brain/samplers/session_batch_sampler.py
@@ -37,7 +37,11 @@ class SessionBatchSampler(torch.utils.data.Sampler[list[DatasetIndex]]):
         ...     sampling_intervals=sampling_intervals,
         ...     window_length=1.0,
         ... )
-        >>> sampler = SessionBatchSampler(inner_sampler, batch_size=16)
+        >>> batch_sampler = SessionBatchSampler(inner_sampler, batch_size=16)
+        >>> loader = torch.utils.data.DataLoader(
+        ...     dataset=your_dataset,
+        ...     batch_sampler=batch_sampler,
+        ... )
     """
 
     def __init__(

--- a/torch_brain/samplers/session_batch_sampler.py
+++ b/torch_brain/samplers/session_batch_sampler.py
@@ -17,8 +17,8 @@ class SessionBatchSampler(torch.utils.data.Sampler[list[DatasetIndex]]):
         sampler: Inner sampler whose :meth:`__iter__` yields
             :class:`~torch_brain.datasets.DatasetIndex` objects.
         batch_size: Number of samples per batch.
-        shuffle_batches: If ``True``, the final batch order is shuffled.
-            Defaults to ``False``.
+        shuffle_batches: If ``True`` (default), the final batch order is shuffled.
+            If ``False``, batches are yielded in the order they were built.
         generator: Optional RNG used when :obj:`shuffle_batches` is ``True``.
             If ``None`` (default), uses the default global PyTorch generator.
         drop_last: If ``True`` (default), the last incomplete batch for each
@@ -45,7 +45,7 @@ class SessionBatchSampler(torch.utils.data.Sampler[list[DatasetIndex]]):
         sampler: torch.utils.data.Sampler,
         batch_size: int,
         *,
-        shuffle_batches: bool = False,
+        shuffle_batches: bool = True,
         generator: torch.Generator | None = None,
         drop_last: bool = True,
     ):

--- a/torch_brain/samplers/session_batch_sampler.py
+++ b/torch_brain/samplers/session_batch_sampler.py
@@ -10,14 +10,14 @@ class SessionWiseBatchSampler(torch.utils.data.Sampler[list[DatasetIndex]]):
     groups its output into per-session batches.
 
     All indices in a batch share the same session id. The inner sampler controls
-    the order of indices within each session; :obj:`shuffle_batches` controls the
+    the order of indices within each session; :obj:`shuffle` controls the
     order of batches across sessions.
 
     Args:
         sampler: Inner sampler whose :meth:`__iter__` yields
             :class:`~torch_brain.datasets.DatasetIndex` objects.
         batch_size: Number of samples per batch.
-        shuffle_batches: If ``True``, the final batch order is shuffled.
+        shuffle: If ``True``, the final batch order is shuffled.
             If ``False`` (default), batches are yielded in the order they were built.
         cache_batches: If ``True`` (default), batches are built once and reused
             across epochs instead of being rebuilt on every :meth:`__iter__`
@@ -25,7 +25,7 @@ class SessionWiseBatchSampler(torch.utils.data.Sampler[list[DatasetIndex]]):
             :class:`RandomFixedWindowSampler`), since with caching on it would
             otherwise freeze the same batches for the lifetime of the sampler
             instead of re-drawing new windows each epoch.
-        generator: Optional RNG used when :obj:`shuffle_batches` is ``True``.
+        generator: Optional RNG used when :obj:`shuffle` is ``True``.
             If ``None`` (default), uses the default global PyTorch generator.
         drop_last: If ``True`` (default), the last incomplete batch for each
             session is dropped.
@@ -59,7 +59,7 @@ class SessionWiseBatchSampler(torch.utils.data.Sampler[list[DatasetIndex]]):
         sampler: torch.utils.data.Sampler[DatasetIndex],
         batch_size: int,
         *,
-        shuffle_batches: bool = False,
+        shuffle: bool = False,
         cache_batches: bool = True,
         generator: torch.Generator | None = None,
         drop_last: bool = True,
@@ -70,7 +70,7 @@ class SessionWiseBatchSampler(torch.utils.data.Sampler[list[DatasetIndex]]):
             raise ValueError("batch_size must be positive.")
         self.sampler = sampler
         self.batch_size = batch_size
-        self.shuffle_batches = shuffle_batches
+        self.shuffle = shuffle
         self.generator = generator
         self.drop_last = drop_last
         self.cache_batches = cache_batches
@@ -117,7 +117,7 @@ class SessionWiseBatchSampler(torch.utils.data.Sampler[list[DatasetIndex]]):
     def _yield_batches(
         self, batches: list[list[DatasetIndex]]
     ) -> Iterator[list[DatasetIndex]]:
-        if self.shuffle_batches and batches:
+        if self.shuffle and batches:
             for idx in torch.randperm(len(batches), generator=self.generator).tolist():
                 yield batches[idx]
         else:

--- a/torch_brain/samplers/session_batch_sampler.py
+++ b/torch_brain/samplers/session_batch_sampler.py
@@ -1,0 +1,100 @@
+from collections.abc import Iterator
+
+import torch
+
+from torch_brain.datasets import DatasetIndex
+
+
+class SessionBatchSampler(torch.utils.data.Sampler[list[DatasetIndex]]):
+    r"""Wraps any sampler yielding :class:`~torch_brain.datasets.DatasetIndex` and
+    groups its output into per-session batches.
+
+    All indices in a batch share the same session id. The inner sampler controls
+    the order of indices within each session; :obj:`shuffle_batches` controls the
+    order of batches across sessions.
+
+    Args:
+        sampler: Inner sampler whose :meth:`__iter__` yields
+            :class:`~torch_brain.datasets.DatasetIndex` objects.
+        batch_size: Number of samples per batch.
+        shuffle_batches: If ``True``, the final batch order is shuffled.
+            Defaults to ``False``.
+        generator: Optional RNG used when :obj:`shuffle_batches` is ``True``.
+            If ``None`` (default), uses the default global PyTorch generator.
+        drop_last: If ``True`` (default), the last incomplete batch for each
+            session is dropped.
+
+    Example::
+
+        >>> from torch_brain.data import Interval
+        >>> from torch_brain.samplers import RandomFixedWindowSampler, SessionBatchSampler
+
+        >>> sampling_intervals = {
+        ...     "session_1": Interval(0.0, 100.0),
+        ...     "session_2": Interval(0.0, 200.0),
+        ... }
+        >>> inner_sampler = RandomFixedWindowSampler(
+        ...     sampling_intervals=sampling_intervals,
+        ...     window_length=1.0,
+        ... )
+        >>> sampler = SessionBatchSampler(inner_sampler, batch_size=16)
+    """
+
+    def __init__(
+        self,
+        sampler: torch.utils.data.Sampler,
+        batch_size: int,
+        *,
+        shuffle_batches: bool = False,
+        generator: torch.Generator | None = None,
+        drop_last: bool = True,
+    ):
+        if batch_size <= 0:
+            raise ValueError("batch_size must be positive.")
+        self.sampler = sampler
+        self.batch_size = batch_size
+        self.shuffle_batches = shuffle_batches
+        self.generator = generator
+        self.drop_last = drop_last
+        self._batches_cache: list[list[DatasetIndex]] | None = None
+
+    def _build_batches(self) -> list[list[DatasetIndex]]:
+        indices_by_session: dict[str, list[DatasetIndex]] = {}
+        for idx in self.sampler:
+            session_id = idx.recording_id
+            if session_id not in indices_by_session:
+                indices_by_session[session_id] = []
+            indices_by_session[session_id].append(idx)
+
+        batches: list[list[DatasetIndex]] = []
+        for indices in indices_by_session.values():
+            max_len = len(indices)
+            if self.drop_last:
+                max_len = (max_len // self.batch_size) * self.batch_size
+            for i in range(0, max_len, self.batch_size):
+                batch = indices[i : i + self.batch_size]
+                if len(batch) == self.batch_size or not self.drop_last:
+                    batches.append(batch)
+
+        return batches
+
+    def _prepare_cache(self) -> None:
+        if self._batches_cache is None:
+            self._batches_cache = self._build_batches()
+
+    def __len__(self) -> int:
+        r"""Returns the total number of batches across all sessions."""
+        self._prepare_cache()
+        return len(self._batches_cache)
+
+    def __iter__(self) -> Iterator[list[DatasetIndex]]:
+        r"""Yields per-session batches of :class:`~torch_brain.datasets.DatasetIndex`."""
+        self._prepare_cache()
+        batches = self._batches_cache
+        self._batches_cache = None  # reset so next epoch rebuilds
+
+        if self.shuffle_batches and batches:
+            for idx in torch.randperm(len(batches), generator=self.generator).tolist():
+                yield batches[idx]
+        else:
+            yield from batches

--- a/torch_brain/samplers/session_batch_sampler.py
+++ b/torch_brain/samplers/session_batch_sampler.py
@@ -42,7 +42,7 @@ class SessionBatchSampler(torch.utils.data.Sampler[list[DatasetIndex]]):
 
     def __init__(
         self,
-        sampler: torch.utils.data.Sampler,
+        sampler: torch.utils.data.Sampler[DatasetIndex],
         batch_size: int,
         *,
         shuffle_batches: bool = True,

--- a/torch_brain/samplers/session_batch_sampler.py
+++ b/torch_brain/samplers/session_batch_sampler.py
@@ -23,6 +23,12 @@ class SessionBatchSampler(torch.utils.data.Sampler[list[DatasetIndex]]):
             If ``None`` (default), uses the default global PyTorch generator.
         drop_last: If ``True`` (default), the last incomplete batch for each
             session is dropped.
+        cache_batches: If ``True``, batches are built once and reused across
+            epochs instead of being rebuilt on every :meth:`__iter__` call.
+            Useful when the inner sampler is deterministic and rebuilding is
+            wasted work. Leave ``False`` (default) if the inner sampler is
+            random (e.g. :class:`RandomFixedWindowSampler`), since caching
+            would freeze the same batches for the lifetime of the sampler.
 
     Example::
 
@@ -52,6 +58,7 @@ class SessionBatchSampler(torch.utils.data.Sampler[list[DatasetIndex]]):
         shuffle_batches: bool = True,
         generator: torch.Generator | None = None,
         drop_last: bool = True,
+        cache_batches: bool = False,
     ):
         if isinstance(batch_size, bool) or not isinstance(batch_size, int):
             raise TypeError("batch_size must be an integer.")
@@ -62,6 +69,7 @@ class SessionBatchSampler(torch.utils.data.Sampler[list[DatasetIndex]]):
         self.shuffle_batches = shuffle_batches
         self.generator = generator
         self.drop_last = drop_last
+        self.cache_batches = cache_batches
         self._batches_cache: list[list[DatasetIndex]] | None = None
 
     def _build_batches(self) -> list[list[DatasetIndex]]:
@@ -98,7 +106,8 @@ class SessionBatchSampler(torch.utils.data.Sampler[list[DatasetIndex]]):
         :class:`~torch_brain.datasets.DatasetIndex`."""
         self._prepare_cache()
         batches = self._batches_cache
-        self._batches_cache = None  # reset so next epoch rebuilds
+        if not self.cache_batches:
+            self._batches_cache = None  # reset so next epoch rebuilds
         return self._yield_batches(batches)
 
     def _yield_batches(

--- a/torch_brain/samplers/session_batch_sampler.py
+++ b/torch_brain/samplers/session_batch_sampler.py
@@ -5,7 +5,7 @@ import torch
 from torch_brain.datasets import DatasetIndex
 
 
-class SessionBatchSampler(torch.utils.data.Sampler[list[DatasetIndex]]):
+class SessionWiseBatchSampler(torch.utils.data.Sampler[list[DatasetIndex]]):
     r"""Wraps any sampler yielding :class:`~torch_brain.datasets.DatasetIndex` and
     groups its output into per-session batches.
 
@@ -17,23 +17,23 @@ class SessionBatchSampler(torch.utils.data.Sampler[list[DatasetIndex]]):
         sampler: Inner sampler whose :meth:`__iter__` yields
             :class:`~torch_brain.datasets.DatasetIndex` objects.
         batch_size: Number of samples per batch.
-        shuffle_batches: If ``True`` (default), the final batch order is shuffled.
-            If ``False``, batches are yielded in the order they were built.
+        shuffle_batches: If ``True``, the final batch order is shuffled.
+            If ``False`` (default), batches are yielded in the order they were built.
+        cache_batches: If ``True`` (default), batches are built once and reused
+            across epochs instead of being rebuilt on every :meth:`__iter__`
+            call. Set to ``False`` if the inner sampler is random (e.g.
+            :class:`RandomFixedWindowSampler`), since with caching on it would
+            otherwise freeze the same batches for the lifetime of the sampler
+            instead of re-drawing new windows each epoch.
         generator: Optional RNG used when :obj:`shuffle_batches` is ``True``.
             If ``None`` (default), uses the default global PyTorch generator.
         drop_last: If ``True`` (default), the last incomplete batch for each
             session is dropped.
-        cache_batches: If ``True``, batches are built once and reused across
-            epochs instead of being rebuilt on every :meth:`__iter__` call.
-            Useful when the inner sampler is deterministic and rebuilding is
-            wasted work. Leave ``False`` (default) if the inner sampler is
-            random (e.g. :class:`RandomFixedWindowSampler`), since caching
-            would freeze the same batches for the lifetime of the sampler.
 
     Example::
 
         >>> from torch_brain.data import Interval
-        >>> from torch_brain.samplers import RandomFixedWindowSampler, SessionBatchSampler
+        >>> from torch_brain.samplers import RandomFixedWindowSampler, SessionWiseBatchSampler
 
         >>> class ToyDataset(torch.utils.data.Dataset):
         ...     def __getitem__(self, index: DatasetIndex):
@@ -47,7 +47,7 @@ class SessionBatchSampler(torch.utils.data.Sampler[list[DatasetIndex]]):
         ...     sampling_intervals=sampling_intervals,
         ...     window_length=1.0,
         ... )
-        >>> batch_sampler = SessionBatchSampler(inner_sampler, batch_size=16)
+        >>> batch_sampler = SessionWiseBatchSampler(inner_sampler, batch_size=16)
         >>> loader = torch.utils.data.DataLoader(
         ...     dataset=your_dataset,
         ...     batch_sampler=batch_sampler,
@@ -59,10 +59,10 @@ class SessionBatchSampler(torch.utils.data.Sampler[list[DatasetIndex]]):
         sampler: torch.utils.data.Sampler[DatasetIndex],
         batch_size: int,
         *,
-        shuffle_batches: bool = True,
+        shuffle_batches: bool = False,
+        cache_batches: bool = True,
         generator: torch.Generator | None = None,
         drop_last: bool = True,
-        cache_batches: bool = False,
     ):
         if isinstance(batch_size, bool) or not isinstance(batch_size, int):
             raise TypeError("batch_size must be an integer.")

--- a/torch_brain/samplers/session_batch_sampler.py
+++ b/torch_brain/samplers/session_batch_sampler.py
@@ -35,6 +35,10 @@ class SessionBatchSampler(torch.utils.data.Sampler[list[DatasetIndex]]):
         >>> from torch_brain.data import Interval
         >>> from torch_brain.samplers import RandomFixedWindowSampler, SessionBatchSampler
 
+        >>> class ToyDataset(torch.utils.data.Dataset):
+        ...     def __getitem__(self, index: DatasetIndex):
+        ...         return index
+        >>> your_dataset = ToyDataset()
         >>> sampling_intervals = {
         ...     "session_1": Interval(0.0, 100.0),
         ...     "session_2": Interval(0.0, 200.0),


### PR DESCRIPTION
## Summary

Adds `SessionBatchSampler`, a `Sampler` wrapper that groups any inner sampler's `DatasetIndex` output into per-session batches (no batch mixes sessions), with optional batch shuffling and `drop_last` control. Extracted from the NDT multi-session notebook, where it was previously defined inline.

- New: `torch_brain/samplers/session_batch_sampler.py`, registered in `torch_brain/samplers/__init__.py`
- Tests: `tests/test_sampler.py::test_session_batch_sampler` (per-session grouping, `drop_last` True/False, invalid `batch_size`, `len()` consistency)