### PR TITLE
docs: Fix copybutton for python REPL codeblocks

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -95,12 +95,10 @@ myst_enable_extensions = [
 
 nb_execution_mode = "off"
 
-# sphinx-copybutton: for REPL-style blocks (``pycon``, ``console``), copy only the
-# input lines with their prompts stripped, so users don't paste ">>>" or printed
-# output. Blocks with no prompts (plain ``python``/``bash``) are copied in full.
-# Note: do not set ``copybutton_exclude`` to skip ``.gp`` (the prompt spans) -- the
-# prompts must survive text extraction for the regex below to find them.
-copybutton_prompt_text = r">>> |\.\.\. |\$ "
+# Copybutton config to compensate for REPL-style blocks (python, console, ipython).
+# Taken from:
+# https://sphinx-copybutton.readthedocs.io/en/latest/use.html#strip-and-configure-input-prompts-for-code-cells
+copybutton_prompt_text = r">>> |\.\.\. |\$ |In \[\d*\]: | {2,5}\.\.\.: | {5,8}: "
 copybutton_prompt_is_regexp = True
 
 bokeh_plot_pyfile_include_dirs = [

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -95,6 +95,14 @@ myst_enable_extensions = [
 
 nb_execution_mode = "off"
 
+# sphinx-copybutton: for REPL-style blocks (``pycon``, ``console``), copy only the
+# input lines with their prompts stripped, so users don't paste ">>>" or printed
+# output. Blocks with no prompts (plain ``python``/``bash``) are copied in full.
+# Note: do not set ``copybutton_exclude`` to skip ``.gp`` (the prompt spans) -- the
+# prompts must survive text extraction for the regex below to find them.
+copybutton_prompt_text = r">>> |\.\.\. |\$ "
+copybutton_prompt_is_regexp = True
+
 bokeh_plot_pyfile_include_dirs = [
     "concepts/examples",
 ]


### PR DESCRIPTION
With this change, clicking the copy-button will not copy chevrons and outputs. Test it [here](https://torch-brain--341.org.readthedocs.build/en/341/guides/data/data_objects_intro.html).

Partially fixes #336

The lint and test CI failures are due to unrelated issues.